### PR TITLE
Fix crash, cursor leak, and broken file opening in LocalFiles lens

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LocalFiles.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LocalFiles.java
@@ -1,14 +1,12 @@
 package be.robinj.distrohopper.desktop.dash.lens;
 
-import android.annotation.TargetApi;
 import android.content.ActivityNotFoundException;
+import android.content.ContentUris;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.MediaStore;
-import android.webkit.MimeTypeMap;
 
 import org.json.JSONException;
 
@@ -41,36 +39,39 @@ public class LocalFiles extends Lens
 		return "Search results for files on your device";
 	}
 
-	@Override
-	public int getMinSDKVersion ()
-	{
-		return 11;
-	}
-
-	@TargetApi (Build.VERSION_CODES.HONEYCOMB)
 	public List<LensSearchResult> search (final String str, final int maxResults) throws IOException, JSONException
 	{
 		List<LensSearchResult> results = new ArrayList<LensSearchResult> ();
-		int nResults = 0;
 
 		String[] projection = new String[]
 		{
+			MediaStore.Files.FileColumns._ID,
+			MediaStore.Files.FileColumns.DISPLAY_NAME,
 			MediaStore.Files.FileColumns.DATA
 		};
-		String selection = MediaStore.Files.FileColumns.TITLE + " LIKE '%" + str.replace ("'", "''") + "%'";
-		Cursor cursor = this.context.getContentResolver ().query (MediaStore.Files.getContentUri ("external"), projection, selection, null, null);
+		String selection = MediaStore.Files.FileColumns.TITLE + " LIKE ?";
+		String[] selectionArgs = new String[] { "%" + str + "%" };
+		Uri contentUri = MediaStore.Files.getContentUri ("external");
 
-		while (cursor.moveToNext ())
+		try (Cursor cursor = this.context.getContentResolver ().query (contentUri, projection, selection, selectionArgs, null))
 		{
-			String path = cursor.getString (0);
-			File file = new File (path);
+			if (cursor == null) {
+				return results;
+			}
 
-			LensSearchResult result = new LensSearchResult (this.context, file.getName (), file.toString (), this.icon);
+			while (cursor.moveToNext () && results.size () < maxResults)
+			{
+				long id = cursor.getLong (0);
+				String name = cursor.getString (1);
+				if (name == null)
+				{
+					String path = cursor.getString (2);
+					name = path == null ? Long.toString (id) : new File (path).getName ();
+				}
 
-			results.add (result);
+				Uri fileUri = ContentUris.withAppendedId (contentUri, id);
 
-			if (++nResults >= maxResults) {
-				break;
+				results.add (new LensSearchResult (this.context, name, fileUri.toString (), this.icon));
 			}
 		}
 
@@ -82,21 +83,17 @@ public class LocalFiles extends Lens
 	{
 		try
 		{
-			File file = new File (url);
+			Uri uri = Uri.parse (url);
 
-			String extension = MimeTypeMap.getFileExtensionFromUrl (url);
-			String mime = "*/*";
-
-			if (extension != null)
-			{
-				MimeTypeMap map = MimeTypeMap.getSingleton ();
-				mime = map.getMimeTypeFromExtension (extension);
+			String mime = this.context.getContentResolver ().getType (uri);
+			if (mime == null) {
+				mime = "*/*";
 			}
 
 			Intent intent = new Intent ();
 			intent.setAction (Intent.ACTION_VIEW);
-			intent.setDataAndType (Uri.parse (file.getPath()), mime);
-			intent.setFlags (Intent.FLAG_ACTIVITY_NEW_TASK);
+			intent.setDataAndType (uri, mime);
+			intent.setFlags (Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
 			this.context.startActivity (intent);
 		}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LocalFilesTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LocalFilesTest.kt
@@ -1,0 +1,136 @@
+package be.robinj.distrohopper.desktop.dash.lens
+
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Intent
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowContentResolver
+
+@RunWith(RobolectricTestRunner::class)
+class LocalFilesTest {
+    private lateinit var application: Application
+    private lateinit var provider: RecordingMediaProvider
+    private lateinit var lens: LocalFiles
+
+    @Before fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        provider = RecordingMediaProvider()
+        ShadowContentResolver.registerProviderInternal("media", provider)
+        lens = LocalFiles(application)
+    }
+
+    private fun mediaCursor(vararg rows: Pair<Long, String>): MatrixCursor {
+        val cursor = MatrixCursor(arrayOf(
+            MediaStore.Files.FileColumns._ID,
+            MediaStore.Files.FileColumns.DISPLAY_NAME,
+            MediaStore.Files.FileColumns.DATA,
+        ))
+        rows.forEach { (id, name) -> cursor.addRow(arrayOf<Any>(id, name, "/storage/emulated/0/$name")) }
+        return cursor
+    }
+
+    @Test fun searchReturnsResultsFromMediaStore() {
+        provider.cursorToReturn = mediaCursor(1L to "notes.txt", 2L to "notes2.txt")
+        val results = lens.search("notes", 10)
+        assertEquals(2, results.size)
+        assertEquals("notes.txt", results[0].name)
+        assertEquals("notes2.txt", results[1].name)
+    }
+
+    @Test fun searchReturnsEmptyListWhenQueryFails() {
+        provider.cursorToReturn = null
+        val results = lens.search("anything", 10)
+        assertTrue(results.isEmpty())
+    }
+
+    @Test fun searchClosesCursor() {
+        val cursor = mediaCursor(1L to "notes.txt")
+        provider.cursorToReturn = cursor
+        lens.search("notes", 10)
+        assertTrue(cursor.isClosed)
+    }
+
+    @Test fun searchClosesCursorWhenNoResults() {
+        val cursor = mediaCursor()
+        provider.cursorToReturn = cursor
+        lens.search("nothing", 10)
+        assertTrue(cursor.isClosed)
+    }
+
+    @Test fun searchUsesSelectionArgsInsteadOfStringConcatenation() {
+        provider.cursorToReturn = mediaCursor()
+        lens.search("o'brien", 10)
+        assertNotNull(provider.lastSelection)
+        assertTrue(provider.lastSelection!!.contains("?"))
+        assertFalse(provider.lastSelection!!.contains("o'brien"))
+        assertFalse(provider.lastSelection!!.contains("o''brien"))
+        assertArrayEquals(arrayOf("%o'brien%"), provider.lastSelectionArgs)
+    }
+
+    @Test fun searchRespectsMaxResults() {
+        provider.cursorToReturn = mediaCursor(1L to "a.txt", 2L to "b.txt", 3L to "c.txt", 4L to "d.txt")
+        val results = lens.search("txt", 2)
+        assertEquals(2, results.size)
+    }
+
+    @Test fun resultUrlIsAContentUriForTheMediaStoreEntry() {
+        provider.cursorToReturn = mediaCursor(42L to "notes.txt")
+        val results = lens.search("notes", 10)
+        val uri = Uri.parse(results[0].url)
+        assertEquals("content", uri.scheme)
+        assertEquals("42", uri.lastPathSegment)
+    }
+
+    @Test fun clickStartsViewIntentWithContentUri() {
+        provider.typeToReturn = "text/plain"
+        lens.onClick("content://media/external/file/42")
+        val intent = Shadows.shadowOf(application).nextStartedActivity
+        assertNotNull(intent)
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        assertEquals("content://media/external/file/42", intent.dataString)
+        assertEquals("text/plain", intent.type)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+        assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+    }
+
+    @Test fun clickFallsBackToWildcardMimeTypeWhenUnknown() {
+        provider.typeToReturn = null
+        lens.onClick("content://media/external/file/42")
+        val intent = Shadows.shadowOf(application).nextStartedActivity
+        assertNotNull(intent)
+        assertEquals("*/*", intent.type)
+    }
+
+    private class RecordingMediaProvider : ContentProvider() {
+        var cursorToReturn: Cursor? = null
+        var typeToReturn: String? = null
+        var lastSelection: String? = null
+        var lastSelectionArgs: Array<out String>? = null
+
+        override fun onCreate() = true
+
+        override fun query(uri: Uri, projection: Array<out String>?, selection: String?,
+                           selectionArgs: Array<out String>?, sortOrder: String?): Cursor? {
+            this.lastSelection = selection
+            this.lastSelectionArgs = selectionArgs
+            return this.cursorToReturn
+        }
+
+        override fun getType(uri: Uri) = this.typeToReturn
+        override fun insert(uri: Uri, values: ContentValues?) = null
+        override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?) = 0
+        override fun update(uri: Uri, values: ContentValues?, selection: String?,
+                            selectionArgs: Array<out String>?) = 0
+    }
+}


### PR DESCRIPTION
## Bug

The LocalFiles dash lens (`LocalFiles.java`) had four issues, found during a codebase review:

1. **Crash:** `ContentResolver.query()` can return `null` (e.g. when the storage permission isn't granted — which it never is, since the app doesn't request it at runtime). The cursor was dereferenced without a null check, so searching from the dash with this lens enabled threw an NPE.
2. **Resource leak:** the `Cursor` was never closed.
3. **Unsafe SQL:** the `selection` clause was built by string concatenation with only single-quote escaping instead of using `selectionArgs`.
4. **Broken file opening:** `onClick()` built the view intent with `Uri.parse(file.getPath())` — a scheme-less URI no viewer app can resolve (and `file://` URIs trigger `FileUriExposedException` since API 24 anyway).

## Fix

- Query result handled with try-with-resources and a null check.
- Selection uses `LIKE ?` with `selectionArgs`.
- Results now carry MediaStore `content://` URIs (`ContentUris.withAppendedId`), with display name falling back to the file path. `onClick()` resolves the MIME type from the content provider and grants `FLAG_GRANT_READ_URI_PERMISSION`, which works under scoped storage (minSdk is 29).
- Removed the dead `getMinSDKVersion() == 11` override / `@TargetApi(HONEYCOMB)` annotation (minSdk is 29).

## Tests

`LocalFilesTest.kt` (new) uses a recording `ContentProvider` registered for the `media` authority:

- **Bug-surfacing tests** (fail against the previous implementation — 8 of 9 tests failed pre-fix): null cursor returns empty results instead of crashing; cursor is closed after search (with and without results); selection uses placeholders + args rather than concatenated input; result URLs are `content://` URIs; clicks fire `ACTION_VIEW` with the content URI, resolved MIME type, and read-grant flag.
- **Regression tests:** results mapped from cursor rows; `maxResults` respected; wildcard MIME fallback.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c)_