### PR TITLE
Add a first-run setup wizard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,17 @@ etc/                                        — design assets (SVG/XCF sources, 
     (`InstalledApps`, `LocalFiles`, `DuckDuckGo`, `GitHub`, Stack Exchange
     sites, `Reddit`, …) coordinated by `LensManager` with `AsyncSearch` and
     result/collection adapters.
+- **`onboarding/`** — the first-run wizard. `OnboardingActivity` is a
+  full-screen ViewPager2 pager (theme choice, runtime permission prompts,
+  set-as-default-home via `RoleManager.ROLE_HOME`) shown over the wallpaper.
+  `HomeActivity.onCreate` checks `OnboardingGate.shouldShow` before any
+  initialisation and redirects (finishing itself) on first run; Done/Skip
+  set the `SETUP_COMPLETED` preference and relaunch `HomeActivity` so the
+  chosen theme applies via the usual recreate path. Users with a `theme`
+  preference from before the wizard existed are marked completed silently.
+  Tests that launch `HomeActivity` with fresh prefs must seed
+  `SETUP_COMPLETED` (done by `ActivityTestSupport.launchHome()`) or they
+  will be redirected to the wizard.
 - **`preferences/`** — `PreferencesActivity` (settings UI built
   programmatically with `PreferenceScreen`/categories), plus dedicated
   activities for lens ordering (`LensPreferencesActivity`) and theme

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,9 @@ etc/                                        — design assets (SVG/XCF sources, 
     in new model-level code.
   - `App`, `Application`, `AppComparatorAlphabetical` — app model classes.
   - `IconPackHelper`, `Image`, `Utils`, `ViewFinder`, `InsetsHelper`,
-    `Permission`, `RequestCode`, `ExceptionHandler` — support/utilities.
+    `Permission`, `RequestCode`, `ExceptionHandler`, `HomeRole` —
+    support/utilities. `HomeRole` wraps the HOME-role (default launcher)
+    checks/request intent used by the wizard and the preferences screen.
     `InsetsHelper` handles system bar / display cutout insets (e.g. keeping
     UI clear of the 3-button navigation bar).
   - `Observed`/`IObserver` — small homegrown observer pattern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,12 @@ etc/                                        — design assets (SVG/XCF sources, 
   initialisation and redirects (finishing itself) on first run; Done/Skip
   set the `SETUP_COMPLETED` preference and relaunch `HomeActivity` so the
   chosen theme applies via the usual recreate path. Users with a `theme`
-  preference from before the wizard existed are marked completed silently.
+  preference from before the wizard existed are marked completed silently —
+  the wizard writes `SETUP_STARTED` on launch so its own theme write (made
+  as soon as a card is tapped) doesn't trip that grandfathering when a run
+  is interrupted. The permission page is dropped on devices where the
+  wallpaper permission isn't grantable (Android 13+), so the page list is
+  per-device.
   Tests that launch `HomeActivity` with fresh prefs must seed
   `SETUP_COMPLETED` (done by `ActivityTestSupport.launchHome()`) or they
   will be redirected to the wizard.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.4'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.4'
+    implementation 'androidx.viewpager2:viewpager2:1.1.0'
 
     // ACRA
     def acraVersion = '5.13.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,12 @@
 			</intent-filter>
 		</activity>
 		<activity
+			android:name="be.robinj.distrohopper.onboarding.OnboardingActivity"
+			android:label="@string/title_activity_onboarding"
+			android:launchMode="singleTask"
+			android:theme="@style/OnboardingTheme"
+			android:exported="false" />
+		<activity
 			android:name="be.robinj.distrohopper.AboutActivity"
 			android:label="@string/title_activity_about"
 			android:parentActivityName="be.robinj.distrohopper.preferences.PreferencesActivity"

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -47,6 +47,8 @@ import be.robinj.distrohopper.home.StartupLoader;
 import be.robinj.distrohopper.home.ThemeApplier;
 import be.robinj.distrohopper.home.WallpaperColourApplier;
 import be.robinj.distrohopper.dev.LogToaster;
+import be.robinj.distrohopper.onboarding.OnboardingActivity;
+import be.robinj.distrohopper.onboarding.OnboardingGate;
 import be.robinj.distrohopper.preferences.Preference;
 import be.robinj.distrohopper.preferences.Preferences;
 import be.robinj.distrohopper.preferences.PreferencesActivity;
@@ -101,6 +103,16 @@ public class HomeActivity extends AppCompatActivity
 	protected void onCreate (Bundle savedInstanceState)
 	{
 		super.onCreate (savedInstanceState);
+
+		// First run: hand over to the setup wizard before initialising anything //
+		if (OnboardingGate.shouldShow (DependencyContainer.of (this).getPrefs ()))
+		{
+			this.startActivity (new Intent (this, OnboardingActivity.class));
+			this.finish ();
+
+			return;
+		}
+
 		setContentView (R.layout.activity_home);
 		this.viewFinder = new ViewFinder(this);
 

--- a/app/src/main/java/be/robinj/distrohopper/HomeRole.kt
+++ b/app/src/main/java/be/robinj/distrohopper/HomeRole.kt
@@ -1,0 +1,33 @@
+package be.robinj.distrohopper
+
+import android.app.role.RoleManager
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+
+/**
+ * Default-launcher (HOME role) helpers, shared by the first-run wizard and
+ * the preferences screen.
+ */
+object HomeRole {
+	@JvmStatic
+	fun isHeld(context: Context): Boolean =
+		context.getSystemService(RoleManager::class.java)
+			?.isRoleHeld(RoleManager.ROLE_HOME) == true
+
+	/**
+	 * An intent prompting the user to make this app the default home app: the
+	 * system's role dialog, or the home settings screen where the role is
+	 * unavailable.
+	 */
+	@JvmStatic
+	fun requestIntent(context: Context): Intent {
+		val roleManager = context.getSystemService(RoleManager::class.java)
+
+		return if (roleManager != null && roleManager.isRoleAvailable(RoleManager.ROLE_HOME)) {
+			roleManager.createRequestRoleIntent(RoleManager.ROLE_HOME)
+		} else {
+			Intent(Settings.ACTION_HOME_SETTINGS)
+		}
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
@@ -1,10 +1,8 @@
 package be.robinj.distrohopper.onboarding
 
 import android.Manifest
-import android.app.role.RoleManager
 import android.content.Intent
 import android.os.Bundle
-import android.provider.Settings
 import android.view.View
 import android.widget.Button
 import android.widget.LinearLayout
@@ -15,6 +13,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager2.widget.ViewPager2
 import be.robinj.distrohopper.DependencyContainer
 import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.HomeRole
 import be.robinj.distrohopper.InsetsHelper
 import be.robinj.distrohopper.Permission
 import be.robinj.distrohopper.R
@@ -136,11 +135,14 @@ class OnboardingActivity : AppCompatActivity() {
 	}
 
 	private fun bindDefaultLauncherPage(view: View) {
-		val isDefault = this.isDefaultLauncher()
+		val isDefault = HomeRole.isHeld(this)
 
 		view.findViewById<Button>(R.id.btnOnboardingSetDefault).apply {
 			this.visibility = if (isDefault) View.GONE else View.VISIBLE
-			this.setOnClickListener { this@OnboardingActivity.requestHomeRole() }
+			this.setOnClickListener {
+				this@OnboardingActivity.roleRequest
+					.launch(HomeRole.requestIntent(this@OnboardingActivity))
+			}
 		}
 		view.findViewById<TextView>(R.id.tvOnboardingAlreadyDefault)
 			.visibility = if (isDefault) View.VISIBLE else View.GONE
@@ -150,20 +152,6 @@ class OnboardingActivity : AppCompatActivity() {
 		this.wizardPermissions
 			.filterNot { Permission(this, it).check() }
 			.toTypedArray()
-
-	private fun isDefaultLauncher(): Boolean =
-		this.getSystemService(RoleManager::class.java)
-			?.isRoleHeld(RoleManager.ROLE_HOME) == true
-
-	private fun requestHomeRole() {
-		val roleManager = this.getSystemService(RoleManager::class.java)
-
-		if (roleManager != null && roleManager.isRoleAvailable(RoleManager.ROLE_HOME)) {
-			this.roleRequest.launch(roleManager.createRequestRoleIntent(RoleManager.ROLE_HOME))
-		} else {
-			this.startActivity(Intent(Settings.ACTION_HOME_SETTINGS))
-		}
-	}
 
 	private fun themes(): List<Theme> {
 		val dev = this.container.prefs.getBoolean(Preference.DEV, false)

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
@@ -2,6 +2,7 @@ package be.robinj.distrohopper.onboarding
 
 import android.Manifest
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
@@ -36,8 +37,21 @@ class OnboardingActivity : AppCompatActivity() {
 	private lateinit var adapter: OnboardingPagerAdapter
 	private lateinit var themeCards: OnboardingThemeCards
 
-	/** The runtime permissions the wizard asks for; extend as the app gains new ones. */
-	private val wizardPermissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+	/**
+	 * The runtime permissions the wizard asks for; extend as the app gains new
+	 * ones. READ_EXTERNAL_STORAGE (used by the wallpaper-colour code) stopped
+	 * being grantable on Android 13+, so it is omitted there.
+	 */
+	private val wizardPermissions =
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+			arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+		else
+			emptyArray()
+
+	/** The permission page is dropped when there is nothing grantable to ask for. */
+	private val pages = OnboardingPage.entries.filter {
+		it != OnboardingPage.PERMISSION || this.wizardPermissions.isNotEmpty()
+	}
 
 	private val permissionRequest = this.registerForActivityResult(
 		ActivityResultContracts.RequestMultiplePermissions()
@@ -54,6 +68,10 @@ class OnboardingActivity : AppCompatActivity() {
 
 		this.container = DependencyContainer.of(this)
 
+		// Before any other preference write, so that the gate can tell this
+		// wizard run's writes apart from a pre-wizard install's //
+		OnboardingGate.markStarted(this.container.prefs)
+
 		this.pager = this.findViewById(R.id.vpOnboarding)
 		this.indicator = this.findViewById(R.id.opiOnboardingDots)
 		this.btnSkip = this.findViewById(R.id.btnOnboardingSkip)
@@ -65,11 +83,11 @@ class OnboardingActivity : AppCompatActivity() {
 			this::applyTheme,
 		)
 
-		this.adapter = OnboardingPagerAdapter(this::bindPage)
+		this.adapter = OnboardingPagerAdapter(this.pages, this::bindPage)
 		this.pager.adapter = this.adapter
 		this.pager.setPageTransformer(OnboardingPageTransformer())
 
-		this.indicator.count = OnboardingPage.entries.size
+		this.indicator.count = this.pages.size
 		this.pager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
 			override fun onPageScrolled(position: Int, offset: Float, offsetPixels: Int) {
 				this@OnboardingActivity.indicator.setPosition(position, offset)
@@ -82,7 +100,7 @@ class OnboardingActivity : AppCompatActivity() {
 
 		this.btnSkip.setOnClickListener { this.finishSetup() }
 		this.btnNext.setOnClickListener {
-			if (this.pager.currentItem == OnboardingPage.entries.size - 1) {
+			if (this.pager.currentItem == this.pages.size - 1) {
 				this.finishSetup()
 			} else {
 				this.pager.currentItem += 1
@@ -179,7 +197,7 @@ class OnboardingActivity : AppCompatActivity() {
 	}
 
 	private fun updateButtons(position: Int) {
-		val last = position == OnboardingPage.entries.size - 1
+		val last = position == this.pages.size - 1
 
 		this.btnNext.setText(if (last) R.string.onboarding_button_done else R.string.onboarding_button_next)
 		this.btnSkip.visibility = if (last) View.INVISIBLE else View.VISIBLE

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
@@ -1,0 +1,199 @@
+package be.robinj.distrohopper.onboarding
+
+import android.Manifest
+import android.app.role.RoleManager
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.viewpager2.widget.ViewPager2
+import be.robinj.distrohopper.DependencyContainer
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.InsetsHelper
+import be.robinj.distrohopper.Permission
+import be.robinj.distrohopper.R
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.theme.Theme
+import be.robinj.distrohopper.theme.ThemeRegistry
+
+/**
+ * First-run wizard: theme choice, permission prompts, and the option to set
+ * DistroHopper as the default home screen. Shown by HomeActivity (gated by
+ * [OnboardingGate]) before anything else is initialised; Done/Skip mark setup
+ * complete and relaunch HomeActivity so it comes up in the chosen theme.
+ */
+class OnboardingActivity : AppCompatActivity() {
+	private lateinit var container: DependencyContainer
+	private lateinit var pager: ViewPager2
+	private lateinit var indicator: OnboardingPageIndicator
+	private lateinit var btnSkip: Button
+	private lateinit var btnNext: Button
+	private lateinit var adapter: OnboardingPagerAdapter
+	private lateinit var themeCards: OnboardingThemeCards
+
+	/** The runtime permissions the wizard asks for; extend as the app gains new ones. */
+	private val wizardPermissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+
+	private val permissionRequest = this.registerForActivityResult(
+		ActivityResultContracts.RequestMultiplePermissions()
+	) { this.adapter.rebind(OnboardingPage.PERMISSION) }
+
+	private val roleRequest = this.registerForActivityResult(
+		ActivityResultContracts.StartActivityForResult()
+	) { this.adapter.rebind(OnboardingPage.DEFAULT_LAUNCHER) }
+
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+		this.setContentView(R.layout.activity_onboarding)
+		InsetsHelper.applySystemBarsPadding(this)
+
+		this.container = DependencyContainer.of(this)
+
+		this.pager = this.findViewById(R.id.vpOnboarding)
+		this.indicator = this.findViewById(R.id.opiOnboardingDots)
+		this.btnSkip = this.findViewById(R.id.btnOnboardingSkip)
+		this.btnNext = this.findViewById(R.id.btnOnboardingNext)
+
+		this.themeCards = OnboardingThemeCards(
+			this.themes(),
+			{ this.container.themeManager.current.getName() },
+			this::applyTheme,
+		)
+
+		this.adapter = OnboardingPagerAdapter(this::bindPage)
+		this.pager.adapter = this.adapter
+		this.pager.setPageTransformer(OnboardingPageTransformer())
+
+		this.indicator.count = OnboardingPage.entries.size
+		this.pager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+			override fun onPageScrolled(position: Int, offset: Float, offsetPixels: Int) {
+				this@OnboardingActivity.indicator.setPosition(position, offset)
+			}
+
+			override fun onPageSelected(position: Int) {
+				this@OnboardingActivity.updateButtons(position)
+			}
+		})
+
+		this.btnSkip.setOnClickListener { this.finishSetup() }
+		this.btnNext.setOnClickListener {
+			if (this.pager.currentItem == OnboardingPage.entries.size - 1) {
+				this.finishSetup()
+			} else {
+				this.pager.currentItem += 1
+			}
+		}
+
+		// Back steps through the pages; on the first page it does nothing (the
+		// wizard is the task's only activity, and Skip is the explicit way out).
+		this.onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+			override fun handleOnBackPressed() {
+				if (this@OnboardingActivity.pager.currentItem > 0) {
+					this@OnboardingActivity.pager.currentItem -= 1
+				}
+			}
+		})
+
+		this.updateButtons(this.pager.currentItem)
+	}
+
+	override fun onResume() {
+		super.onResume()
+
+		// The user may have granted either from system Settings in the meantime //
+		this.adapter.rebind(OnboardingPage.PERMISSION)
+		this.adapter.rebind(OnboardingPage.DEFAULT_LAUNCHER)
+	}
+
+	private fun bindPage(page: OnboardingPage, view: View) {
+		when (page) {
+			OnboardingPage.WELCOME -> Unit
+			OnboardingPage.THEME ->
+				this.themeCards.bind(view.findViewById<LinearLayout>(R.id.llOnboardingThemeCards))
+			OnboardingPage.PERMISSION -> this.bindPermissionPage(view)
+			OnboardingPage.DEFAULT_LAUNCHER -> this.bindDefaultLauncherPage(view)
+		}
+	}
+
+	private fun bindPermissionPage(view: View) {
+		val granted = this.missingPermissions().isEmpty()
+
+		view.findViewById<Button>(R.id.btnOnboardingGrantPermission).apply {
+			this.visibility = if (granted) View.GONE else View.VISIBLE
+			this.setOnClickListener {
+				this@OnboardingActivity.permissionRequest
+					.launch(this@OnboardingActivity.missingPermissions())
+			}
+		}
+		view.findViewById<TextView>(R.id.tvOnboardingPermissionGranted)
+			.visibility = if (granted) View.VISIBLE else View.GONE
+	}
+
+	private fun bindDefaultLauncherPage(view: View) {
+		val isDefault = this.isDefaultLauncher()
+
+		view.findViewById<Button>(R.id.btnOnboardingSetDefault).apply {
+			this.visibility = if (isDefault) View.GONE else View.VISIBLE
+			this.setOnClickListener { this@OnboardingActivity.requestHomeRole() }
+		}
+		view.findViewById<TextView>(R.id.tvOnboardingAlreadyDefault)
+			.visibility = if (isDefault) View.VISIBLE else View.GONE
+	}
+
+	private fun missingPermissions(): Array<String> =
+		this.wizardPermissions
+			.filterNot { Permission(this, it).check() }
+			.toTypedArray()
+
+	private fun isDefaultLauncher(): Boolean =
+		this.getSystemService(RoleManager::class.java)
+			?.isRoleHeld(RoleManager.ROLE_HOME) == true
+
+	private fun requestHomeRole() {
+		val roleManager = this.getSystemService(RoleManager::class.java)
+
+		if (roleManager != null && roleManager.isRoleAvailable(RoleManager.ROLE_HOME)) {
+			this.roleRequest.launch(roleManager.createRequestRoleIntent(RoleManager.ROLE_HOME))
+		} else {
+			this.startActivity(Intent(Settings.ACTION_HOME_SETTINGS))
+		}
+	}
+
+	private fun themes(): List<Theme> {
+		val dev = this.container.prefs.getBoolean(Preference.DEV, false)
+
+		return ThemeRegistry.themes.values
+			.map { it() }
+			.filter { dev || !it.dev_only }
+	}
+
+	/** Same three preferences ThemePreferencesButtonClickListener writes. */
+	private fun applyTheme(theme: Theme) {
+		val res = this.resources
+
+		this.container.prefs.edit {
+			this.putString(Preference.THEME.getName(), theme.getName())
+			this.putInt(Preference.LAUNCHER_EDGE.getName(), res.getInteger(theme.launcher_location))
+			this.putInt(Preference.PANEL_EDGE.getName(), res.getInteger(theme.panel_location))
+		}
+	}
+
+	private fun finishSetup() {
+		OnboardingGate.markCompleted(this.container.prefs)
+		this.startActivity(Intent(this, HomeActivity::class.java))
+		this.finish()
+	}
+
+	private fun updateButtons(position: Int) {
+		val last = position == OnboardingPage.entries.size - 1
+
+		this.btnNext.setText(if (last) R.string.onboarding_button_done else R.string.onboarding_button_next)
+		this.btnSkip.visibility = if (last) View.INVISIBLE else View.VISIBLE
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingGate.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingGate.kt
@@ -15,13 +15,23 @@ object OnboardingGate {
 			return false
 		}
 
-		if (prefs.getString(Preference.THEME, null) != null) {
+		// A theme preference can only identify a pre-wizard install if the
+		// wizard never ran: the wizard's own theme page writes it too, and a
+		// user killed mid-wizard must still get the remaining pages. //
+		if (prefs.getString(Preference.THEME, null) != null
+			&& !prefs.getBoolean(Preference.SETUP_STARTED, false)) {
 			markCompleted(prefs)
 
 			return false
 		}
 
 		return true
+	}
+
+	/** Recorded by the wizard before it writes anything else (see [shouldShow]). */
+	@JvmStatic
+	fun markStarted(prefs: PreferencesRepository) {
+		prefs.edit { putBoolean(Preference.SETUP_STARTED.getName(), true) }
 	}
 
 	@JvmStatic

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingGate.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingGate.kt
@@ -1,0 +1,31 @@
+package be.robinj.distrohopper.onboarding
+
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.PreferencesRepository
+
+/**
+ * Decides whether the first-run wizard ([OnboardingActivity]) should be shown.
+ * Users who customised the app before the wizard existed (a theme preference
+ * is present) are grandfathered in without seeing it.
+ */
+object OnboardingGate {
+	@JvmStatic
+	fun shouldShow(prefs: PreferencesRepository): Boolean {
+		if (prefs.getBoolean(Preference.SETUP_COMPLETED, false)) {
+			return false
+		}
+
+		if (prefs.getString(Preference.THEME, null) != null) {
+			markCompleted(prefs)
+
+			return false
+		}
+
+		return true
+	}
+
+	@JvmStatic
+	fun markCompleted(prefs: PreferencesRepository) {
+		prefs.edit { putBoolean(Preference.SETUP_COMPLETED.getName(), true) }
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPage.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPage.kt
@@ -1,0 +1,12 @@
+package be.robinj.distrohopper.onboarding
+
+import androidx.annotation.LayoutRes
+import be.robinj.distrohopper.R
+
+/** The wizard's pages, in order. */
+enum class OnboardingPage(@LayoutRes val layout: Int) {
+	WELCOME(R.layout.widget_onboarding_page_welcome),
+	THEME(R.layout.widget_onboarding_page_theme),
+	PERMISSION(R.layout.widget_onboarding_page_permission),
+	DEFAULT_LAUNCHER(R.layout.widget_onboarding_page_default_launcher),
+}

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPageIndicator.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPageIndicator.kt
@@ -1,0 +1,77 @@
+package be.robinj.distrohopper.onboarding
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.util.AttributeSet
+import android.view.View
+
+/**
+ * Dot page indicator for the wizard's pager: the active dot stretches into a
+ * pill, animating smoothly between pages as [setPosition] is fed scroll
+ * offsets from the pager.
+ */
+class OnboardingPageIndicator @JvmOverloads constructor(
+	context: Context,
+	attrs: AttributeSet? = null,
+) : View(context, attrs) {
+	var count: Int = 0
+		set(value) {
+			field = value
+			this.requestLayout()
+		}
+
+	private var position: Int = 0
+	private var offset: Float = 0f
+
+	private val density = this.resources.displayMetrics.density
+	private val dotRadius = 4f * this.density
+	private val gap = 8f * this.density
+	private val pillExtraWidth = 16f * this.density
+
+	private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+	fun setPosition(position: Int, offset: Float) {
+		this.position = position
+		this.offset = offset
+		this.invalidate()
+	}
+
+	override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+		val width = this.paddingLeft + this.paddingRight +
+			(this.count * 2f * this.dotRadius + (this.count - 1) * this.gap + this.pillExtraWidth).toInt()
+		val height = this.paddingTop + this.paddingBottom + (2f * this.dotRadius).toInt()
+
+		this.setMeasuredDimension(
+			resolveSize(width, widthMeasureSpec),
+			resolveSize(height, heightMeasureSpec),
+		)
+	}
+
+	override fun onDraw(canvas: Canvas) {
+		super.onDraw(canvas)
+
+		val cy = this.paddingTop + this.dotRadius
+		var x = this.paddingLeft.toFloat()
+
+		for (i in 0 until this.count) {
+			val active = this.activeFraction(i)
+			val width = 2f * this.dotRadius + this.pillExtraWidth * active
+			this.paint.color = 0xFFFFFF or (((0x66 + (0xFF - 0x66) * active).toInt()) shl 24)
+
+			canvas.drawRoundRect(
+				x, cy - this.dotRadius, x + width, cy + this.dotRadius,
+				this.dotRadius, this.dotRadius, this.paint,
+			)
+
+			x += width + this.gap
+		}
+	}
+
+	/** How "selected" dot [i] currently is, in [0, 1]; mid-swipe it is split between two dots. */
+	private fun activeFraction(i: Int): Float = when (i) {
+		this.position -> 1f - this.offset
+		this.position + 1 -> this.offset
+		else -> 0f
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPageTransformer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPageTransformer.kt
@@ -1,0 +1,18 @@
+package be.robinj.distrohopper.onboarding
+
+import android.view.View
+import androidx.viewpager2.widget.ViewPager2
+import be.robinj.distrohopper.R
+import kotlin.math.abs
+
+/**
+ * Fades pages out as they scroll away and moves their content slower than the
+ * page itself (parallax), which makes the swipe feel deeper than a flat slide.
+ */
+class OnboardingPageTransformer : ViewPager2.PageTransformer {
+	override fun transformPage(page: View, position: Float) {
+		page.alpha = 1f - 0.5f * abs(position).coerceAtMost(1f)
+		page.findViewById<View>(R.id.llOnboardingPageContent)
+			?.translationX = -position * page.width * 0.2f
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPagerAdapter.kt
@@ -6,27 +6,36 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 
 /**
- * Inflates one fixed layout per [OnboardingPage]. State lives in
- * [OnboardingActivity], which supplies [bind]; pages whose state changed
- * (permission granted, role held) are refreshed via [rebind].
+ * Inflates one fixed layout per page of [pages] (the [OnboardingPage]s the
+ * wizard shows on this device). State lives in [OnboardingActivity], which
+ * supplies [bind]; pages whose state changed (permission granted, role held)
+ * are refreshed via [rebind].
  */
 class OnboardingPagerAdapter(
+	private val pages: List<OnboardingPage>,
 	private val bind: (OnboardingPage, View) -> Unit,
 ) : RecyclerView.Adapter<OnboardingPagerAdapter.PageHolder>() {
 	class PageHolder(view: View) : RecyclerView.ViewHolder(view)
 
-	override fun getItemCount(): Int = OnboardingPage.entries.size
+	override fun getItemCount(): Int = this.pages.size
 
 	override fun getItemViewType(position: Int): Int = position
 
 	override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PageHolder =
 		PageHolder(
 			LayoutInflater.from(parent.context)
-				.inflate(OnboardingPage.entries[viewType].layout, parent, false)
+				.inflate(this.pages[viewType].layout, parent, false)
 		)
 
 	override fun onBindViewHolder(holder: PageHolder, position: Int) =
-		this.bind(OnboardingPage.entries[position], holder.itemView)
+		this.bind(this.pages[position], holder.itemView)
 
-	fun rebind(page: OnboardingPage) = this.notifyItemChanged(page.ordinal)
+	/** No-op for pages this device doesn't show. */
+	fun rebind(page: OnboardingPage) {
+		val position = this.pages.indexOf(page)
+
+		if (position >= 0) {
+			this.notifyItemChanged(position)
+		}
+	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPagerAdapter.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingPagerAdapter.kt
@@ -1,0 +1,32 @@
+package be.robinj.distrohopper.onboarding
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * Inflates one fixed layout per [OnboardingPage]. State lives in
+ * [OnboardingActivity], which supplies [bind]; pages whose state changed
+ * (permission granted, role held) are refreshed via [rebind].
+ */
+class OnboardingPagerAdapter(
+	private val bind: (OnboardingPage, View) -> Unit,
+) : RecyclerView.Adapter<OnboardingPagerAdapter.PageHolder>() {
+	class PageHolder(view: View) : RecyclerView.ViewHolder(view)
+
+	override fun getItemCount(): Int = OnboardingPage.entries.size
+
+	override fun getItemViewType(position: Int): Int = position
+
+	override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PageHolder =
+		PageHolder(
+			LayoutInflater.from(parent.context)
+				.inflate(OnboardingPage.entries[viewType].layout, parent, false)
+		)
+
+	override fun onBindViewHolder(holder: PageHolder, position: Int) =
+		this.bind(OnboardingPage.entries[position], holder.itemView)
+
+	fun rebind(page: OnboardingPage) = this.notifyItemChanged(page.ordinal)
+}

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingThemeCards.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingThemeCards.kt
@@ -54,7 +54,7 @@ class OnboardingThemeCards(
 		val strokeWidth = (2f * context.resources.displayMetrics.density).toInt()
 
 		if (selected) {
-			background.setStroke(strokeWidth, context.getColor(theme.brand_colour))
+			background.setStroke(strokeWidth, context.getColor(theme.card_colour))
 			background.setColor(context.getColor(R.color.transparent80))
 		} else {
 			background.setStroke(strokeWidth, context.getColor(R.color.transparent))

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingThemeCards.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingThemeCards.kt
@@ -1,0 +1,64 @@
+package be.robinj.distrohopper.onboarding
+
+import android.graphics.drawable.GradientDrawable
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import be.robinj.distrohopper.R
+import be.robinj.distrohopper.theme.Theme
+
+/**
+ * Populates the wizard's theme page with one selectable card per theme.
+ * Selection is persisted immediately through [onSelected]; [selectedName]
+ * supplies the persisted choice so rebinds restore the highlight.
+ */
+class OnboardingThemeCards(
+	private val themes: List<Theme>,
+	private val selectedName: () -> String,
+	private val onSelected: (Theme) -> Unit,
+) {
+	fun bind(container: LinearLayout) {
+		container.removeAllViews()
+		val inflater = LayoutInflater.from(container.context)
+
+		for (theme in this.themes) {
+			val card = inflater.inflate(R.layout.widget_onboarding_theme_card, container, false)
+			card.findViewById<ImageView>(R.id.ivOnboardingThemeLogo)
+				.setImageResource(theme.launcher_bfb_image)
+			card.findViewById<TextView>(R.id.tvOnboardingThemeName).text = theme.name
+			card.findViewById<TextView>(R.id.tvOnboardingThemeDescription).text = theme.description
+			card.tag = theme
+
+			this.applySelection(card, theme, theme.getName() == this.selectedName())
+
+			card.setOnClickListener {
+				for (i in 0 until container.childCount) {
+					val sibling = container.getChildAt(i)
+					this.applySelection(sibling, sibling.tag as Theme, sibling === card)
+				}
+
+				this.onSelected(theme)
+			}
+
+			container.addView(card)
+		}
+	}
+
+	private fun applySelection(card: View, theme: Theme, selected: Boolean) {
+		card.isSelected = selected
+
+		val context = card.context
+		val background = card.background.mutate() as GradientDrawable
+		val strokeWidth = (2f * context.resources.displayMetrics.density).toInt()
+
+		if (selected) {
+			background.setStroke(strokeWidth, context.getColor(theme.brand_colour))
+			background.setColor(context.getColor(R.color.transparent80))
+		} else {
+			background.setStroke(strokeWidth, context.getColor(R.color.transparent))
+			background.setColor(context.getColor(R.color.transparentblack60))
+		}
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -17,6 +17,7 @@ public enum Preference {
 	CRASH_REPORTING_ENABLED("crash_reporting_enabled"),
 	THEME("theme"),
 	ICON_PACK("icon_pack"),
+	SETUP_COMPLETED("setup_completed"),
 	DEV("dev"),
 	DEV_LOG_TOASTER("dev_log_toaster");
 

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -18,6 +18,7 @@ public enum Preference {
 	THEME("theme"),
 	ICON_PACK("icon_pack"),
 	SETUP_COMPLETED("setup_completed"),
+	SETUP_STARTED("setup_started"),
 	DEV("dev"),
 	DEV_LOG_TOASTER("dev_log_toaster");
 

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -25,6 +25,7 @@ import be.robinj.distrohopper.AboutActivity;
 import be.robinj.distrohopper.BuildConfig;
 import be.robinj.distrohopper.ContributeActivity;
 import be.robinj.distrohopper.ExceptionHandler;
+import be.robinj.distrohopper.HomeRole;
 import be.robinj.distrohopper.IconPackHelper;
 import be.robinj.distrohopper.InsetsHelper;
 import be.robinj.distrohopper.R;
@@ -148,6 +149,40 @@ public class PreferencesActivity extends AppCompatActivity
 					}
 				}
 			);
+
+			this.findPreference ("dummy_set_default_launcher").setOnPreferenceClickListener (
+				new Preference.OnPreferenceClickListener ()
+				{
+					@Override
+					public boolean onPreferenceClick (Preference preference)
+					{
+						try
+						{
+							startActivity (HomeRole.requestIntent (requireContext ()));
+						}
+						catch (Exception ex)
+						{
+							new ExceptionHandler (ex).show (requireActivity ());
+						}
+
+						return true;
+					}
+				}
+			);
+		}
+
+		@Override
+		public void onResume ()
+		{
+			super.onResume ();
+
+			// Only offer to set DistroHopper as the home screen while it isn't;
+			// re-checked here in case the user just made it so //
+			final Preference setDefaultLauncher = this.findPreference ("dummy_set_default_launcher");
+			if (setDefaultLauncher != null)
+			{
+				setDefaultLauncher.setVisible (! HomeRole.isHeld (this.requireContext ()));
+			}
 		}
 
 		private void addCategory (final int titleRes, final int prefsRes)

--- a/app/src/main/java/be/robinj/distrohopper/theme/Cinnamon.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Cinnamon.java
@@ -11,7 +11,7 @@ public class Cinnamon extends Theme
 	{
 		this.name = "Cinnamon";
 		this.description = "Linux Mint's Cinnamon desktop";
-		this.brand_colour = R.color.theme_cinnamon_brand_colour;
+		this.card_colour = R.color.theme_cinnamon_card_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_cinnamon_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_cinnamon_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Cinnamon.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Cinnamon.java
@@ -11,6 +11,7 @@ public class Cinnamon extends Theme
 	{
 		this.name = "Cinnamon";
 		this.description = "Linux Mint's Cinnamon desktop";
+		this.brand_colour = R.color.theme_cinnamon_brand_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_cinnamon_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_cinnamon_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Default.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Default.java
@@ -11,7 +11,7 @@ public class Default extends Theme
 	{
 		this.name = "Ubuntu Unity";
 		this.description = "Ubuntu's Unity desktop";
-		this.brand_colour = R.color.theme_default_brand_colour;
+		this.card_colour = R.color.theme_default_card_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_default_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_default_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Default.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Default.java
@@ -11,6 +11,7 @@ public class Default extends Theme
 	{
 		this.name = "Ubuntu Unity";
 		this.description = "Ubuntu's Unity desktop";
+		this.brand_colour = R.color.theme_default_brand_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_default_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_default_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Elementary.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Elementary.java
@@ -11,6 +11,7 @@ public class Elementary extends Theme
 	{
 		this.name = "elementary OS";
 		this.description = "elementary OS's Patheon desktop";
+		this.brand_colour = R.color.theme_elementary_brand_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_elementary_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_elementary_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Elementary.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Elementary.java
@@ -11,7 +11,7 @@ public class Elementary extends Theme
 	{
 		this.name = "elementary OS";
 		this.description = "elementary OS's Patheon desktop";
-		this.brand_colour = R.color.theme_elementary_brand_colour;
+		this.card_colour = R.color.theme_elementary_card_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_elementary_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_elementary_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Gnome.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Gnome.java
@@ -11,7 +11,7 @@ public class Gnome extends Theme
 	{
 		this.name = "Gnome";
 		this.description = "Gnome Shell";
-		this.brand_colour = R.color.theme_gnome_brand_colour;
+		this.card_colour = R.color.theme_gnome_card_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_gnome_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_gnome_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Gnome.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Gnome.java
@@ -11,6 +11,7 @@ public class Gnome extends Theme
 	{
 		this.name = "Gnome";
 		this.description = "Gnome Shell";
+		this.brand_colour = R.color.theme_gnome_brand_colour;
 
 		this.wallpaper_overlay = R.drawable.theme_gnome_wallpaper_overlay;
 		this.wallpaper_overlay_when_dash_opened = R.drawable.theme_gnome_wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Theme.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Theme.java
@@ -15,7 +15,7 @@ public abstract class Theme
 	public boolean dev_only = false;
 
 	/** The distro's brand/accent colour (used by the first-run wizard's theme cards). */
-	public int brand_colour;
+	public int card_colour;
 
 	public int wallpaper_overlay;
 	public int wallpaper_overlay_when_dash_opened;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Theme.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Theme.java
@@ -14,6 +14,9 @@ public abstract class Theme
 	public String description;
 	public boolean dev_only = false;
 
+	/** The distro's brand/accent colour (used by the first-run wizard's theme cards). */
+	public int brand_colour;
+
 	public int wallpaper_overlay;
 	public int wallpaper_overlay_when_dash_opened;
 	public int dynamic_background_opacity;

--- a/app/src/main/res/drawable/onboarding_button_primary.xml
+++ b/app/src/main/res/drawable/onboarding_button_primary.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+	<item android:state_pressed="true">
+		<shape>
+			<corners android:radius="24dp" />
+			<solid android:color="@color/onboarding_accent_pressed" />
+		</shape>
+	</item>
+	<item>
+		<shape>
+			<corners android:radius="24dp" />
+			<solid android:color="@color/onboarding_accent" />
+		</shape>
+	</item>
+</selector>

--- a/app/src/main/res/drawable/onboarding_card_background.xml
+++ b/app/src/main/res/drawable/onboarding_card_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Fill and stroke are swapped programmatically when a card is (de)selected. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+	<corners android:radius="16dp" />
+	<solid android:color="@color/transparentblack60" />
+	<stroke
+		android:width="2dp"
+		android:color="@color/transparent" />
+</shape>

--- a/app/src/main/res/drawable/onboarding_scrim.xml
+++ b/app/src/main/res/drawable/onboarding_scrim.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Darkens the wallpaper behind the wizard so its text stays readable. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+	<gradient
+		android:angle="270"
+		android:startColor="@color/transparentblack40"
+		android:endColor="@color/transparentblack20" />
+</shape>

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:background="@drawable/onboarding_scrim"
+	android:orientation="vertical">
+
+	<androidx.viewpager2.widget.ViewPager2
+		android:id="@+id/vpOnboarding"
+		android:layout_width="match_parent"
+		android:layout_height="0dp"
+		android:layout_weight="1" />
+
+	<RelativeLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:padding="16dp">
+
+		<Button
+			android:id="@+id/btnOnboardingSkip"
+			style="?android:attr/borderlessButtonStyle"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_alignParentStart="true"
+			android:layout_centerVertical="true"
+			android:minWidth="88dp"
+			android:text="@string/onboarding_button_skip"
+			android:textColor="@color/transparent40" />
+
+		<be.robinj.distrohopper.onboarding.OnboardingPageIndicator
+			android:id="@+id/opiOnboardingDots"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_centerInParent="true" />
+
+		<Button
+			android:id="@+id/btnOnboardingNext"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_alignParentEnd="true"
+			android:layout_centerVertical="true"
+			android:background="@drawable/onboarding_button_primary"
+			android:minWidth="88dp"
+			android:paddingStart="24dp"
+			android:paddingEnd="24dp"
+			android:stateListAnimator="@null"
+			android:text="@string/onboarding_button_next"
+			android:textColor="@android:color/white" />
+	</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/widget_onboarding_page_default_launcher.xml
+++ b/app/src/main/res/layout/widget_onboarding_page_default_launcher.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+	<LinearLayout
+		android:id="@+id/llOnboardingPageContent"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_gravity="center"
+		android:gravity="center_horizontal"
+		android:orientation="vertical"
+		android:padding="32dp">
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:gravity="center"
+			android:text="@string/onboarding_default_launcher_title"
+			android:textColor="@android:color/white"
+			android:textSize="28sp"
+			android:textStyle="bold" />
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="12dp"
+			android:gravity="center"
+			android:lineSpacingExtra="4dp"
+			android:text="@string/onboarding_default_launcher_body"
+			android:textColor="@color/transparent30"
+			android:textSize="16sp" />
+
+		<Button
+			android:id="@+id/btnOnboardingSetDefault"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="32dp"
+			android:background="@drawable/onboarding_button_primary"
+			android:minWidth="160dp"
+			android:paddingStart="32dp"
+			android:paddingEnd="32dp"
+			android:stateListAnimator="@null"
+			android:text="@string/onboarding_button_set_default"
+			android:textColor="@android:color/white" />
+
+		<TextView
+			android:id="@+id/tvOnboardingAlreadyDefault"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="32dp"
+			android:gravity="center"
+			android:text="@string/onboarding_default_launcher_already"
+			android:textColor="@android:color/white"
+			android:textSize="16sp"
+			android:visibility="gone" />
+	</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/widget_onboarding_page_permission.xml
+++ b/app/src/main/res/layout/widget_onboarding_page_permission.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+	<LinearLayout
+		android:id="@+id/llOnboardingPageContent"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_gravity="center"
+		android:gravity="center_horizontal"
+		android:orientation="vertical"
+		android:padding="32dp">
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:gravity="center"
+			android:text="@string/onboarding_permission_title"
+			android:textColor="@android:color/white"
+			android:textSize="28sp"
+			android:textStyle="bold" />
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="12dp"
+			android:gravity="center"
+			android:lineSpacingExtra="4dp"
+			android:text="@string/onboarding_permission_body"
+			android:textColor="@color/transparent30"
+			android:textSize="16sp" />
+
+		<Button
+			android:id="@+id/btnOnboardingGrantPermission"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="32dp"
+			android:background="@drawable/onboarding_button_primary"
+			android:minWidth="160dp"
+			android:paddingStart="32dp"
+			android:paddingEnd="32dp"
+			android:stateListAnimator="@null"
+			android:text="@string/onboarding_button_grant"
+			android:textColor="@android:color/white" />
+
+		<TextView
+			android:id="@+id/tvOnboardingPermissionGranted"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="32dp"
+			android:gravity="center"
+			android:text="@string/onboarding_permission_granted"
+			android:textColor="@android:color/white"
+			android:textSize="16sp"
+			android:visibility="gone" />
+	</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/widget_onboarding_page_theme.xml
+++ b/app/src/main/res/layout/widget_onboarding_page_theme.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+	<LinearLayout
+		android:id="@+id/llOnboardingPageContent"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:orientation="vertical"
+		android:paddingStart="24dp"
+		android:paddingTop="48dp"
+		android:paddingEnd="24dp">
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:text="@string/onboarding_theme_title"
+			android:textColor="@android:color/white"
+			android:textSize="28sp"
+			android:textStyle="bold" />
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="8dp"
+			android:lineSpacingExtra="4dp"
+			android:text="@string/onboarding_theme_body"
+			android:textColor="@color/transparent30"
+			android:textSize="16sp" />
+
+		<ScrollView
+			android:layout_width="match_parent"
+			android:layout_height="0dp"
+			android:layout_marginTop="20dp"
+			android:layout_weight="1"
+			android:scrollbars="none">
+
+			<LinearLayout
+				android:id="@+id/llOnboardingThemeCards"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:orientation="vertical"
+				android:paddingBottom="16dp" />
+		</ScrollView>
+	</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/widget_onboarding_page_welcome.xml
+++ b/app/src/main/res/layout/widget_onboarding_page_welcome.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
+	<LinearLayout
+		android:id="@+id/llOnboardingPageContent"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_gravity="center"
+		android:gravity="center_horizontal"
+		android:orientation="vertical"
+		android:padding="32dp">
+
+		<ImageView
+			android:layout_width="96dp"
+			android:layout_height="96dp"
+			android:contentDescription="@string/app_name"
+			android:src="@mipmap/ic_launcher" />
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="24dp"
+			android:gravity="center"
+			android:text="@string/onboarding_welcome_title"
+			android:textColor="@android:color/white"
+			android:textSize="28sp"
+			android:textStyle="bold" />
+
+		<TextView
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="12dp"
+			android:gravity="center"
+			android:lineSpacingExtra="4dp"
+			android:text="@string/onboarding_welcome_body"
+			android:textColor="@color/transparent30"
+			android:textSize="16sp" />
+	</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/widget_onboarding_theme_card.xml
+++ b/app/src/main/res/layout/widget_onboarding_theme_card.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:layout_marginBottom="12dp"
+	android:background="@drawable/onboarding_card_background"
+	android:gravity="center_vertical"
+	android:orientation="horizontal"
+	android:padding="16dp">
+
+	<ImageView
+		android:id="@+id/ivOnboardingThemeLogo"
+		android:layout_width="48dp"
+		android:layout_height="48dp"
+		android:importantForAccessibility="no" />
+
+	<LinearLayout
+		android:layout_width="0dp"
+		android:layout_height="wrap_content"
+		android:layout_marginStart="16dp"
+		android:layout_weight="1"
+		android:orientation="vertical">
+
+		<TextView
+			android:id="@+id/tvOnboardingThemeName"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:textColor="@android:color/white"
+			android:textSize="18sp"
+			android:textStyle="bold" />
+
+		<TextView
+			android:id="@+id/tvOnboardingThemeDescription"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginTop="2dp"
+			android:textColor="@color/transparent30"
+			android:textSize="14sp" />
+	</LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,4 +20,7 @@
     <color name="transparentblack30">#B3000000</color>
     <color name="transparentblack20">#CC000000</color>
     <color name="transparentblack10">#E6000000</color>
+
+    <color name="onboarding_accent">#E95420</color>
+    <color name="onboarding_accent_pressed">#C7431B</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
     <string name="option_dev">Developer mode</string>
     <string name="hint_dev">Access debug logs and other technical information. Enabling this will negatively impact performance and stability.</string>
     <string name="option_dev_logs">Logs</string>
+    <string name="option_set_default_launcher">Set as home screen</string>
+    <string name="hint_set_default_launcher">Make DistroHopper your default home screen, so that it appears whenever you press the home button.</string>
     <string name="hm_timvdstaaij_why">* Testing (If he doesn\'t manage to wreck it then it\'s probably safe for consumption by the rest of the world.)\n
         * Help with the dominant colour calculation function.</string>
     <string name="hm_todddavies_why">* I used his ProgressWheel component, since the default (round) Android ProgressBar component can\'t actually indicate progress.\n

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,21 @@
     <string name="theme_elementary_res_panel_bfb_text">Applications</string>
 
     <string name="toast_sending_crash_report">Sending crash report...</string>
+
+    <string name="title_activity_onboarding">Welcome</string>
+    <string name="onboarding_welcome_title">Welcome to DistroHopper</string>
+    <string name="onboarding_welcome_body">Your Android home screen, with the look and feel of your favourite Linux desktop.\nSwipe to get set up.</string>
+    <string name="onboarding_theme_title">Pick your distro</string>
+    <string name="onboarding_theme_body">Which Linux desktop do you want DistroHopper to look like? You can change this at any time in the preferences.</string>
+    <string name="onboarding_permission_title">Wallpaper access</string>
+    <string name="onboarding_permission_body">DistroHopper uses your wallpaper\'s colours to tint the launcher and dash so they blend in with your home screen. Allow storage access to enable this.</string>
+    <string name="onboarding_permission_granted">✓ Wallpaper access granted</string>
+    <string name="onboarding_button_grant">Allow</string>
+    <string name="onboarding_default_launcher_title">Make it home</string>
+    <string name="onboarding_default_launcher_body">Set DistroHopper as your home screen, so that it appears whenever you press the home button.</string>
+    <string name="onboarding_default_launcher_already">✓ DistroHopper is your home screen</string>
+    <string name="onboarding_button_set_default">Set as home screen</string>
+    <string name="onboarding_button_skip">Skip</string>
+    <string name="onboarding_button_next">Next</string>
+    <string name="onboarding_button_done">Get started</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,6 +13,10 @@
         <item name="android:windowTranslucentStatus">true</item>
     </style>
 
+    <!-- Full-screen over the wallpaper, like the home screen itself. -->
+    <style name="OnboardingTheme" parent="AppTheme">
+    </style>
+
     <style name="DialogTheme" parent="Theme.AppCompat">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowShowWallpaper">true</item>

--- a/app/src/main/res/values/theme_cinnamon.xml
+++ b/app/src/main/res/values/theme_cinnamon.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="theme_cinnamon_brand_colour">#87CF3E</color>
     <drawable name="theme_cinnamon_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_cinnamon_wallpaper_overlay_when_dash_opened">@android:color/transparent</drawable>
     <integer name="theme_cinnamon_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/values/theme_cinnamon.xml
+++ b/app/src/main/res/values/theme_cinnamon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="theme_cinnamon_brand_colour">#87CF3E</color>
+    <color name="theme_cinnamon_card_colour">#87CF3E</color>
     <drawable name="theme_cinnamon_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_cinnamon_wallpaper_overlay_when_dash_opened">@android:color/transparent</drawable>
     <integer name="theme_cinnamon_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/values/theme_default.xml
+++ b/app/src/main/res/values/theme_default.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="theme_default_brand_colour">#E95420</color>
     <drawable name="theme_default_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_default_wallpaper_overlay_when_dash_opened">@android:color/transparent</drawable>
     <integer name="theme_default_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/values/theme_default.xml
+++ b/app/src/main/res/values/theme_default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="theme_default_brand_colour">#E95420</color>
+    <color name="theme_default_card_colour">#E95420</color>
     <drawable name="theme_default_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_default_wallpaper_overlay_when_dash_opened">@android:color/transparent</drawable>
     <integer name="theme_default_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/values/theme_elementary.xml
+++ b/app/src/main/res/values/theme_elementary.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="theme_elementary_brand_colour">#64BAFF</color>
     <drawable name="theme_elementary_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_elementary_wallpaper_overlay_when_dash_opened">@android:color/transparent</drawable>
     <integer name="theme_elementary_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/values/theme_elementary.xml
+++ b/app/src/main/res/values/theme_elementary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="theme_elementary_brand_colour">#64BAFF</color>
+    <color name="theme_elementary_card_colour">#64BAFF</color>
     <drawable name="theme_elementary_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_elementary_wallpaper_overlay_when_dash_opened">@android:color/transparent</drawable>
     <integer name="theme_elementary_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/values/theme_gnome.xml
+++ b/app/src/main/res/values/theme_gnome.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="theme_gnome_brand_colour">#4A86CF</color>
     <drawable name="theme_gnome_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_gnome_wallpaper_overlay_when_dash_opened">@drawable/theme_gnome_res_wallpaper_overlay_when_dash_opened</drawable>
     <integer name="theme_gnome_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/values/theme_gnome.xml
+++ b/app/src/main/res/values/theme_gnome.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="theme_gnome_brand_colour">#4A86CF</color>
+    <color name="theme_gnome_card_colour">#4A86CF</color>
     <drawable name="theme_gnome_wallpaper_overlay">@android:color/transparent</drawable>
     <drawable name="theme_gnome_wallpaper_overlay_when_dash_opened">@drawable/theme_gnome_res_wallpaper_overlay_when_dash_opened</drawable>
     <integer name="theme_gnome_dynamic_background_opacity">50</integer>

--- a/app/src/main/res/xml/pref_functionality.xml
+++ b/app/src/main/res/xml/pref_functionality.xml
@@ -20,4 +20,10 @@
         android:summary="@string/hint_widgets_enabled"
         android:defaultValue="true" />
 
+    <Preference
+        android:key="dummy_set_default_launcher"
+        android:title="@string/option_set_default_launcher"
+        android:summary="@string/hint_set_default_launcher">
+    </Preference>
+
 </PreferenceScreen>

--- a/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
+++ b/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
@@ -8,6 +8,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.ResolveInfo
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
 import kotlinx.coroutines.Dispatchers
 import org.robolectric.Robolectric
@@ -63,7 +64,9 @@ internal object ActivityTestSupport {
         listOf(Preferences.PREFERENCES, Preferences.PINNED_APPS, Preferences.LENSES).forEach {
             application.getSharedPreferences(it, 0).edit().clear().commit()
         }
+        // Fresh prefs would otherwise redirect HomeActivity to the first-run wizard //
         application.getSharedPreferences(Preferences.PREFERENCES, 0).edit()
+            .putBoolean(Preference.SETUP_COMPLETED.getName(), true)
             .also(configurePrefs).commit()
         DependencyContainer.of(ApplicationProvider.getApplicationContext()).customiseMode.value = false
         installTestDispatchers()

--- a/app/src/test/java/be/robinj/distrohopper/HomeActivityOnboardingGateTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/HomeActivityOnboardingGateTest.kt
@@ -1,0 +1,46 @@
+package be.robinj.distrohopper
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.onboarding.OnboardingActivity
+import be.robinj.distrohopper.preferences.Preferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class HomeActivityOnboardingGateTest {
+    @Before fun setUp() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        listOf(Preferences.PREFERENCES, Preferences.PINNED_APPS, Preferences.LENSES).forEach {
+            application.getSharedPreferences(it, 0).edit().clear().commit()
+        }
+    }
+
+    @Test fun firstRunRedirectsToTheWizardWithoutInitialisingTheHomeScreen() {
+        val activity = Robolectric.buildActivity(HomeActivity::class.java).create().get()
+
+        assertTrue(activity.isFinishing)
+        assertEquals(
+            OnboardingActivity::class.java.name,
+            Shadows.shadowOf(activity).nextStartedActivity.component?.className,
+        )
+    }
+
+    @Test fun completedSetupLaunchesTheHomeScreenNormally() {
+        // launchHome() seeds SETUP_COMPLETED, like any device that finished the wizard //
+        ActivityTestSupport.launchHome().use { scenario ->
+            scenario.onActivity { activity ->
+                assertEquals(false, activity.isFinishing)
+                assertTrue(activity.findViewById<android.view.View>(R.id.llLauncherAndDashContainer) != null)
+            }
+        }
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingActivityTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingActivityTest.kt
@@ -1,0 +1,147 @@
+package be.robinj.distrohopper.onboarding
+
+import android.Manifest
+import android.app.Application
+import android.widget.Button
+import android.widget.LinearLayout
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.viewpager2.widget.ViewPager2
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.R
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.Preferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class OnboardingActivityTest {
+    private lateinit var application: Application
+
+    @Before fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        application.getSharedPreferences(Preferences.PREFERENCES, 0).edit().clear().commit()
+    }
+
+    private fun launch(): ActivityScenario<OnboardingActivity> =
+        ActivityScenario.launch(OnboardingActivity::class.java)
+            .also { ShadowLooper.runUiThreadTasksIncludingDelayedTasks() }
+
+    @Test fun nextAdvancesThroughThePagesAndBackStepsBack() {
+        launch().use { scenario ->
+            scenario.onActivity { activity ->
+                // Smooth scrolls never settle under the legacy looper (the clock
+                // doesn't advance); queue them instead — currentItem updates synchronously //
+                Robolectric.getForegroundThreadScheduler().pause()
+
+                val pager = activity.findViewById<ViewPager2>(R.id.vpOnboarding)
+                val next = activity.findViewById<Button>(R.id.btnOnboardingNext)
+
+                assertEquals(0, pager.currentItem)
+                next.performClick()
+                assertEquals(1, pager.currentItem)
+
+                activity.onBackPressedDispatcher.onBackPressed()
+                assertEquals(0, pager.currentItem)
+
+                // Back on the first page must not finish the wizard //
+                activity.onBackPressedDispatcher.onBackPressed()
+                assertEquals(0, pager.currentItem)
+                assertFalse(activity.isFinishing)
+            }
+        }
+    }
+
+    @Test fun tappingAThemeCardPersistsTheThemeAndItsEdges() {
+        launch().use { scenario ->
+            scenario.onActivity { activity ->
+                val pager = activity.findViewById<ViewPager2>(R.id.vpOnboarding)
+                pager.setCurrentItem(OnboardingPage.THEME.ordinal, false)
+                ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+                val cards = activity.findViewById<LinearLayout>(R.id.llOnboardingThemeCards)
+                assertNotNull("theme page should be bound", cards)
+                cards.getChildAt(1).performClick() // Gnome //
+
+                val prefs = application.getSharedPreferences(Preferences.PREFERENCES, 0)
+                assertEquals("gnome", prefs.getString(Preference.THEME.getName(), null))
+                assertTrue(prefs.contains(Preference.LAUNCHER_EDGE.getName()))
+                assertTrue(prefs.contains(Preference.PANEL_EDGE.getName()))
+            }
+        }
+    }
+
+    @Test fun doneMarksSetupCompleteAndRelaunchesHome() {
+        launch().use { scenario ->
+            scenario.onActivity { activity ->
+                val pager = activity.findViewById<ViewPager2>(R.id.vpOnboarding)
+                val next = activity.findViewById<Button>(R.id.btnOnboardingNext)
+                pager.setCurrentItem(OnboardingPage.entries.size - 1, false)
+                ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+                assertEquals(activity.getString(R.string.onboarding_button_done), next.text)
+                next.performClick()
+
+                assertTrue(
+                    application.getSharedPreferences(Preferences.PREFERENCES, 0)
+                        .getBoolean(Preference.SETUP_COMPLETED.getName(), false)
+                )
+                assertEquals(
+                    HomeActivity::class.java.name,
+                    Shadows.shadowOf(activity).nextStartedActivity.component?.className,
+                )
+                assertTrue(activity.isFinishing)
+            }
+        }
+    }
+
+    @Test fun skipMarksSetupCompleteAndRelaunchesHome() {
+        launch().use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<Button>(R.id.btnOnboardingSkip).performClick()
+
+                assertTrue(
+                    application.getSharedPreferences(Preferences.PREFERENCES, 0)
+                        .getBoolean(Preference.SETUP_COMPLETED.getName(), false)
+                )
+                assertEquals(
+                    HomeActivity::class.java.name,
+                    Shadows.shadowOf(activity).nextStartedActivity.component?.className,
+                )
+                assertTrue(activity.isFinishing)
+            }
+        }
+    }
+
+    @Test fun permissionPageShowsGrantedStateWhenAlreadyGranted() {
+        Shadows.shadowOf(application).grantPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
+
+        launch().use { scenario ->
+            scenario.onActivity { activity ->
+                val pager = activity.findViewById<ViewPager2>(R.id.vpOnboarding)
+                pager.setCurrentItem(OnboardingPage.PERMISSION.ordinal, false)
+                ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+                assertEquals(
+                    android.view.View.VISIBLE,
+                    activity.findViewById<android.view.View>(R.id.tvOnboardingPermissionGranted).visibility,
+                )
+                assertEquals(
+                    android.view.View.GONE,
+                    activity.findViewById<android.view.View>(R.id.btnOnboardingGrantPermission).visibility,
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingActivityTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingActivityTest.kt
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
 import org.robolectric.shadows.ShadowLooper
 
@@ -87,7 +88,7 @@ class OnboardingActivityTest {
             scenario.onActivity { activity ->
                 val pager = activity.findViewById<ViewPager2>(R.id.vpOnboarding)
                 val next = activity.findViewById<Button>(R.id.btnOnboardingNext)
-                pager.setCurrentItem(OnboardingPage.entries.size - 1, false)
+                pager.setCurrentItem(pager.adapter!!.itemCount - 1, false)
                 ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
                 assertEquals(activity.getString(R.string.onboarding_button_done), next.text)
@@ -124,12 +125,15 @@ class OnboardingActivityTest {
         }
     }
 
+    // READ_EXTERNAL_STORAGE is only grantable below Android 13 //
+    @Config(sdk = [32])
     @Test fun permissionPageShowsGrantedStateWhenAlreadyGranted() {
         Shadows.shadowOf(application).grantPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
 
         launch().use { scenario ->
             scenario.onActivity { activity ->
                 val pager = activity.findViewById<ViewPager2>(R.id.vpOnboarding)
+                assertEquals(OnboardingPage.entries.size, pager.adapter!!.itemCount)
                 pager.setCurrentItem(OnboardingPage.PERMISSION.ordinal, false)
                 ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
@@ -142,6 +146,27 @@ class OnboardingActivityTest {
                     activity.findViewById<android.view.View>(R.id.btnOnboardingGrantPermission).visibility,
                 )
             }
+        }
+    }
+
+    // robolectric.properties pins tests to SDK 36, where the wallpaper
+    // permission cannot be granted: the page asking for it must not appear //
+    @Test fun permissionPageIsOmittedWhereThePermissionIsUngrantable() {
+        launch().use { scenario ->
+            scenario.onActivity { activity ->
+                val pager = activity.findViewById<ViewPager2>(R.id.vpOnboarding)
+
+                assertEquals(OnboardingPage.entries.size - 1, pager.adapter!!.itemCount)
+            }
+        }
+    }
+
+    @Test fun launchingTheWizardRecordsThatItStarted() {
+        launch().use {
+            assertTrue(
+                application.getSharedPreferences(Preferences.PREFERENCES, 0)
+                    .getBoolean(Preference.SETUP_STARTED.getName(), false)
+            )
         }
     }
 }

--- a/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingGateTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingGateTest.kt
@@ -1,0 +1,44 @@
+package be.robinj.distrohopper.onboarding
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.Preferences
+import be.robinj.distrohopper.preferences.PreferencesRepository
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OnboardingGateTest {
+    private lateinit var application: Application
+    private lateinit var prefs: PreferencesRepository
+
+    @Before fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        application.getSharedPreferences(Preferences.PREFERENCES, 0).edit().clear().commit()
+        prefs = PreferencesRepository(application)
+    }
+
+    @Test fun shownOnFreshInstall() {
+        assertTrue(OnboardingGate.shouldShow(prefs))
+    }
+
+    @Test fun notShownOnceCompleted() {
+        OnboardingGate.markCompleted(prefs)
+
+        assertFalse(OnboardingGate.shouldShow(prefs))
+    }
+
+    @Test fun existingUsersWithAThemeAreGrandfatheredIn() {
+        application.getSharedPreferences(Preferences.PREFERENCES, 0).edit()
+            .putString(Preference.THEME.getName(), "gnome").commit()
+
+        assertFalse(OnboardingGate.shouldShow(prefs))
+        // ... and the flag is backfilled so the theme heuristic is only needed once //
+        assertTrue(prefs.getBoolean(Preference.SETUP_COMPLETED, false))
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingGateTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingGateTest.kt
@@ -41,4 +41,14 @@ class OnboardingGateTest {
         // ... and the flag is backfilled so the theme heuristic is only needed once //
         assertTrue(prefs.getBoolean(Preference.SETUP_COMPLETED, false))
     }
+
+    @Test fun aThemeChosenInAnInterruptedWizardRunIsNotGrandfathered() {
+        // As when the app is killed after the wizard's theme page but before Done/Skip //
+        OnboardingGate.markStarted(prefs)
+        application.getSharedPreferences(Preferences.PREFERENCES, 0).edit()
+            .putString(Preference.THEME.getName(), "gnome").commit()
+
+        assertTrue(OnboardingGate.shouldShow(prefs))
+        assertFalse(prefs.getBoolean(Preference.SETUP_COMPLETED, false))
+    }
 }

--- a/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingThemeCardsTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingThemeCardsTest.kt
@@ -1,0 +1,47 @@
+package be.robinj.distrohopper.onboarding
+
+import android.app.Application
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.R
+import be.robinj.distrohopper.theme.Default
+import be.robinj.distrohopper.theme.Gnome
+import be.robinj.distrohopper.theme.Theme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OnboardingThemeCardsTest {
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+    private val themes = listOf<Theme>(Default(), Gnome())
+
+    @Test fun bindsOneCardPerThemeAndPreselectsThePersistedOne() {
+        val container = LinearLayout(application)
+        OnboardingThemeCards(themes, { "gnome" }, {}).bind(container)
+
+        assertEquals(2, container.childCount)
+        assertFalse(container.getChildAt(0).isSelected)
+        assertTrue(container.getChildAt(1).isSelected)
+        assertEquals(
+            "Ubuntu Unity",
+            container.getChildAt(0).findViewById<TextView>(R.id.tvOnboardingThemeName).text,
+        )
+    }
+
+    @Test fun tappingACardSelectsItAndReportsTheTheme() {
+        var selected: Theme? = null
+        val container = LinearLayout(application)
+        OnboardingThemeCards(themes, { "default" }, { selected = it }).bind(container)
+
+        container.getChildAt(1).performClick()
+
+        assertEquals("gnome", selected?.getName())
+        assertFalse(container.getChildAt(0).isSelected)
+        assertTrue(container.getChildAt(1).isSelected)
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/preferences/PreferencesDefaultLauncherOptionTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/PreferencesDefaultLauncherOptionTest.kt
@@ -1,0 +1,44 @@
+package be.robinj.distrohopper.preferences
+
+import android.app.Application
+import android.app.role.RoleManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.R
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowRoleManager
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class PreferencesDefaultLauncherOptionTest {
+    private fun preference(activity: PreferencesActivity): androidx.preference.Preference =
+        (activity.supportFragmentManager.findFragmentById(R.id.preferences_container)
+            as PreferencesActivity.PreferencesFragment)
+            .findPreference("dummy_set_default_launcher")!!
+
+    @Test fun shownWhileNotTheDefaultLauncher() {
+        ActivityScenario.launch(PreferencesActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                assertTrue(preference(activity).isVisible)
+            }
+        }
+    }
+
+    @Test fun hiddenOnceTheHomeRoleIsHeld() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val roleManager = application.getSystemService(RoleManager::class.java)
+        Shadow.extract<ShadowRoleManager>(roleManager).addHeldRole(RoleManager.ROLE_HOME)
+
+        ActivityScenario.launch(PreferencesActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                assertFalse(preference(activity).isVisible)
+            }
+        }
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetsContainerHomeTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetsContainerHomeTest.kt
@@ -33,7 +33,10 @@ class WidgetsContainerHomeTest {
             application.getSharedPreferences(it, 0).edit().clear().commit()
         }
         application.getSharedPreferences(Preferences.PREFERENCES, 0)
-            .edit().putBoolean(Preference.WIDGETS_ENABLED.getName(), false).commit()
+            .edit()
+            .putBoolean(Preference.WIDGETS_ENABLED.getName(), false)
+            .putBoolean(Preference.SETUP_COMPLETED.getName(), true)
+            .commit()
         DependencyContainer.of(ApplicationProvider.getApplicationContext()).customiseMode.value = false
         ActivityTestSupport.installTestDispatchers()
         ActivityTestSupport.seedPackageManager()


### PR DESCRIPTION
A full-screen, swipeable onboarding pager (ViewPager2) shown once on
first launch, over the wallpaper like the home screen itself:

- Welcome page, theme choice, permission prompts, and set-as-default-home
  (via RoleManager.ROLE_HOME, with an ACTION_HOME_SETTINGS fallback).
- Theme cards reuse each theme's BFB logo and a new brand_colour theme
  field for the selected-card accent; tapping a card persists the same
  THEME/LAUNCHER_EDGE/PANEL_EDGE prefs the theme picker writes.
- HomeActivity redirects to the wizard before initialising anything,
  gated by a new SETUP_COMPLETED preference; Done/Skip relaunch
  HomeActivity so the chosen theme applies through the usual recreate.
  Users who already have a theme preference never see the wizard.
- Animated dot indicator and fade+parallax page transformer, no new
  libraries beyond androidx.viewpager2.

https://claude.ai/code/session_013mjXp9YuMtANaPFAJk8fGW