### PR TITLE
Fix NPE in AppManager.addRunningApps for pinned apps without a view

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/AppManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/AppManager.java
@@ -109,7 +109,8 @@ public class AppManager implements Iterable<App>
 			if (this.isPinned (app))
 			{
 				AppLauncher appLauncher = (AppLauncher) this.llLauncherPinnedApps.findViewWithTag (app);
-				appLauncher.setRunning (true);
+				if (appLauncher != null)
+					appLauncher.setRunning (true);
 			}
 			else
 			{

--- a/app/src/test/java/be/robinj/distrohopper/AppManagerPinnedRunningAppsTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/AppManagerPinnedRunningAppsTest.kt
@@ -1,0 +1,71 @@
+package be.robinj.distrohopper
+
+import android.app.ActivityManager
+import android.content.Context
+import android.graphics.Color
+import android.widget.LinearLayout
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.desktop.launcher.AppLauncher
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class AppManagerPinnedRunningAppsTest {
+    private lateinit var scenario: ActivityScenario<HomeActivity>
+
+    @Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
+    @After fun tearDown() { scenario.close() }
+
+    private fun setRunningProcess(activity: HomeActivity, packageName: String) {
+        val activityManager = activity.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val process = ActivityManager.RunningAppProcessInfo(packageName, 1234, arrayOf(packageName))
+            .apply { importance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND }
+        Shadows.shadowOf(activityManager).setProcesses(listOf(process))
+    }
+
+    @Test fun addRunningAppsToleratesPinnedAppWithoutLauncherView() {
+        scenario.onActivity { activity ->
+            val manager = activity.appManager
+            val app = manager.findAppsByPackageName("com.example.alpha").first()
+            manager.pin(app, false, false, false) // pinned, but no view in llLauncherPinnedApps
+            setRunningProcess(activity, "com.example.alpha")
+
+            manager.addRunningApps(Color.BLACK)
+        }
+    }
+
+    @Test fun addRunningAppsMarksPinnedAppViewAsRunning() {
+        scenario.onActivity { activity ->
+            val manager = activity.appManager
+            val app = manager.findAppsByPackageName("com.example.alpha").first()
+            manager.pin(app, false, false, true)
+            setRunningProcess(activity, "com.example.alpha")
+
+            manager.addRunningApps(Color.BLACK)
+
+            val pinnedContainer = activity.findViewById<LinearLayout>(R.id.llLauncherPinnedApps)
+            val launcher = pinnedContainer.findViewWithTag<AppLauncher>(app)
+            assertNotNull(launcher)
+            assertTrue(launcher.isRunning)
+        }
+    }
+
+    @Test fun addRunningAppsAddsLauncherForUnpinnedRunningApp() {
+        scenario.onActivity { activity ->
+            val manager = activity.appManager
+            setRunningProcess(activity, "com.example.beta")
+
+            manager.addRunningApps(Color.BLACK)
+
+            val runningContainer = activity.findViewById<LinearLayout>(R.id.llLauncherRunningApps)
+            assertEquals(1, runningContainer.childCount)
+        }
+    }
+}


### PR DESCRIPTION
## Bug

Found during a codebase review: `AppManager.addRunningApps()` marks running pinned apps via

```java
AppLauncher appLauncher = (AppLauncher) this.llLauncherPinnedApps.findViewWithTag (app);
appLauncher.setRunning (true);
```

`findViewWithTag()` returns `null` whenever the pinned app has no launcher view — for example when an app was pinned with `pin(app, ..., addView=false)` or while the pinned-apps row is being rebuilt. With "show running apps" enabled, this crashed the home screen with a `NullPointerException` on resume.

## Fix

Null-check the view before calling `setRunning(true)`. The data model (`pinned` list) remains the source of truth; the view is updated only if it exists.

## Tests

`AppManagerPinnedRunningAppsTest.kt` (new), driving a real `HomeActivity` with a shadowed `ActivityManager`:

- **Bug-surfacing test** (fails with an NPE without the fix): a pinned app without a launcher view that is currently running no longer crashes `addRunningApps()`.
- **Regression tests:** a pinned app *with* a view is correctly marked as running, and an unpinned running app still gets an entry in the running-apps container.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c)_