### PR TITLE
Show error dialogs from ExceptionHandler regardless of calling thread

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/ExceptionHandler.java
+++ b/app/src/main/java/be/robinj/distrohopper/ExceptionHandler.java
@@ -2,6 +2,7 @@ package be.robinj.distrohopper;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.os.Looper;
 import android.text.Html;
 
 import org.acra.ACRA;
@@ -41,24 +42,36 @@ public class ExceptionHandler {
 
 		if (context != null)
 		{
-			try
+			if (Looper.myLooper () == Looper.getMainLooper ())
 			{
-				AlertDialog.Builder dlg = new AlertDialog.Builder (context);
-				dlg.setTitle ("(╯°□°）╯︵ ┻━┻");
-				dlg.setMessage (message.toString ());
-				dlg.setCancelable (true);
-				dlg.setNeutralButton ("OK", null);
-
-				dlg.show ();
+				this.showDialog (context, message.toString ());
 			}
-			catch (Exception ex2)
+			else
 			{
-				Log.getInstance ().e (this.getClass ().getSimpleName (), "Couldn't show AlertDialog");
+				Utils.runOnUiThread (() -> this.showDialog (context, message.toString ()));
 			}
 		}
 		else
 		{
 			Log.getInstance ().w (this.getClass ().getSimpleName (), "User wasn't notified that there was a problem because context == NULL");
+		}
+	}
+
+	private void showDialog (final Context context, final String message)
+	{
+		try
+		{
+			AlertDialog.Builder dlg = new AlertDialog.Builder (context);
+			dlg.setTitle ("(╯°□°）╯︵ ┻━┻");
+			dlg.setMessage (message);
+			dlg.setCancelable (true);
+			dlg.setNeutralButton ("OK", null);
+
+			dlg.show ();
+		}
+		catch (Exception ex2)
+		{
+			Log.getInstance ().e (this.getClass ().getSimpleName (), "Couldn't show AlertDialog: " + ex2.getMessage ());
 		}
 	}
 

--- a/app/src/test/java/be/robinj/distrohopper/ExceptionHandlerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/ExceptionHandlerTest.kt
@@ -1,0 +1,61 @@
+package be.robinj.distrohopper
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowAlertDialog
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class ExceptionHandlerTest {
+    private lateinit var context: Context
+
+    @Before fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        ShadowAlertDialog.reset()
+    }
+
+    @Test fun showFromMainThreadDisplaysDialog() {
+        ExceptionHandler(IllegalStateException("boom")).show(context)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        val dialog = ShadowAlertDialog.getLatestAlertDialog()
+        assertNotNull(dialog)
+        assertTrue(dialog.isShowing)
+    }
+
+    @Test fun showFromBackgroundThreadDisplaysDialog() {
+        val background = Thread { ExceptionHandler(IllegalStateException("boom")).show(context) }
+        background.start()
+        background.join(5000)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        assertNotNull(
+            "the error dialog must also be shown when show() is called from a background thread",
+            ShadowAlertDialog.getLatestAlertDialog(),
+        )
+    }
+
+    @Test fun dialogMessageDescribesTheException() {
+        ExceptionHandler(IllegalStateException("something exploded")).show(context)
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        val message = Shadows.shadowOf(ShadowAlertDialog.getLatestAlertDialog()).message.toString()
+        assertTrue(message.contains("IllegalStateException"))
+        assertTrue(message.contains("something exploded"))
+    }
+
+    @Test fun showWithNullContextDoesNotThrow() {
+        ExceptionHandler(IllegalStateException("boom")).show(null)
+    }
+}


### PR DESCRIPTION
## Bug

Found during a codebase review: `ExceptionHandler.show()` built and showed its `AlertDialog` directly on the calling thread. When invoked from a background thread — notably the catch block in `AsyncLoadApps.doInBackground()` — dialog creation threw internally (`Can't create handler inside thread that has not called Looper.prepare()`), that exception was swallowed by `show()`'s own catch ("Couldn't show AlertDialog"), and the user was never told that something — like app loading — had failed. The launcher just sat there with a partially initialized state.

## Fix

- `show()` displays the dialog inline when already on the main looper, and posts it to the main looper via the existing `Utils.runOnUiThread()` otherwise — so main-thread callers keep their current synchronous behavior and background callers now actually reach the user.
- The fallback log now includes *why* the dialog couldn't be shown instead of a bare "Couldn't show AlertDialog".

## Tests

`ExceptionHandlerTest.kt` (new):

- **Bug-surfacing test** (fails without the fix): `show()` called from a background thread displays the dialog after the main looper drains.
- **Regression tests:** `show()` on the main thread still displays the dialog; the dialog message contains the exception type and message; `show(null)` doesn't throw.

Full unit test suite passes locally (`./gradlew testDebugUnitTest`).

https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUohvLCkouo6hdXiHeaf3c)_