### PR TITLE
Update all dependencies, build system, and CI to latest stable versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: unit-test-results
           path: app/build/reports/tests/testDebugUnitTest/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
 
 def properties = new Properties()
 def secretFile = rootProject.file("secret.properties")
@@ -9,11 +8,11 @@ if (secretFile.exists()) {
 
 android {
     namespace "be.robinj.distrohopper"
-    compileSdkVersion 36
+    compileSdk 36
     defaultConfig {
         applicationId "be.robinj.distrohopper"
-        minSdkVersion 29
-        targetSdkVersion 36
+        minSdk 29
+        targetSdk 36
         versionCode 101
         versionName "2.6.5"
         buildConfigField "String", "ACRA_USERNAME", "\"" + (properties['acra_username'] ?: "") + "\""
@@ -43,9 +42,6 @@ android {
     lint {
         disable 'MissingTranslation', 'ExtraTranslation'
     }
-    kotlinOptions {
-        jvmTarget = '17'
-    }
 }
 
 repositories {
@@ -57,26 +53,26 @@ repositories {
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'asia.ivity.android:drag-sort-listview:1.0'
     implementation 'androidx.core:core-ktx:1.17.0'
 
     // ACRA
-    def acraVersion = '5.5.1'
+    def acraVersion = '5.13.1'
     implementation "ch.acra:acra-http:$acraVersion"
     implementation "ch.acra:acra-toast:$acraVersion"
 
     // Robolectric – runs on the JVM, no emulator needed
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.robolectric:robolectric:4.11.1'
-    testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'androidx.test.ext:junit:1.1.5'
-    testImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    testImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
+    testImplementation 'org.robolectric:robolectric:4.16.1'
+    testImplementation 'androidx.test:core:1.7.0'
+    testImplementation 'androidx.test.ext:junit:1.3.0'
+    testImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    testImplementation 'androidx.test.espresso:espresso-intents:3.7.0'
 
     // Minimal androidTest runner kept for any future on-device tests
     androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
         release {
             minifyEnabled false
             shrinkResources false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     buildFeatures {

--- a/app/src/main/java/be/robinj/distrohopper/Application.java
+++ b/app/src/main/java/be/robinj/distrohopper/Application.java
@@ -19,18 +19,22 @@ public class Application extends android.app.Application
 	protected void attachBaseContext(final Context base) {
 		super.attachBaseContext(base);
 
-		CoreConfigurationBuilder builder = new CoreConfigurationBuilder()
-				.withReportFormat(StringFormat.JSON);
-		builder.getPluginConfigurationBuilder(HttpSenderConfigurationBuilder.class)
-				.withUri("https://acra.robinj.be/report")
-				.withBasicAuthLogin(BuildConfig.ACRA_USERNAME)
-				.withBasicAuthPassword(BuildConfig.ACRA_PASSWORD)
-				.withHttpMethod(HttpSender.Method.POST)
-				.withEnabled(true);
-		builder.getPluginConfigurationBuilder(ToastConfigurationBuilder.class)
-				.withText(base.getString(R.string.toast_sending_crash_report))
-				.withLength(Toast.LENGTH_SHORT)
-				.withEnabled(true);
-		ACRA.init(this, builder);
+		ACRA.init(this, new CoreConfigurationBuilder()
+				.withReportFormat(StringFormat.JSON)
+				.withPluginConfigurations(
+						new HttpSenderConfigurationBuilder()
+								.withUri("https://acra.robinj.be/report")
+								.withBasicAuthLogin(BuildConfig.ACRA_USERNAME)
+								.withBasicAuthPassword(BuildConfig.ACRA_PASSWORD)
+								.withHttpMethod(HttpSender.Method.POST)
+								.withEnabled(true)
+								.build(),
+						new ToastConfigurationBuilder()
+								.withText(base.getString(R.string.toast_sending_crash_report))
+								.withLength(Toast.LENGTH_SHORT)
+								.withEnabled(true)
+								.build()
+				)
+		);
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/Application.java
+++ b/app/src/main/java/be/robinj/distrohopper/Application.java
@@ -4,29 +4,33 @@ import android.content.Context;
 import android.widget.Toast;
 
 import org.acra.ACRA;
-import org.acra.annotation.AcraCore;
-import org.acra.annotation.AcraHttpSender;
-import org.acra.annotation.AcraToast;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.HttpSenderConfigurationBuilder;
+import org.acra.config.ToastConfigurationBuilder;
 import org.acra.data.StringFormat;
 import org.acra.sender.HttpSender;
 
 /**
  * Created by robin on 8/22/14.
  */
-@AcraCore(reportFormat = StringFormat.JSON)
-@AcraHttpSender(uri = "https://acra.robinj.be/report",
-	basicAuthLogin = BuildConfig.ACRA_USERNAME,
-	basicAuthPassword = BuildConfig.ACRA_PASSWORD,
-	httpMethod = HttpSender.Method.POST)
-@AcraToast(resText = R.string.toast_sending_crash_report,
-	length = Toast.LENGTH_SHORT)
 public class Application extends android.app.Application
 {
 	@Override
 	protected void attachBaseContext(final Context base) {
 		super.attachBaseContext(base);
 
-		// The following line triggers the initialization of ACRA
-		ACRA.init(this);
+		CoreConfigurationBuilder builder = new CoreConfigurationBuilder()
+				.withReportFormat(StringFormat.JSON);
+		builder.getPluginConfigurationBuilder(HttpSenderConfigurationBuilder.class)
+				.withUri("https://acra.robinj.be/report")
+				.withBasicAuthLogin(BuildConfig.ACRA_USERNAME)
+				.withBasicAuthPassword(BuildConfig.ACRA_PASSWORD)
+				.withHttpMethod(HttpSender.Method.POST)
+				.withEnabled(true);
+		builder.getPluginConfigurationBuilder(ToastConfigurationBuilder.class)
+				.withText(base.getString(R.string.toast_sending_crash_report))
+				.withLength(Toast.LENGTH_SHORT)
+				.withEnabled(true);
+		ACRA.init(this, builder);
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext {
-        kotlin_version = '2.2.0'
-    }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:9.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- AGP: 8.13.0 (invalid) → 9.1.1 (latest stable, April 2026)
- Gradle wrapper: 8.13 → 9.3.1 (required by AGP 9.1.1)
- Remove explicit Kotlin plugin; AGP 9.0+ has built-in Kotlin support
- Update DSL: compileSdkVersion/minSdkVersion/targetSdkVersion → compileSdk/minSdk/targetSdk
- appcompat: 1.1.0 → 1.7.1
- ACRA: 5.5.1 → 5.13.1
- Robolectric: 4.11.1 → 4.16.1
- androidx.test:core: 1.5.0 → 1.7.0
- androidx.test.ext:junit: 1.1.5 → 1.3.0
- espresso-core/intents: 3.5.1 → 3.7.0
- CI: JDK 17 → 21 (required by Robolectric 4.16.1 for SDK 36 tests)

https://claude.ai/code/session_01GRQ9uP4MFTBndjyea7UQ2P