### PR TITLE
Add internal DistroHopper Settings shortcut and hide public launcher entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ etc/                                        — design assets (SVG/XCF sources, 
     `home/LauncherBarBinder` (resolved lazily so AppManager can be
     constructed on a background thread). Prefer `AppRepository` directly
     in new model-level code.
-  - `App`, `Application`, `AppComparatorAlphabetical` — app model classes.
+  - `App`, `Application`, `AppComparatorAlphabetical` — app model classes. `App` usually wraps a PackageManager `ResolveInfo`, but can also represent DistroHopper-owned internal shortcuts that live only in the dash (currently the settings shortcut) and launch by explicit in-app intent rather than a public launcher component.
   - `IconPackHelper`, `Image`, `Utils`, `ViewFinder`, `InsetsHelper`,
     `Permission`, `RequestCode`, `ExceptionHandler`, `HomeRole` —
     support/utilities. `HomeRole` wraps the HOME-role (default launcher)

--- a/app/src/main/java/be/robinj/distrohopper/App.java
+++ b/app/src/main/java/be/robinj/distrohopper/App.java
@@ -16,6 +16,7 @@ import be.robinj.distrohopper.cache.ICache;
 import be.robinj.distrohopper.desktop.AppIcon;
 import be.robinj.distrohopper.desktop.dash.AppLauncher;
 import be.robinj.distrohopper.dev.Log;
+import be.robinj.distrohopper.preferences.PreferencesActivity;
 
 import static java.lang.String.format;
 
@@ -32,8 +33,15 @@ public class App implements Parcelable
 	private String activityName;
 
 	private transient ResolveInfo resInf = null;
+	// Normal apps are resolved from PackageManager and launch via ACTION_MAIN.
+	// Internal DistroHopper-only shortcuts (for example Settings) are not public
+	// launcher components, so they carry an explicit intent instead.
+	private transient Intent launchIntent = null;
 	private boolean labelLoaded = false;
 	private boolean iconLoaded = false;
+	// Customise mode blocks launching external apps while the user is editing the
+	// launcher, but Settings must stay reachable so users can leave/fix that mode.
+	private boolean launchAllowedInCustomiseMode = false;
 
 	private transient Context context;
 	private transient AppManager appManager;
@@ -64,6 +72,35 @@ public class App implements Parcelable
 		}
 	}
 
+	private App (Context context, AppManager appManager, String packageName, String activityName,
+					 String label, AppIcon icon, Intent launchIntent, boolean launchAllowedInCustomiseMode)
+	{
+		this.context = context;
+		this.appManager = appManager;
+		this.packageName = packageName;
+		this.activityName = activityName;
+		this.label = label;
+		this.icon = icon;
+		this.launchIntent = launchIntent;
+		this.launchAllowedInCustomiseMode = launchAllowedInCustomiseMode;
+		this.labelLoaded = label != null;
+		this.iconLoaded = icon != null;
+	}
+
+	/**
+	 * Creates the DistroHopper Settings entry shown inside DistroHopper's own
+	 * dash. This is deliberately not a manifest LAUNCHER activity/alias: other
+	 * launchers should still only see DistroHopper itself.
+	 */
+	public static App settingsShortcut (Context context, AppManager appManager)
+	{
+		final Intent launchIntent = new Intent (context, PreferencesActivity.class);
+		launchIntent.setFlags (Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+
+		return new App (context, appManager, context.getPackageName (), PreferencesActivity.class.getName (),
+				context.getString (R.string.shortcut_label_distrohopper_settings), null, launchIntent, true);
+	}
+
 	private App (Parcel parcel)
 	{
 		this.activityName = parcel.readString ();
@@ -74,18 +111,26 @@ public class App implements Parcelable
 
 	public void launch ()
 	{
-		if (DependencyContainer.of (this.context).getCustomiseMode ().getValue ()) {
+		if ((! this.launchAllowedInCustomiseMode) && DependencyContainer.of (this.context).getCustomiseMode ().getValue ()) {
 			Toast.makeText(this.context, "App launching disabled while customising UI.", Toast.LENGTH_SHORT).show(); //TODO// getString () //
 
 			return;
 		}
 
 		try {
-			final ComponentName compName = new ComponentName(this.packageName, this.activityName);
-			final Intent intent = new Intent(Intent.ACTION_MAIN);
-			intent.addCategory(Intent.CATEGORY_LAUNCHER);
-			intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
-			intent.setComponent(compName);
+			final Intent intent;
+			// Internal shortcuts use their explicit in-app intent. PackageManager apps
+			// keep the Android launcher intent shape expected by external activities.
+			if (this.launchIntent != null) {
+				intent = new Intent (this.launchIntent);
+			}
+			else {
+				final ComponentName compName = new ComponentName(this.packageName, this.activityName);
+				intent = new Intent(Intent.ACTION_MAIN);
+				intent.addCategory(Intent.CATEGORY_LAUNCHER);
+				intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+				intent.setComponent(compName);
+			}
 
 			this.context.startActivity(intent);
 		} catch (final Exception ex) {
@@ -121,8 +166,10 @@ public class App implements Parcelable
 
 	public String getLabel(final boolean useCached) {
 		if (this.label == null || (!this.labelLoaded && !useCached)) {
-			this.label = this.resInf.activityInfo.loadLabel(this.getPackageManager()).toString();
-			this.labelLoaded = true;
+			if (this.resInf != null) {
+				this.label = this.resInf.activityInfo.loadLabel(this.getPackageManager()).toString();
+				this.labelLoaded = true;
+			}
 		}
 
 		return this.label;
@@ -159,7 +206,7 @@ public class App implements Parcelable
 				icon = this.appManager.getIconPack().getIconForApp(this);
 			}
 			if (icon == null) {
-				icon = this.appManager.getIconPack().getFallbackIcon(this.resInf.loadIcon(this.getPackageManager()));
+				icon = this.appManager.getIconPack().getFallbackIcon(this.loadFallbackIcon());
 			}
 
 			this.icon = icon;
@@ -167,6 +214,18 @@ public class App implements Parcelable
 		}
 
 		return this.icon;
+	}
+
+	private Drawable loadFallbackIcon ()
+	{
+		if (this.resInf != null) {
+			return this.resInf.loadIcon(this.getPackageManager());
+		}
+
+		// Internal shortcuts are not backed by PackageManager ResolveInfo; use
+		// DistroHopper's own icon so the Settings shortcut has the same icon as
+		// the app entry it replaces.
+		return this.context.getApplicationInfo ().loadIcon (this.getPackageManager ());
 	}
 
 	public boolean setIcon(final AppIcon icon, final ICache<Drawable> appIconCache) {

--- a/app/src/main/java/be/robinj/distrohopper/broadcast/PackageManagerBroadcastReceiver.java
+++ b/app/src/main/java/be/robinj/distrohopper/broadcast/PackageManagerBroadcastReceiver.java
@@ -46,10 +46,15 @@ public class PackageManagerBroadcastReceiver extends BroadcastReceiver
 					{
 						friendlyAction = "added";
 
-						for (ResolveInfo resInf : appManager.queryInstalledApps (packageName))
+						// DistroHopper's own package is represented by the internal Settings
+						// shortcut, not by its public HomeActivity launcher entry.
+						if (! packageName.equals (context.getPackageName ()))
 						{
-							final App app = new App(context, appManager, resInf);
-							appManager.add (app, true, true);
+							for (ResolveInfo resInf : appManager.queryInstalledApps (packageName))
+							{
+								final App app = new App(context, appManager, resInf);
+								appManager.add (app, true, true);
+							}
 						}
 					}
 					else if (action.equals (res.getString (R.string.intent_action_package_removed)))

--- a/app/src/main/java/be/robinj/distrohopper/home/AppsLoader.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/AppsLoader.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.ensureActive
  * checkpoints the AsyncTasks had.
  */
 object AppsLoader {
-	private val IGNORE = arrayOf("be.robinj.distrohopper", "be.robinj.ubuntu") // Inception //
+	private val IGNORE = arrayOf("be.robinj.ubuntu") // Legacy package name //
 
 	suspend fun loadApps(
 		parent: HomeActivity,
@@ -53,6 +53,11 @@ object AppsLoader {
 		for (resInf in resInfs) {
 			if (IGNORE.contains(resInf.activityInfo.packageName))
 				continue
+			// Hide DistroHopper's public HomeActivity launcher entry. A private
+			// Settings shortcut is added below so settings stay reachable from the dash
+			// without exposing a second icon to other launchers.
+			if (resInf.activityInfo.packageName == context.packageName)
+				continue
 
 			// One broken package (corrupt icon, vanished mid-query, ...) must not
 			// abort the load: the launcher used to come up with a partial list //
@@ -63,6 +68,10 @@ object AppsLoader {
 				ExceptionHandler(ex).logAndTrack()
 			}
 		}
+
+		// The shortcut is part of DistroHopper's model only; it is not returned by
+		// PackageManager and therefore cannot show up in other launchers.
+		appManager.add(App.settingsShortcut(context, appManager), false, false)
 
 		val tDoneRetrievingInstalledApps = System.currentTimeMillis()
 		Log.getInstance().v(this.javaClass.simpleName, "Retrieved " + size

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="dash_lens_apps_title">Applications</string>
     <string name="dash_lens_other_title">Other</string>
     <string name="title_activity_preferences">Preferences</string>
+    <string name="shortcut_label_distrohopper_settings">DistroHopper Settings</string>
     <string name="title_activity_about">About</string>
     <string name="title_activity_lens_preferences">Search sources</string>
     <string name="title_activity_theme_preferences">Themes</string>

--- a/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
+++ b/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
@@ -31,7 +31,16 @@ internal object ActivityTestSupport {
         val packageManager = Shadows.shadowOf(application.packageManager)
         val launcherIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
 
-        packages.forEach { (packageName, activityName, label) ->
+        // Include DistroHopper's real launcher entry so tests exercise the
+        // production replacement path: AppsLoader must hide this entry and add
+        // the internal Settings shortcut instead.
+        val launcherApps = packages + Triple(
+            application.packageName,
+            HomeActivity::class.java.name,
+            application.getString(R.string.app_name),
+        )
+
+        launcherApps.forEach { (packageName, activityName, label) ->
             val resolveInfo = resolveInfo(packageName, activityName, label)
             packageManager.addResolveInfoForIntent(launcherIntent, resolveInfo)
             packageManager.addResolveInfoForIntent(

--- a/app/src/test/java/be/robinj/distrohopper/AppManagerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/AppManagerTest.kt
@@ -1,7 +1,9 @@
 package be.robinj.distrohopper
 
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.PreferencesActivity
 import be.robinj.distrohopper.preferences.Preferences
 import org.junit.After
 import org.junit.Assert.*
@@ -23,6 +25,10 @@ class AppManagerTest {
         scenario.onActivity { block(it.appManager) }
     }
     private fun AppManager.unpinned() = firstOrNull { !isPinned(it) }
+    private fun AppManager.settingsShortcut() = requireNotNull(findAppByPackageAndActivityName(
+        ApplicationProvider.getApplicationContext<android.app.Application>().packageName,
+        PreferencesActivity::class.java.name,
+    ))
 
     @Test fun everyAppHasNonEmptyPackageName() = withManager { manager ->
         manager.forEach { assertTrue(it.packageName.isNotEmpty()) }
@@ -79,8 +85,20 @@ class AppManagerTest {
 
     @Test fun searchWithMaxResultsLimitsOutput() = withManager { assertTrue(it.search("a", 2).size <= 2) }
 
+    @Test fun searchFindsSettingsShortcutByPrefix() = withManager { manager ->
+        assertEquals(listOf(manager.settingsShortcut()), manager.search("DistroHopper"))
+    }
+
     @Test fun fullSearchFindsInfixMatches() = withManager { manager ->
-        assertEquals(listOf("Settings"), manager.search("ting").map(App::getLabel))
+        assertEquals(listOf("DistroHopper Settings", "Settings"), manager.search("ting").map(App::getLabel))
+    }
+
+    @Test fun distroHopperSettingsShortcutReplacesOwnLauncherApp() = withManager { manager ->
+        val packageName = ApplicationProvider.getApplicationContext<android.app.Application>().packageName
+
+        assertNull(manager.findAppByPackageAndActivityName(packageName, HomeActivity::class.java.name))
+        assertNotNull(manager.findAppByPackageAndActivityName(packageName, PreferencesActivity::class.java.name))
+        assertTrue(manager.installedApps.any { it.label == "DistroHopper Settings" })
     }
 
     @Test fun prefixOnlySearchRejectsInfixMatches() {
@@ -109,6 +127,21 @@ class AppManagerTest {
         assertEquals(listOf(second, first), it.pinned)
     }
 
+    @Test fun settingsShortcutCanBePinnedMovedAndPersisted() = withManager { manager ->
+        val alpha = manager.findAppsByPackageName("com.example.alpha").first()
+        val settings = manager.settingsShortcut()
+
+        manager.pin(alpha, false, false, false)
+        manager.pin(settings, false, false, false)
+        manager.movePinnedApp(1, 0)
+        manager.savePinnedApps()
+
+        assertEquals(listOf(settings, alpha), manager.pinned)
+        val pinnedPrefs = Preferences.getSharedPreferences(manager.context, Preferences.PINNED_APPS)
+        assertEquals(settings.packageAndActivityName, pinnedPrefs.getString("0", null))
+        assertEquals(alpha.packageAndActivityName, pinnedPrefs.getString("1", null))
+    }
+
     @Test fun findAppByPackageAndActivityNameReturnsCorrectApp() = withManager {
         val expected = it[0]; assertEquals(expected, it.findAppByPackageAndActivityName(expected.packageName, expected.activityName))
     }
@@ -123,6 +156,11 @@ class AppManagerTest {
 
     @Test fun installedAppsMapUsesCombinedIdentity() = withManager {
         assertEquals(it.size(), it.installedAppsMap.size); assertSame(it[0], it.installedAppsMap[it[0].packageAndActivityName])
+    }
+
+    @Test fun installedAppsMapIncludesSettingsShortcutIdentity() = withManager { manager ->
+        val settings = manager.settingsShortcut()
+        assertSame(settings, manager.installedAppsMap[settings.packageAndActivityName])
     }
 
     @Test fun packageQueryCanBeFiltered() = withManager {

--- a/app/src/test/java/be/robinj/distrohopper/AppTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/AppTest.kt
@@ -5,6 +5,7 @@ import android.os.Parcel
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import be.robinj.distrohopper.cache.TestStringCache
+import be.robinj.distrohopper.preferences.PreferencesActivity
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -39,6 +40,40 @@ class AppTest {
             while (shadow.nextStartedActivity != null) { }
             DependencyContainer.of(ApplicationProvider.getApplicationContext()).customiseMode.value = true; activity.appManager[0].launch()
             assertNull(shadow.nextStartedActivity)
+        }
+    }
+
+    @Test fun settingsShortcutLaunchesPreferencesDirectly() {
+        scenario.onActivity { activity ->
+            val app = requireNotNull(activity.appManager.findAppByPackageAndActivityName(
+                activity.packageName,
+                PreferencesActivity::class.java.name,
+            ))
+
+            app.launch()
+
+            val intent = Shadows.shadowOf(activity).nextStartedActivity
+            assertNull(intent.action)
+            assertTrue(intent.categories == null || intent.categories.isEmpty())
+            assertEquals(activity.packageName, intent.component?.packageName)
+            assertEquals(PreferencesActivity::class.java.name, intent.component?.className)
+        }
+    }
+
+    @Test fun settingsShortcutLaunchesWhileCustomising() {
+        scenario.onActivity { activity ->
+            val app = requireNotNull(activity.appManager.findAppByPackageAndActivityName(
+                activity.packageName,
+                PreferencesActivity::class.java.name,
+            ))
+            DependencyContainer.of(ApplicationProvider.getApplicationContext()).customiseMode.value = true
+
+            app.launch()
+
+            assertEquals(
+                PreferencesActivity::class.java.name,
+                Shadows.shadowOf(activity).nextStartedActivity.component?.className,
+            )
         }
     }
 

--- a/app/src/test/java/be/robinj/distrohopper/home/AppsLoaderTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/AppsLoaderTest.kt
@@ -9,12 +9,14 @@ import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.cache.ICache
 import be.robinj.distrohopper.cache.TestDrawableCache
 import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.PreferencesActivity
 import be.robinj.distrohopper.preferences.Preferences
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -107,6 +109,31 @@ class AppsLoaderTest {
 		assertEquals("com.android.camera2\nCameraActivity", pinned.getString("3", null))
 		assertFalse(Preferences.getSharedPreferences(this.application)
 			.getBoolean(Preference.DEFAULT_PINS_PENDING.getName(), false))
+	}
+
+	@Test fun pinnedSettingsShortcutIsRestoredFromPreferences() {
+		val settingsIdentity = "${this.application.packageName}\n${PreferencesActivity::class.java.name}"
+		Preferences.getSharedPreferences(this.application, Preferences.PINNED_APPS).edit()
+			.putString("0", settingsIdentity)
+			.commit()
+
+		this.scenario.onActivity { activity ->
+			val appManager = runBlocking {
+				AppsLoader.loadApps(
+					activity,
+					activity.applicationContext,
+					HashLabelCache(),
+					TestDrawableCache(activity, "apps_loader_settings_pin_icons"),
+				) { _, _ -> }
+			}
+			val settings = appManager.findAppByPackageAndActivityName(
+				activity.packageName,
+				PreferencesActivity::class.java.name,
+			)
+
+			assertEquals(listOf("DistroHopper Settings"), appManager.pinned.map { it.label })
+			assertSame(settings, appManager.pinned.single())
+		}
 	}
 
 	@Test fun defaultAttemptIsConsumedWhenNothingMatches() {

--- a/app/src/test/java/be/robinj/distrohopper/home/LauncherBarBinderReorderTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/LauncherBarBinderReorderTest.kt
@@ -8,6 +8,7 @@ import be.robinj.distrohopper.App
 import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.R
 import be.robinj.distrohopper.desktop.launcher.AppLauncher
+import be.robinj.distrohopper.preferences.PreferencesActivity
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -41,6 +42,12 @@ class LauncherBarBinderReorderTest {
 
     private fun pinnedContainer(activity: HomeActivity): LinearLayout =
         activity.findViewById(R.id.llLauncherPinnedApps)
+
+    private fun settingsShortcut(activity: HomeActivity): App =
+        activity.appManager.findAppByPackageAndActivityName(
+            activity.packageName,
+            PreferencesActivity::class.java.name,
+        )
 
     private fun viewOrder(activity: HomeActivity): List<App> {
         val container = pinnedContainer(activity)
@@ -142,6 +149,23 @@ class LauncherBarBinderReorderTest {
             val placeholder = pinnedContainer(activity).findViewWithTag<AppLauncher>(zeta)
             assertEquals(View.INVISIBLE, placeholder.visibility)
             assertEquals(listOf(alpha, beta, gamma), activity.appManager.pinned)
+        }
+    }
+
+    @Test fun droppingSettingsShortcutFromDashPinsItAtThePreviewedSlot() {
+        scenario.onActivity { activity ->
+            val (alpha, beta, gamma) = pinThree(activity)
+            val settings = settingsShortcut(activity)
+
+            activity.appManager.startedDraggingDashApp(settings)
+            activity.appManager.draggedPinnedAppOver(beta)
+            activity.appManager.droppedPinnedApp()
+            activity.appManager.endedDraggingPinnedApp()
+
+            assertEquals(listOf(alpha, settings, beta, gamma), activity.appManager.pinned)
+            assertEquals(listOf(alpha, settings, beta, gamma), viewOrder(activity))
+            assertEquals(View.VISIBLE,
+                pinnedContainer(activity).findViewWithTag<AppLauncher>(settings).visibility)
         }
     }
 

--- a/app/src/test/java/be/robinj/distrohopper/home/LauncherBarBinderTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/LauncherBarBinderTest.kt
@@ -12,6 +12,7 @@ import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.R
 import be.robinj.distrohopper.desktop.launcher.AppLauncher
 import be.robinj.distrohopper.desktop.launcher.RunningAppLauncher
+import be.robinj.distrohopper.preferences.PreferencesActivity
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -34,6 +35,12 @@ class LauncherBarBinderTest {
 
 	private fun app(activity: HomeActivity, packageName: String): App =
 		activity.appManager.findAppsByPackageName(packageName).first()
+
+	private fun settingsShortcut(activity: HomeActivity): App =
+		activity.appManager.findAppByPackageAndActivityName(
+			activity.packageName,
+			PreferencesActivity::class.java.name,
+		)
 
 	private fun pinnedContainer(activity: HomeActivity): LinearLayout =
 		activity.findViewById(R.id.llLauncherPinnedApps)
@@ -60,6 +67,22 @@ class LauncherBarBinderTest {
 			binder.removePinnedAppView(app)
 			assertEquals(0, container.childCount)
 			assertNull(container.findViewWithTag<AppLauncher>(app))
+		}
+	}
+
+	@Test fun addAndRemoveSettingsShortcutViewRoundTripThroughTheViewTag() {
+		scenario.onActivity { activity ->
+			val binder = LauncherBarBinder(activity.appManager)
+			val settings = settingsShortcut(activity)
+			val container = pinnedContainer(activity)
+
+			binder.addPinnedAppView(settings)
+			assertEquals(1, container.childCount)
+			assertNotNull(container.findViewWithTag<AppLauncher>(settings))
+
+			binder.removePinnedAppView(settings)
+			assertEquals(0, container.childCount)
+			assertNull(container.findViewWithTag<AppLauncher>(settings))
 		}
 	}
 


### PR DESCRIPTION
### Motivation

- Prevent DistroHopper from exposing a second public launcher icon while keeping an in-launcher Settings shortcut reachable. 
- Ensure the Settings shortcut can be launched even while the user is in customise/edit mode. 
- Avoid adding the app's own public `HomeActivity` entry to the internal app model so other launchers don't see a duplicate icon.

### Description

- Add support for internal-only shortcuts to `App` by introducing a `launchIntent`, `launchAllowedInCustomiseMode`, a `settingsShortcut` factory method, and a private `loadFallbackIcon()` for non-`ResolveInfo` entries. 
- Update `App.launch()` to use the explicit `launchIntent` for internal shortcuts and to respect `launchAllowedInCustomiseMode`. 
- Change `AppsLoader` to skip the package matching `context.packageName` when enumerating `ResolveInfo` results and to add the `App.settingsShortcut()` to the model instead. 
- Update `PackageManagerBroadcastReceiver` to avoid adding the app's own package when packages are added. 
- Add string resource `shortcut_label_distrohopper_settings` and wire in `PreferencesActivity`; update test helpers and many Robolectric unit tests to exercise and assert the new shortcut behaviour and persistence.

### Testing

- Ran the unit test suite (Robolectric-based tests) including `AppTest`, `AppManagerTest`, `AppsLoaderTest`, `LauncherBarBinderTest`, and `LauncherBarBinderReorderTest` after changes. 
- All updated and newly added unit tests passed. 
- No automated integration/device tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c597678d08322b0284933f33523d8)