### PR TITLE
Fix wrong variable in LensManager constructor null guard

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LensManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LensManager.java
@@ -43,7 +43,7 @@ public class LensManager
 		this.enabled = new ArrayList<Lens> ();
 		this.llDashHomeAppsContainer = llDashHomeAppsContainer;
 		this.llDashHomeLensesContainer = llDashHomeLensesContainer;
-		if (llDashHomeAppsContainer != null)
+		if (llDashHomeLensesContainer != null)
 			this.lvDashHomeLensResults = (ListView) llDashHomeLensesContainer.findViewById (R.id.lvDashHomeLensResults);
 		this.pwDashSearchProgress = pwDashSearchProgress;
 

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LensManagerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LensManagerTest.kt
@@ -1,7 +1,10 @@
 package be.robinj.distrohopper.desktop.dash.lens
 
 import android.content.Context
+import android.widget.LinearLayout
+import android.widget.ListView
 import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.R
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
 import org.junit.Assert.*
@@ -75,5 +78,23 @@ class LensManagerTest {
         assertEquals("LocalFiles", prefs.getString("1", null))
         assertEquals("GitHub", prefs.getString("2", null))
         assertNull(prefs.getString("3", null))
+    }
+
+    @Test fun constructionToleratesMissingLensesContainer() {
+        // The apps container being present must not make the constructor dereference the
+        // (absent) lenses container.
+        LensManager(context, LinearLayout(context), null, null, null)
+    }
+
+    @Test fun lensResultsViewIsResolvedFromTheLensesContainer() {
+        val lensesContainer = LinearLayout(context)
+        val lensResults = ListView(context).apply { id = R.id.lvDashHomeLensResults }
+        lensesContainer.addView(lensResults)
+
+        val manager = LensManager(context, null, lensesContainer, null, null)
+
+        val field = LensManager::class.java.getDeclaredField("lvDashHomeLensResults")
+        field.isAccessible = true
+        assertSame(lensResults, field.get(manager))
     }
 }


### PR DESCRIPTION
## Bug

Found during a codebase review — `LensManager`'s constructor guards one variable but dereferences another:

```java
if (llDashHomeAppsContainer != null)
    this.lvDashHomeLensResults = (ListView) llDashHomeLensesContainer.findViewById (R.id.lvDashHomeLensResults);
```

Consequences:
- apps container present, lenses container absent → `NullPointerException`;
- lenses container present, apps container absent → the lens results `ListView` is silently never resolved, which later NPEs in `AsyncSearch.onPreExecute()` when a search starts.

## Fix

The guard now checks `llDashHomeLensesContainer` — the variable actually dereferenced.

## Tests

Added to the existing `LensManagerTest.kt` (both fail without the fix):

- **Bug-surfacing test:** constructing with an apps container but no lenses container no longer throws.
- **Regression test:** the lens results view is resolved from the lenses container regardless of whether the apps container is provided.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c)_