### PR TITLE
Fix stream leaks and missing timeouts in Lens network helpers

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/Lens.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/Lens.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.List;
 
 /**
@@ -25,6 +26,8 @@ import java.util.List;
 public abstract class Lens
 {
 	private static final int DEFAULT_MAX_RESULTS = 20;
+	private static final int CONNECT_TIMEOUT_MS = 10000;
+	private static final int READ_TIMEOUT_MS = 10000;
 
 	protected Context context;
 
@@ -93,42 +96,45 @@ public abstract class Lens
 		}
 	}
 
+	protected URLConnection openConnection (String url) throws IOException
+	{
+		URLConnection connection = new URL (url).openConnection ();
+		connection.setConnectTimeout (CONNECT_TIMEOUT_MS);
+		connection.setReadTimeout (READ_TIMEOUT_MS);
+
+		return connection;
+	}
+
 	protected String downloadStr (String url) throws IOException
 	{
-		URL urlObj = new URL (url);
-		InputStreamReader streamReader = new InputStreamReader (urlObj.openStream ());
-		BufferedReader reader = new BufferedReader (streamReader);
+		try (BufferedReader reader = new BufferedReader (new InputStreamReader (this.openConnection (url).getInputStream ())))
+		{
+			StringBuilder str = new StringBuilder ();
+			String line = null;
 
-		StringBuilder str = new StringBuilder ();
-		String line = null;
+			while ((line = reader.readLine ()) != null)
+				str.append (line);
 
-		while ((line = reader.readLine ()) != null)
-			str.append (line);
-
-		reader.close ();
-
-		return str.toString ();
+			return str.toString ();
+		}
 	}
 
 	protected Drawable downloadImage (String url) throws IOException
 	{
-		URL urlObj = new URL (url);
-		InputStream in = new BufferedInputStream (urlObj.openStream ());
-		ByteArrayOutputStream out = new ByteArrayOutputStream ();
-		byte[] buffer = new byte[1024];
+		try (InputStream in = new BufferedInputStream (this.openConnection (url).getInputStream ());
+			ByteArrayOutputStream out = new ByteArrayOutputStream ())
+		{
+			byte[] buffer = new byte[1024];
 
-		int x = 0;
+			int x = 0;
 
-		while ((x = in.read (buffer)) != -1)
-			out.write (buffer, 0, x);
+			while ((x = in.read (buffer)) != -1)
+				out.write (buffer, 0, x);
 
-		out.close ();
-		in.close ();
+			byte[] imageBytes = out.toByteArray ();
 
-		byte[] imageBytes = out.toByteArray ();
-		Drawable image = new BitmapDrawable (BitmapFactory.decodeByteArray (imageBytes, 0, imageBytes.length));
-
-		return image;
+			return new BitmapDrawable (BitmapFactory.decodeByteArray (imageBytes, 0, imageBytes.length));
+		}
 	}
 
 	protected void showDialog (String message)

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LensNetworkTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LensNetworkTest.kt
@@ -1,0 +1,125 @@
+package be.robinj.distrohopper.desktop.dash.lens
+
+import android.app.Application
+import android.graphics.Bitmap
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.net.URL
+import java.net.URLConnection
+
+@RunWith(RobolectricTestRunner::class)
+class LensNetworkTest {
+    private lateinit var application: Application
+    private lateinit var lens: FakeConnectionLens
+
+    @Before fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        lens = FakeConnectionLens(application)
+    }
+
+    @Test fun downloadStrReadsAllContent() {
+        lens.stream = TrackingInputStream("line1\nline2".byteInputStream())
+        assertEquals("line1line2", lens.download("http://example.com"))
+    }
+
+    @Test fun downloadStrClosesStreamOnSuccess() {
+        val stream = TrackingInputStream("content".byteInputStream())
+        lens.stream = stream
+        lens.download("http://example.com")
+        assertTrue(stream.closed)
+    }
+
+    @Test fun downloadStrClosesStreamWhenReadFails() {
+        val stream = TrackingInputStream(FailingInputStream())
+        lens.stream = stream
+        try {
+            lens.download("http://example.com")
+            fail("Expected IOException")
+        } catch (expected: IOException) {
+        }
+        assertTrue("stream must be closed even when the download fails", stream.closed)
+    }
+
+    @Test fun downloadImageDecodesImageBytes() {
+        val pngBytes = ByteArrayOutputStream().also {
+            Bitmap.createBitmap(4, 4, Bitmap.Config.ARGB_8888)
+                .compress(Bitmap.CompressFormat.PNG, 100, it)
+        }.toByteArray()
+        lens.stream = TrackingInputStream(ByteArrayInputStream(pngBytes))
+        assertNotNull(lens.downloadDrawable("http://example.com/image.png"))
+    }
+
+    @Test fun downloadImageClosesStreamOnSuccess() {
+        val stream = TrackingInputStream(ByteArrayInputStream(ByteArray(8)))
+        lens.stream = stream
+        lens.downloadDrawable("http://example.com/image.png")
+        assertTrue(stream.closed)
+    }
+
+    @Test fun downloadImageClosesStreamWhenReadFails() {
+        val stream = TrackingInputStream(FailingInputStream())
+        lens.stream = stream
+        try {
+            lens.downloadDrawable("http://example.com/image.png")
+            fail("Expected IOException")
+        } catch (expected: IOException) {
+        }
+        assertTrue("stream must be closed even when the download fails", stream.closed)
+    }
+
+    @Test fun connectionsAreConfiguredWithTimeouts() {
+        val connection = lens.realConnection("http://example.com")
+        assertTrue("a connect timeout must be set", connection.connectTimeout > 0)
+        assertTrue("a read timeout must be set", connection.readTimeout > 0)
+    }
+
+    /** Wraps a stream and records whether it has been closed. */
+    private class TrackingInputStream(private val delegate: InputStream) : InputStream() {
+        var closed = false
+
+        override fun read() = delegate.read()
+        override fun read(b: ByteArray, off: Int, len: Int) = delegate.read(b, off, len)
+        override fun close() {
+            closed = true
+            delegate.close()
+        }
+    }
+
+    /** Yields a few bytes, then fails mid-download. */
+    private class FailingInputStream : InputStream() {
+        private var reads = 0
+
+        override fun read(): Int {
+            if (++reads > 4) {
+                throw IOException("connection reset")
+            }
+            return 'x'.code
+        }
+    }
+
+    private class FakeConnectionLens(context: android.content.Context) : Lens(context) {
+        var stream: InputStream? = null
+
+        fun download(url: String): String = downloadStr(url)
+        fun downloadDrawable(url: String) = downloadImage(url)
+        fun realConnection(url: String): URLConnection = super.openConnection(url)
+
+        override fun openConnection(url: String): URLConnection =
+            object : URLConnection(URL(url)) {
+                override fun connect() {}
+                override fun getInputStream(): InputStream = stream!!
+            }
+
+        override fun search(str: String, maxResults: Int): List<LensSearchResult> = emptyList()
+        override fun getName() = "FakeConnection"
+        override fun getDescription() = "Test lens"
+    }
+}


### PR DESCRIPTION
## Bug

`Lens.downloadStr()` and `Lens.downloadImage()` — used by all seven network lenses (DuckDuckGo, GitHub, Reddit, AskUbuntu, StackOverflow, ServerFault, SuperUser) — had two issues, found during a codebase review:

1. **Stream leak:** streams were only closed on the happy path. Any `IOException` thrown mid-read (connection reset, etc.) leaked the underlying connection.
2. **No timeouts:** connections were opened via `URL.openStream()` with no connect/read timeout, so a single unresponsive server could hang a dash search indefinitely — the progress wheel spins forever.

## Fix

- Both helpers now use try-with-resources, so streams are closed on every path.
- Connections go through a new `openConnection()` method that applies 10-second connect/read timeouts. The seam also makes the download logic unit-testable without real network access.

No behavior change for the lens subclasses.

## Tests

`LensNetworkTest.kt` (new) drives the helpers through a fake `URLConnection` with a close-tracking stream:

- **Bug-surfacing tests** (verified to fail against the previous implementation): streams are closed when a download fails mid-read (both helpers), and connections carry connect/read timeouts.
- **Regression tests:** `downloadStr` reads and concatenates content; `downloadImage` decodes PNG bytes into a drawable; streams are closed on success.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c)_