### PR TITLE
Handle null process list in AppManager.getRunningApps

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/AppManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/AppManager.java
@@ -197,6 +197,8 @@ public class AppManager implements Iterable<App>
 		if (Build.VERSION.SDK_INT >= 21) // ActivityManager.getRunningTasks () is deprecated //
 		{
 			List<ActivityManager.RunningAppProcessInfo> runningAppProcesses = am.getRunningAppProcesses ();
+			if (runningAppProcesses == null)
+				return running;
 
 			for (ActivityManager.RunningAppProcessInfo appProcess : runningAppProcesses)
 			{

--- a/app/src/test/java/be/robinj/distrohopper/AppManagerRunningProcessesTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/AppManagerRunningProcessesTest.kt
@@ -1,0 +1,83 @@
+package be.robinj.distrohopper
+
+import android.app.ActivityManager
+import android.content.Context
+import androidx.test.core.app.ActivityScenario
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowActivityManager
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class AppManagerRunningProcessesTest {
+    private lateinit var scenario: ActivityScenario<HomeActivity>
+
+    @Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
+    @After fun tearDown() { scenario.close() }
+
+    private fun process(packageName: String, processImportance: Int) =
+        ActivityManager.RunningAppProcessInfo(packageName, 1234, arrayOf(packageName))
+            .apply { importance = processImportance }
+
+    private fun setProcesses(activity: HomeActivity, processes: List<ActivityManager.RunningAppProcessInfo>) {
+        val activityManager = activity.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        Shadows.shadowOf(activityManager).setProcesses(processes)
+    }
+
+    @Test
+    @Config(shadows = [NullProcessListActivityManagerShadow::class])
+    fun getRunningAppsReturnsEmptyListWhenProcessListIsUnavailable() {
+        scenario.onActivity { activity ->
+            // ActivityManager.getRunningAppProcesses() is documented to return null
+            val running = activity.appManager.runningApps
+            assertTrue(running.isEmpty())
+        }
+    }
+
+    @Test fun getRunningAppsReturnsAppsWithImportantProcesses() {
+        scenario.onActivity { activity ->
+            setProcesses(activity, listOf(
+                process("com.example.alpha", ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND),
+                process("com.example.beta", ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE),
+            ))
+            val running = activity.appManager.runningApps
+            assertEquals(
+                listOf("com.example.alpha", "com.example.beta"),
+                running.map { it.packageName },
+            )
+        }
+    }
+
+    @Test fun getRunningAppsIgnoresGoneProcesses() {
+        scenario.onActivity { activity ->
+            setProcesses(activity, listOf(
+                process("com.example.alpha", ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE),
+            ))
+            assertTrue(activity.appManager.runningApps.isEmpty())
+        }
+    }
+
+    @Test fun getRunningAppsIgnoresProcessesOfUnknownPackages() {
+        scenario.onActivity { activity ->
+            setProcesses(activity, listOf(
+                process("com.example.notinstalled", ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND),
+            ))
+            assertTrue(activity.appManager.runningApps.isEmpty())
+        }
+    }
+
+    @Implements(ActivityManager::class)
+    class NullProcessListActivityManagerShadow : ShadowActivityManager() {
+        @Implementation
+        override fun getRunningAppProcesses(): MutableList<ActivityManager.RunningAppProcessInfo>? = null
+    }
+}


### PR DESCRIPTION
## Bug

Found during a codebase review: `ActivityManager.getRunningAppProcesses()` is [documented to return null](https://developer.android.com/reference/android/app/ActivityManager#getRunningAppProcesses()), but `AppManager.getRunningApps()` iterated the result unconditionally:

```java
List<ActivityManager.RunningAppProcessInfo> runningAppProcesses = am.getRunningAppProcesses ();
for (ActivityManager.RunningAppProcessInfo appProcess : runningAppProcesses)  // NPE when null
```

With "show running apps" enabled, this crashed the home screen on resume whenever the system returned no process list.

## Fix

Return an empty list when the process list is unavailable.

(Related observation, intentionally left out of this PR's scope: with `minSdk 29` the pre-API-21 `getRunningTasks` branch in this method is dead code, and on API 29+ `getRunningAppProcesses()` only reports the caller's own processes, so the running-apps feature has limited visibility on modern Android — worth a separate product decision.)

## Tests

`AppManagerRunningProcessesTest.kt` (new):

- **Bug-surfacing test** (fails with an NPE without the fix): a custom `ShadowActivityManager` whose `getRunningAppProcesses()` returns null — `getRunningApps()` now returns an empty list instead of crashing.
- **Regression tests:** processes with important importances map to the matching installed apps in order; `IMPORTANCE_GONE` processes and processes of packages that aren't installed are ignored.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c)_