### PR TITLE
Fix fd leak, key collisions, and SharedPreferences set misuse in DrawableCache

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
+++ b/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
@@ -170,13 +170,20 @@ public class DrawableCache implements ICache<Drawable> {
 	@NonNull
 	@Override
 	public synchronized Set<String> keySet() {
-		for (final String key : this.keys) { // safe: this.keys is reassigned, never mutated //
+		this.removeKeysWithoutBackingFile();
+
+		return this.keys;
+	}
+
+	// The cache directory can be purged by the system or the user at any time, independently //
+	// of the key set persisted in SharedPreferences - so before relying on the key set, drop //
+	// keys whose backing file has disappeared. //
+	private synchronized void removeKeysWithoutBackingFile() {
+		for (final String key : this.keys) {
 			if (! this.containsKey(key)) {
 				this.remove(key);
 			}
 		}
-
-		return this.keys;
 	}
 
 	@NonNull

--- a/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
+++ b/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
@@ -7,10 +7,14 @@ import android.graphics.drawable.Drawable;
 import androidx.annotation.NonNull;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -28,19 +32,35 @@ public class DrawableCache implements ICache<Drawable> {
 	protected DrawableCache(final Context context, final String name) {
 		this.name = name;
 		this.prefs = context.getSharedPreferences("cache_" + name, Context.MODE_PRIVATE);
-		this.keys = this.prefs.getStringSet("keys", new HashSet<>());
+		// The set returned by getStringSet() must never be modified, so take a copy //
+		this.keys = new HashSet<>(this.prefs.getStringSet("keys", Collections.emptySet()));
 		this.cachePath = context.getCacheDir().getPath() + "/";
 	}
 
 	private String getPath(final String key) {
 		return new StringBuilder(this.cachePath)
-			.append(key.hashCode())
+			.append(hash(key))
 			.append(".png")
 			.toString();
 	}
 
+	private static String hash(final String key) {
+		try {
+			final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			final byte[] bytes = digest.digest(key.getBytes(StandardCharsets.UTF_8));
+			final StringBuilder hex = new StringBuilder(bytes.length * 2);
+			for (final byte b : bytes) {
+				hex.append(String.format("%02x", b));
+			}
+
+			return hex.toString();
+		} catch (final NoSuchAlgorithmException ex) {
+			throw new IllegalStateException(ex); // SHA-256 is available on every Android version
+		}
+	}
+
 	private synchronized void commitKeys() {
-		this.prefs.edit().putStringSet("keys", this.keys).commit();
+		this.prefs.edit().putStringSet("keys", new HashSet<>(this.keys)).commit();
 	}
 
 	@Override
@@ -89,14 +109,15 @@ public class DrawableCache implements ICache<Drawable> {
 			if (bitmap == null) {
 				return null;
 			}
-			final FileOutputStream outputStream = new FileOutputStream(this.getPath(key));
-			bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
+			try (final FileOutputStream outputStream = new FileOutputStream(this.getPath(key))) {
+				bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
+			}
 
 			this.keys.add(key);
 			if (commit) {
 				this.commitKeys();
 			}
-		} catch (FileNotFoundException ex) {
+		} catch (IOException ex) {
 			new ExceptionHandler(ex).logAndTrack();
 
 			return null;
@@ -149,15 +170,13 @@ public class DrawableCache implements ICache<Drawable> {
 	@NonNull
 	@Override
 	public synchronized Set<String> keySet() {
-		final Set<String> keys = this.prefs.getStringSet("keys", new HashSet<String>());
-
-		for (final String key : keys) {
+		for (final String key : new HashSet<>(this.keys)) {
 			if (! this.containsKey(key)) {
 				this.remove(key);
 			}
 		}
 
-		return keys;
+		return new HashSet<>(this.keys);
 	}
 
 	@NonNull

--- a/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
+++ b/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
@@ -9,12 +9,14 @@ import androidx.annotation.NonNull;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import be.robinj.distrohopper.ExceptionHandler;
 import be.robinj.distrohopper.Image;
@@ -35,11 +37,10 @@ public class DrawableCache implements ICache<Drawable> {
 	}
 
 	private String getPath(final String key) {
-		// Keys are "<package>\n<activity>" component names (see App.getPackageAndActivityName()),
-		// which are unique per app and can't contain ':' themselves - so the key doubles as a
-		// collision-free filename once the newline (and '/', for safety) are swapped out. //
+		// Name-based UUID (an MD5 of the key): deterministic and collision-free in practice,
+		// with a fixed-length filename whatever the length of the component name in the key. //
 		return new StringBuilder(this.cachePath)
-			.append(key.replace('\n', ':').replace('/', ':'))
+			.append(UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8)))
 			.append(".png")
 			.toString();
 	}

--- a/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
+++ b/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
@@ -9,9 +9,6 @@ import androidx.annotation.NonNull;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,25 +35,13 @@ public class DrawableCache implements ICache<Drawable> {
 	}
 
 	private String getPath(final String key) {
+		// Keys are "<package>\n<activity>" component names (see App.getPackageAndActivityName()),
+		// which are unique per app and can't contain ':' themselves - so the key doubles as a
+		// collision-free filename once the newline (and '/', for safety) are swapped out. //
 		return new StringBuilder(this.cachePath)
-			.append(hash(key))
+			.append(key.replace('\n', ':').replace('/', ':'))
 			.append(".png")
 			.toString();
-	}
-
-	private static String hash(final String key) {
-		try {
-			final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-			final byte[] bytes = digest.digest(key.getBytes(StandardCharsets.UTF_8));
-			final StringBuilder hex = new StringBuilder(bytes.length * 2);
-			for (final byte b : bytes) {
-				hex.append(String.format("%02x", b));
-			}
-
-			return hex.toString();
-		} catch (final NoSuchAlgorithmException ex) {
-			throw new IllegalStateException(ex); // SHA-256 is available on every Android version
-		}
 	}
 
 	private synchronized void commitKeys() {

--- a/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
+++ b/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +20,8 @@ import java.util.UUID;
 import be.robinj.distrohopper.ExceptionHandler;
 import be.robinj.distrohopper.Image;
 import be.robinj.distrohopper.dev.Log;
+
+import static java.util.Collections.emptySet;
 
 public class DrawableCache implements ICache<Drawable> {
 	private final SharedPreferences prefs;
@@ -32,7 +33,7 @@ public class DrawableCache implements ICache<Drawable> {
 		this.name = name;
 		this.prefs = context.getSharedPreferences("cache_" + name, Context.MODE_PRIVATE);
 		// The set returned by getStringSet() must never be modified, so take a copy //
-		this.keys = new HashSet<>(this.prefs.getStringSet("keys", Collections.emptySet()));
+		this.keys = new HashSet<>(this.prefs.getStringSet("keys", emptySet()));
 		this.cachePath = context.getCacheDir().getPath() + "/";
 	}
 
@@ -46,7 +47,7 @@ public class DrawableCache implements ICache<Drawable> {
 	}
 
 	private synchronized void commitKeys() {
-		this.prefs.edit().putStringSet("keys", new HashSet<>(this.keys)).commit();
+		this.prefs.edit().putStringSet("keys", Set.copyOf(this.keys)).commit();
 	}
 
 	@Override
@@ -156,13 +157,13 @@ public class DrawableCache implements ICache<Drawable> {
 	@NonNull
 	@Override
 	public synchronized Set<String> keySet() {
-		for (final String key : new HashSet<>(this.keys)) {
+		for (final String key : Set.copyOf(this.keys)) {
 			if (! this.containsKey(key)) {
 				this.remove(key);
 			}
 		}
 
-		return new HashSet<>(this.keys);
+		return Set.copyOf(this.keys);
 	}
 
 	@NonNull

--- a/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
+++ b/app/src/main/java/be/robinj/distrohopper/cache/DrawableCache.java
@@ -26,14 +26,15 @@ import static java.util.Collections.emptySet;
 public class DrawableCache implements ICache<Drawable> {
 	private final SharedPreferences prefs;
 	private final String cachePath;
-	private final Set<String> keys;
+	/** Always an immutable set; updated copy-on-write. */
+	private Set<String> keys;
 	private final String name;
 
 	protected DrawableCache(final Context context, final String name) {
 		this.name = name;
 		this.prefs = context.getSharedPreferences("cache_" + name, Context.MODE_PRIVATE);
-		// The set returned by getStringSet() must never be modified, so take a copy //
-		this.keys = new HashSet<>(this.prefs.getStringSet("keys", emptySet()));
+		// The set returned by getStringSet() must never be modified, so take an immutable copy //
+		this.keys = Set.copyOf(this.prefs.getStringSet("keys", emptySet()));
 		this.cachePath = context.getCacheDir().getPath() + "/";
 	}
 
@@ -47,7 +48,19 @@ public class DrawableCache implements ICache<Drawable> {
 	}
 
 	private synchronized void commitKeys() {
-		this.prefs.edit().putStringSet("keys", Set.copyOf(this.keys)).commit();
+		this.prefs.edit().putStringSet("keys", this.keys).commit(); // this.keys is immutable, so no aliasing risk //
+	}
+
+	private synchronized void addKey(final String key) {
+		final Set<String> updated = new HashSet<>(this.keys);
+		updated.add(key);
+		this.keys = Set.copyOf(updated);
+	}
+
+	private synchronized void removeKey(final Object key) {
+		final Set<String> updated = new HashSet<>(this.keys);
+		updated.remove(key);
+		this.keys = Set.copyOf(updated);
 	}
 
 	@Override
@@ -100,7 +113,7 @@ public class DrawableCache implements ICache<Drawable> {
 				bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
 			}
 
-			this.keys.add(key);
+			this.addKey(key);
 			if (commit) {
 				this.commitKeys();
 			}
@@ -125,7 +138,7 @@ public class DrawableCache implements ICache<Drawable> {
 			new File(this.getPath(key.toString())).delete();
 		}
 
-		this.keys.remove(key);
+		this.removeKey(key);
 		if (commit) {
 			this.commitKeys();
 		}
@@ -145,7 +158,7 @@ public class DrawableCache implements ICache<Drawable> {
 	@Override
 	public synchronized void clear() {
 		int nKeysRemoved = 0;
-		for (final String key : Set.copyOf(this.keySet())) {
+		for (final String key : this.keySet()) {
 			this.remove(key, false);
 			nKeysRemoved++;
 		}
@@ -157,13 +170,13 @@ public class DrawableCache implements ICache<Drawable> {
 	@NonNull
 	@Override
 	public synchronized Set<String> keySet() {
-		for (final String key : Set.copyOf(this.keys)) {
+		for (final String key : this.keys) { // safe: this.keys is reassigned, never mutated //
 			if (! this.containsKey(key)) {
 				this.remove(key);
 			}
 		}
 
-		return Set.copyOf(this.keys);
+		return this.keys;
 	}
 
 	@NonNull

--- a/app/src/test/java/be/robinj/distrohopper/cache/DrawableCacheRobustnessTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/cache/DrawableCacheRobustnessTest.kt
@@ -1,0 +1,87 @@
+package be.robinj.distrohopper.cache
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DrawableCacheRobustnessTest {
+    private lateinit var context: Context
+    private lateinit var cache: TestDrawableCache
+
+    @Before fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        cache = TestDrawableCache(context, "drawables_robustness_test")
+        cache.clear()
+    }
+
+    @After fun tearDown() = cache.clear()
+
+    private fun drawable(color: Int, size: Int = 4) = BitmapDrawable(
+        context.resources,
+        Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888).apply { eraseColor(color) },
+    )
+
+    private fun backingFiles() =
+        context.cacheDir.listFiles { file -> file.name.endsWith(".png") }.orEmpty()
+
+    private fun deleteBackingFiles() = backingFiles().forEach { it.delete() }
+
+    @Test fun keysWithCollidingHashCodesAreStoredSeparately() {
+        assertEquals("Aa".hashCode(), "BB".hashCode()) // genuine hash collision
+        cache["Aa"] = drawable(Color.RED, size = 4)
+        cache["BB"] = drawable(Color.BLUE, size = 8)
+
+        assertEquals(2, backingFiles().size)
+        assertEquals(4, (cache["Aa"] as BitmapDrawable).bitmap.width)
+        assertEquals(8, (cache["BB"] as BitmapDrawable).bitmap.width)
+    }
+
+    @Test fun staleKeyCleanupDoesNotThrowConcurrentModification() {
+        cache["a"] = drawable(Color.RED)
+        cache["b"] = drawable(Color.BLUE)
+        deleteBackingFiles()
+
+        val keys = cache.keys // triggers cleanup of keys whose files are gone
+
+        assertTrue(keys.isEmpty())
+        assertEquals(0, cache.size)
+    }
+
+    @Test fun cachedDrawablesSurviveReload() {
+        cache["icon"] = drawable(Color.RED)
+
+        val reloaded = TestDrawableCache(context, "drawables_robustness_test")
+
+        assertTrue(reloaded.containsKey("icon"))
+        assertNotNull(reloaded["icon"])
+    }
+
+    @Test fun removedKeysStayRemovedAfterReload() {
+        cache["a"] = drawable(Color.RED)
+        cache["b"] = drawable(Color.BLUE)
+        cache.remove("a")
+
+        val reloaded = TestDrawableCache(context, "drawables_robustness_test")
+
+        assertFalse(reloaded.containsKey("a"))
+        assertTrue(reloaded.containsKey("b"))
+    }
+
+    @Test fun mutationsAfterReadingKeySetDoNotLeakIntoTheReturnedSet() {
+        cache["a"] = drawable(Color.RED)
+        val keys = cache.keys
+
+        cache["b"] = drawable(Color.BLUE)
+
+        assertEquals(setOf("a"), keys)
+    }
+}


### PR DESCRIPTION
## Bugs

Found during a codebase review — three related issues in the on-disk icon cache (`DrawableCache.java`):

1. **File descriptor leak:** the `FileOutputStream` used to write cached PNGs was never closed. This code runs for every installed app when icons are loaded, so descriptors leak steadily.
2. **Key collisions:** cache files were named after `key.hashCode()`, so two distinct keys with colliding hash codes (e.g. `"Aa"`/`"BB"`) silently overwrote each other's icons — one app would show another app's icon.
3. **SharedPreferences contract violation:** the set returned by `getStringSet()` was stored and mutated directly, which [the Android docs explicitly forbid](https://developer.android.com/reference/android/content/SharedPreferences#getStringSet(java.lang.String,%20java.util.Set%3Cjava.lang.String%3E)) — "consistency of the stored data" becomes undefined. `keySet()` additionally relied on that aliasing for stale-key cleanup and returned a set that tracked internal state (and whose cleanup didn't actually take effect in the returned value).

## Fix

- PNG writes use try-with-resources; `put()` now catches `IOException` (closing can fail too, not just opening).
- Cache files are named after `UUID.nameUUIDFromBytes(key)` — a name-based UUID (an MD5 of the key under the hood). Deterministic, collision-free in practice (122 effective bits vs `hashCode()`'s 32), a stdlib one-liner, and fixed-length filenames that can never exceed the filesystem's 255-byte name limit regardless of how long an app's component name is. Previously cached files become cache misses once and are re-cached; no migration needed for a cache.
- The key set is an immutable `Set.copyOf` of the prefs-returned set, updated copy-on-write through `addKey`/`removeKey`. Since `this.keys` can never be mutated, it can be handed to `putStringSet()` and returned from `keySet()` as-is — no aliasing, no defensive copies needed at the hand-out sites.

## Tests

`DrawableCacheRobustnessTest.kt` (new):

- **Bug-surfacing tests** (verified to fail without the fix): colliding-hash keys are stored as separate files and both retrievable with their own content; stale-key cleanup in `keySet()` actually removes keys whose backing files are gone.
- **Regression tests:** cached drawables survive a cache reload (new instance, same prefs); removed keys stay removed after reload; mutating the cache after reading `keySet()` doesn't leak into the previously returned set.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`), including the pre-existing `DrawableCacheTest`.

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c