### PR TITLE
Unregister PackageManagerBroadcastReceiver when HomeActivity is destroyed

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -670,6 +670,12 @@ public class HomeActivity extends AppCompatActivity
 	{
 		this.cancelAsyncTasks();
 
+		if (this.broadcastPackageManager != null)
+		{
+			this.unregisterReceiver (this.broadcastPackageManager);
+			this.broadcastPackageManager = null;
+		}
+
 		super.onDestroy ();
 	}
 

--- a/app/src/test/java/be/robinj/distrohopper/HomeActivityReceiverTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/HomeActivityReceiverTest.kt
@@ -1,0 +1,43 @@
+package be.robinj.distrohopper
+
+import android.app.Application
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.broadcast.PackageManagerBroadcastReceiver
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class HomeActivityReceiverTest {
+    private lateinit var scenario: ActivityScenario<HomeActivity>
+
+    @Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
+    @After fun tearDown() { scenario.close() }
+
+    private fun packageManagerReceiverRegistrations(): List<Any> {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        return Shadows.shadowOf(application).registeredReceivers
+            .filter { it.broadcastReceiver is PackageManagerBroadcastReceiver }
+    }
+
+    @Test fun packageManagerReceiverIsRegisteredWhileActive() {
+        assertTrue(packageManagerReceiverRegistrations().isNotEmpty())
+    }
+
+    @Test fun packageManagerReceiverIsUnregisteredWhenDestroyed() {
+        scenario.moveToState(Lifecycle.State.DESTROYED)
+        ActivityTestSupport.drainTasks()
+        assertTrue(
+            "PackageManagerBroadcastReceiver must not stay registered after the activity is destroyed",
+            packageManagerReceiverRegistrations().isEmpty(),
+        )
+    }
+}


### PR DESCRIPTION
## Bug

Found during a codebase review: `HomeActivity` registers a `PackageManagerBroadcastReceiver` once app loading completes (`asyncLoadAppsDone`), but no `unregisterReceiver()` call existed anywhere. Every activity teardown — theme change, configuration change, launcher restart — leaked the receiver along with the `HomeActivity` instance it references. On a real device this also surfaces as the `android.app.IntentReceiverLeaked` warning.

## Fix

`onDestroy()` now unregisters the receiver (null-guarded, since registration happens late in an async callback and may not have occurred if the activity is destroyed early).

## Tests

`HomeActivityReceiverTest.kt` (new):

- **Bug-surfacing test** (fails without the fix): after driving the activity to `DESTROYED`, no `PackageManagerBroadcastReceiver` remains in the application's registered receivers.
- **Regression test:** the receiver *is* registered while the activity is alive, so the leak can't be "fixed" by simply never registering it.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c)_