### PR TITLE
Make GNOME launcher background slightly more transparent when dash opens

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
@@ -17,6 +17,7 @@ import be.robinj.distrohopper.ViewFinder
 import be.robinj.distrohopper.desktop.Wallpaper
 import be.robinj.distrohopper.preferences.Preferences
 import be.robinj.distrohopper.preferences.PreferencesRepository
+import be.robinj.distrohopper.theme.Gnome
 import be.robinj.distrohopper.theme.Theme
 import java.util.function.Consumer
 
@@ -37,6 +38,10 @@ class DashController(
 	private val theme: Theme,
 	private val prefs: PreferencesRepository,
 ) {
+	private companion object {
+		private const val GNOME_LAUNCHER_BACKGROUND_DASH_OPEN_ALPHA = 210
+	}
+
 	var isOpen: Boolean = false
 		private set
 
@@ -225,6 +230,8 @@ class DashController(
 			this.panelFade.animateTo(dashOpened = true, duration)
 			this.statusBarFade.animateTo(dashOpened = true, duration)
 		}
+
+		this.applyLauncherBackgroundDashOpenedAlpha()
 	}
 
 	/** Hides the dash and restores the overlays once a close has settled. */
@@ -258,8 +265,32 @@ class DashController(
 			this.statusBarFade.animateTo(dashOpened = false, duration)
 		}
 
+		this.restoreLauncherBackgroundAlpha()
+
 		val imm = this.activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
 		imm?.hideSoftInputFromWindow(
 			this.activity.window.decorView.rootView.windowToken, 0)
+	}
+
+	private fun applyLauncherBackgroundDashOpenedAlpha() {
+		if (this.theme !is Gnome) {
+			return
+		}
+
+		this.viewFinder.get<LinearLayout>(R.id.llLauncher)
+			.background
+			?.mutate()
+			?.alpha = GNOME_LAUNCHER_BACKGROUND_DASH_OPEN_ALPHA
+	}
+
+	private fun restoreLauncherBackgroundAlpha() {
+		if (this.theme !is Gnome) {
+			return
+		}
+
+		this.viewFinder.get<LinearLayout>(R.id.llLauncher)
+			.background
+			?.mutate()
+			?.alpha = 255
 	}
 }


### PR DESCRIPTION
### Motivation

- Make the GNOME-style launcher/dock subtly more transparent while the dash is open so the dash visual feels integrated with the GNOME look-and-feel, and verify that `AGENTS.md`'s guidance remains accurate (no doc change required).

### Description

- Added a GNOME-only alpha constant and logic in `app/src/main/java/be/robinj/distrohopper/home/DashController.kt` to reduce the launcher background alpha when the dash opens and restore it when the dash closes.
- The change is guarded by a theme check (`this.theme is Gnome`) so other themes are unaffected, and it mutates the `llLauncher` background alpha (uses `mutate()` to avoid shared drawable state).

### Testing

- Attempted to run unit tests with `./gradlew testDebugUnitTest`, but the run was blocked due to the environment lacking an Android SDK configuration (`ANDROID_HOME` / `local.properties` `sdk.dir` not set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d4dd4c6988322878f0ab0c39f2d04)