### PR TITLE
Add developer options: clear cache and allow unsupported widget resizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,8 @@ etc/                                        — design assets (SVG/XCF sources, 
   `theme/ThemeCards`). Developer-only options live in `pref_dev.xml` and are
   gated by the `dev` preference; they include one-shot maintenance actions
   (clear the app label/icon caches, rerun onboarding, queue default pins) and
-  debug toggles such as log toasts and unrestricted widget resizing.
+  debug toggles such as log toasts and unrestricted widget resizing; toggles
+  under this section are cleared when developer mode is switched off.
   `PreferencesRepository` provides typed and observable (`valueFlow`, a
   Kotlin `Flow`) access to the main "prefs" file keyed by the `Preference`
   enum — prefer it over raw `SharedPreferences` in new code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,10 +282,13 @@ etc/                                        — design assets (SVG/XCF sources, 
   programmatically with `PreferenceScreen`/categories), plus dedicated
   activities for lens ordering (`LensPreferencesActivity`) and theme
   selection (`ThemePreferencesActivity`, card UI shared with the wizard via
-  `theme/ThemeCards`). `PreferencesRepository` provides
-  typed and observable (`valueFlow`, a Kotlin `Flow`) access to the main
-  "prefs" file keyed by the `Preference` enum — prefer it over raw
-  `SharedPreferences` in new code.
+  `theme/ThemeCards`). Developer-only options live in `pref_dev.xml` and are
+  gated by the `dev` preference; they include one-shot maintenance actions
+  (clear the app label/icon caches, rerun onboarding, queue default pins) and
+  debug toggles such as log toasts and unrestricted widget resizing.
+  `PreferencesRepository` provides typed and observable (`valueFlow`, a
+  Kotlin `Flow`) access to the main "prefs" file keyed by the `Preference`
+  enum — prefer it over raw `SharedPreferences` in new code.
 - **`theme/`** — one class per supported desktop look (`Default`, `Gnome`,
   `Elementary`, `Cinnamon`, `Plasma`, `Mate`, `Cosmic`, `Budgie`), each
   extending the abstract `Theme` (which lists every themeable field and maps
@@ -337,8 +340,9 @@ etc/                                        — design assets (SVG/XCF sources, 
   shown; drops and moves stay within it. Long-pressing a widget puts its
   `WidgetContainer` into
   edit mode: edge handles resize by touch (clamped to the provider's
-  `min`/`maxResize*` limits and `resizeMode`, with a snap-indicator line
-  drawn by `WidgetsContainer`), while dragging the body uses the system
+  `min`/`maxResize*` limits and `resizeMode`, unless the developer-only
+  unrestricted widget resizing preference is enabled, with a snap-indicator
+  line drawn by `WidgetsContainer`), while dragging the body uses the system
   drag-and-drop framework (`WidgetsContainer_DragListener`) and shares the
   launcher's drag-to-trash mechanism. The free-moving system drag shadow is
   accompanied by a snapped landing indicator drawn on `WidgetsContainer`;

--- a/app/src/main/java/be/robinj/distrohopper/cache/AppIconCache.java
+++ b/app/src/main/java/be/robinj/distrohopper/cache/AppIconCache.java
@@ -9,4 +9,8 @@ public class AppIconCache extends DrawableCache {
 	public AppIconCache(Context context) {
 		super(context, NAME);
 	}
+
+	public static void clearAll(Context context) {
+		new ExpiringCache<>(context, new AppIconCache(context), EXPIRATION).clear();
+	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -21,7 +21,8 @@ public enum Preference {
 	DEFAULT_PINS_PENDING("default_pins_pending"),
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
-	DEV_LOG_TOASTER("dev_log_toaster");
+	DEV_LOG_TOASTER("dev_log_toaster"),
+	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false);
 
 	private final String name;
 	private final Object defaultValue;

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -21,9 +21,12 @@ public enum Preference {
 	DEFAULT_PINS_PENDING("default_pins_pending"),
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
+	DEV_LOGS("dummy_dev_logs"),
 	DEV_LOG_TOASTER("dev_log_toaster"),
 	DEV_CLEAR_CACHE("dummy_clear_cache"),
-	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false);
+	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false),
+	DEV_RERUN_ONBOARDING("dummy_rerun_onboarding"),
+	DEV_PIN_DEFAULT_APPS("dummy_pin_default_apps");
 
 	private final String name;
 	private final Object defaultValue;

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -21,21 +21,21 @@ public enum Preference {
 	DEFAULT_PINS_PENDING("default_pins_pending"),
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
-	DEV_LOG_TOASTER("dev_log_toaster", null, true),
-	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false, true);
+	DEV_LOG_TOASTER("dev_log_toaster", null, DEV),
+	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false, DEV);
 
 	private final String name;
 	private final Object defaultValue;
-	private final boolean devChild;
+	private final Preference parent;
 
-	Preference(final String name, final Object defaultValue, final boolean devChild) {
+	Preference(final String name, final Object defaultValue, final Preference parent) {
 		this.name = name;
 		this.defaultValue = defaultValue;
-		this.devChild = devChild;
+		this.parent = parent;
 	}
 
 	Preference(final String name, final Object defaultValue) {
-		this(name, defaultValue, false);
+		this(name, defaultValue, null);
 	}
 
 	Preference(final String name) {
@@ -50,8 +50,8 @@ public enum Preference {
 		return (T) this.defaultValue;
 	}
 
-	public boolean isDevChild() {
-		return this.devChild;
+	public Preference getParent() {
+		return this.parent;
 	}
 
 	@Override

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -22,6 +22,7 @@ public enum Preference {
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
 	DEV_LOG_TOASTER("dev_log_toaster"),
+	DEV_CLEAR_CACHE("dummy_clear_cache"),
 	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false);
 
 	private final String name;

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -21,15 +21,21 @@ public enum Preference {
 	DEFAULT_PINS_PENDING("default_pins_pending"),
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
-	DEV_LOG_TOASTER("dev_log_toaster"),
-	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false);
+	DEV_LOG_TOASTER("dev_log_toaster", null, true),
+	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false, true);
 
 	private final String name;
 	private final Object defaultValue;
+	private final boolean devChild;
 
-	Preference(final String name, final Object defaultValue) {
+	Preference(final String name, final Object defaultValue, final boolean devChild) {
 		this.name = name;
 		this.defaultValue = defaultValue;
+		this.devChild = devChild;
+	}
+
+	Preference(final String name, final Object defaultValue) {
+		this(name, defaultValue, false);
 	}
 
 	Preference(final String name) {
@@ -42,6 +48,10 @@ public enum Preference {
 
 	public <T> T getDefault() {
 		return (T) this.defaultValue;
+	}
+
+	public boolean isDevChild() {
+		return this.devChild;
 	}
 
 	@Override

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -22,7 +22,6 @@ public enum Preference {
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
 	DEV_LOG_TOASTER("dev_log_toaster"),
-	DEV_CLEAR_CACHE("dummy_clear_cache"),
 	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false);
 
 	private final String name;

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -21,7 +21,6 @@ public enum Preference {
 	DEFAULT_PINS_PENDING("default_pins_pending"),
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
-	DEV_LOGS("dummy_dev_logs"),
 	DEV_LOG_TOASTER("dev_log_toaster"),
 	DEV_CLEAR_CACHE("dummy_clear_cache"),
 	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false),

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -23,9 +23,7 @@ public enum Preference {
 	DEV("dev"),
 	DEV_LOG_TOASTER("dev_log_toaster"),
 	DEV_CLEAR_CACHE("dummy_clear_cache"),
-	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false),
-	DEV_RERUN_ONBOARDING("dummy_rerun_onboarding"),
-	DEV_PIN_DEFAULT_APPS("dummy_pin_default_apps");
+	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false);
 
 	private final String name;
 	private final Object defaultValue;

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -268,40 +268,40 @@ public class PreferencesActivity extends AppCompatActivity
 
 			if (! pref.isChecked ())
 			{
-				this.clearDevPreferences ();
+				this.clearChildPreferences (be.robinj.distrohopper.preferences.Preference.DEV);
 			}
 
 			pref.setOnPreferenceChangeListener ((preference, newValue) ->
 			{
 				if (Boolean.FALSE.equals (newValue))
 				{
-					this.clearDevPreferences ();
+					this.clearChildPreferences (be.robinj.distrohopper.preferences.Preference.DEV);
 				}
 
 				return true;
 			});
 		}
 
-		private void clearDevPreferences ()
+		private void clearChildPreferences (final be.robinj.distrohopper.preferences.Preference parent)
 		{
 			final SharedPreferences.Editor editor = Preferences
 				.getSharedPreferences (this.requireContext ())
 				.edit ();
 
-			for (final be.robinj.distrohopper.preferences.Preference devPref
+			for (final be.robinj.distrohopper.preferences.Preference child
 				: be.robinj.distrohopper.preferences.Preference.values ())
 			{
-				if (! devPref.isDevChild ())
+				if (child.getParent () != parent)
 					continue;
 
-				final Preference toggle = this.findPreference (devPref.getName ());
+				final Preference toggle = this.findPreference (child.getName ());
 				if (toggle instanceof SwitchPreferenceCompat)
 					((SwitchPreferenceCompat) toggle).setChecked (false);
 
-				// Explicitly write false rather than removing the key: if a future
-				// devChild preference defaults to true, remove() would leave the
-				// feature active after developer mode is turned off. //
-				editor.putBoolean (devPref.getName (), false);
+				// Explicitly write false rather than removing the key: if a child
+				// preference ever defaults to true, remove() would leave the feature
+				// active after the parent preference is turned off. //
+				editor.putBoolean (child.getName (), false);
 			}
 
 			editor.apply ();

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -161,8 +161,7 @@ public class PreferencesActivity extends AppCompatActivity
 				}
 			);
 
-			final Preference clearCache = this.findPreference (
-				be.robinj.distrohopper.preferences.Preference.DEV_CLEAR_CACHE.getName ());
+			final Preference clearCache = this.findPreference ("dummy_clear_cache");
 			if (clearCache != null)
 			{
 				clearCache.setOnPreferenceClickListener (new Preference.OnPreferenceClickListener ()

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -186,11 +186,8 @@ public class PreferencesActivity extends AppCompatActivity
 				});
 			}
 
-			final Preference rerunOnboarding = this.findPreference (
-				be.robinj.distrohopper.preferences.Preference.DEV_RERUN_ONBOARDING.getName ());
-			if (rerunOnboarding != null)
-			{
-				rerunOnboarding.setOnPreferenceClickListener (new Preference.OnPreferenceClickListener ()
+			this.findPreference ("dummy_rerun_onboarding").setOnPreferenceClickListener (
+				new Preference.OnPreferenceClickListener ()
 				{
 					@Override
 					public boolean onPreferenceClick (Preference preference)
@@ -202,14 +199,11 @@ public class PreferencesActivity extends AppCompatActivity
 
 						return true;
 					}
-				});
-			}
+				}
+			);
 
-			final Preference pinDefaultApps = this.findPreference (
-				be.robinj.distrohopper.preferences.Preference.DEV_PIN_DEFAULT_APPS.getName ());
-			if (pinDefaultApps != null)
-			{
-				pinDefaultApps.setOnPreferenceClickListener (new Preference.OnPreferenceClickListener ()
+			this.findPreference ("dummy_pin_default_apps").setOnPreferenceClickListener (
+				new Preference.OnPreferenceClickListener ()
 				{
 					@Override
 					public boolean onPreferenceClick (Preference preference)
@@ -221,8 +215,8 @@ public class PreferencesActivity extends AppCompatActivity
 
 						return true;
 					}
-				});
-			}
+				}
+			);
 
 			this.findPreference ("dummy_set_default_launcher").setOnPreferenceClickListener (
 				new Preference.OnPreferenceClickListener ()

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -294,14 +294,14 @@ public class PreferencesActivity extends AppCompatActivity
 				if (! devPref.isDevChild ())
 					continue;
 
-				final SwitchPreferenceCompat toggle = this.findPreference (devPref.getName ());
-				if (toggle != null)
-					toggle.setChecked (false);
+				final Preference toggle = this.findPreference (devPref.getName ());
+				if (toggle instanceof SwitchPreferenceCompat)
+					((SwitchPreferenceCompat) toggle).setChecked (false);
 
-				// setChecked(false) keeps the visible switch in sync but persists
-				// false; remove afterwards so disabling developer mode truly clears
-				// developer-only state rather than saving disabled values. //
-				editor.remove (devPref.getName ());
+				// Explicitly write false rather than removing the key: if a future
+				// devChild preference defaults to true, remove() would leave the
+				// feature active after developer mode is turned off. //
+				editor.putBoolean (devPref.getName (), false);
 			}
 
 			editor.apply ();

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -35,6 +35,7 @@ import be.robinj.distrohopper.IconPackHelper;
 import be.robinj.distrohopper.InsetsHelper;
 import be.robinj.distrohopper.R;
 import be.robinj.distrohopper.cache.AppIconCache;
+import be.robinj.distrohopper.cache.AppLabelCache;
 import be.robinj.distrohopper.home.DefaultPinnedApps;
 import be.robinj.distrohopper.onboarding.OnboardingGate;
 
@@ -152,6 +153,29 @@ public class PreferencesActivity extends AppCompatActivity
 					{
 						requireActivity ().setResult (4);
 						requireActivity ().finish ();
+
+						return true;
+					}
+				}
+			);
+
+			this.findPreference ("dummy_clear_cache").setOnPreferenceClickListener (
+				new Preference.OnPreferenceClickListener ()
+				{
+					@Override
+					public boolean onPreferenceClick (Preference preference)
+					{
+						try
+						{
+							new AppIconCache (requireContext ().getApplicationContext ()).clear ();
+							new AppLabelCache (requireContext ().getApplicationContext ()).clear ();
+							Toast.makeText (requireContext (),
+								R.string.toast_cache_cleared, Toast.LENGTH_SHORT).show ();
+						}
+						catch (Exception ex)
+						{
+							new ExceptionHandler (ex).show (requireActivity ());
+						}
 
 						return true;
 					}

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -123,6 +123,7 @@ public class PreferencesActivity extends AppCompatActivity
 			this.initIconPackList ();
 			this.initCrashReportsPreference ();
 			this.initLauncherPinModePreference ();
+			this.initDevPreference ();
 
 			this.findPreference ("dummy_wallpaper").setOnPreferenceClickListener (
 				new Preference.OnPreferenceClickListener ()
@@ -257,6 +258,43 @@ public class PreferencesActivity extends AppCompatActivity
 			header.setTitle (titleRes);
 			this.getPreferenceScreen ().addPreference (header);
 			this.addPreferencesFromResource (prefsRes);
+		}
+
+		private void initDevPreference ()
+		{
+			final SwitchPreferenceCompat pref = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.DEV.getName ());
+			if (pref == null)
+				return;
+
+			pref.setOnPreferenceChangeListener ((preference, newValue) ->
+			{
+				if (Boolean.FALSE.equals (newValue))
+				{
+					this.clearDevPreferences ();
+				}
+
+				return true;
+			});
+		}
+
+		private void clearDevPreferences ()
+		{
+			final SharedPreferences prefs = Preferences.getSharedPreferences (this.requireContext ());
+			prefs.edit ()
+				.remove (be.robinj.distrohopper.preferences.Preference.DEV_LOG_TOASTER.getName ())
+				.remove (be.robinj.distrohopper.preferences.Preference.DEV_WIDGET_RESIZE_ANY.getName ())
+				.apply ();
+
+			final SwitchPreferenceCompat logToaster = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.DEV_LOG_TOASTER.getName ());
+			if (logToaster != null)
+				logToaster.setChecked (false);
+
+			final SwitchPreferenceCompat widgetResize = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.DEV_WIDGET_RESIZE_ANY.getName ());
+			if (widgetResize != null)
+				widgetResize.setChecked (false);
 		}
 
 		private void clearAppCaches ()

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -36,6 +36,7 @@ import be.robinj.distrohopper.InsetsHelper;
 import be.robinj.distrohopper.R;
 import be.robinj.distrohopper.cache.AppIconCache;
 import be.robinj.distrohopper.cache.AppLabelCache;
+import be.robinj.distrohopper.cache.ExpiringCache;
 import be.robinj.distrohopper.home.DefaultPinnedApps;
 import be.robinj.distrohopper.onboarding.OnboardingGate;
 
@@ -167,8 +168,7 @@ public class PreferencesActivity extends AppCompatActivity
 					{
 						try
 						{
-							new AppIconCache (requireContext ().getApplicationContext ()).clear ();
-							new AppLabelCache (requireContext ().getApplicationContext ()).clear ();
+							clearAppCaches ();
 							Toast.makeText (requireContext (),
 								R.string.toast_cache_cleared, Toast.LENGTH_SHORT).show ();
 						}
@@ -255,6 +255,16 @@ public class PreferencesActivity extends AppCompatActivity
 			header.setTitle (titleRes);
 			this.getPreferenceScreen ().addPreference (header);
 			this.addPreferencesFromResource (prefsRes);
+		}
+
+		private void clearAppCaches ()
+		{
+			new AppLabelCache (this.requireContext ().getApplicationContext ()).clear ();
+			new ExpiringCache<> (
+				this.requireContext ().getApplicationContext (),
+				new AppIconCache (this.requireContext ().getApplicationContext ()),
+				AppIconCache.EXPIRATION)
+				.clear ();
 		}
 
 		private void initLauncherPinModePreference ()

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -186,8 +186,11 @@ public class PreferencesActivity extends AppCompatActivity
 				});
 			}
 
-			this.findPreference ("dummy_rerun_onboarding").setOnPreferenceClickListener (
-				new Preference.OnPreferenceClickListener ()
+			final Preference rerunOnboarding = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.DEV_RERUN_ONBOARDING.getName ());
+			if (rerunOnboarding != null)
+			{
+				rerunOnboarding.setOnPreferenceClickListener (new Preference.OnPreferenceClickListener ()
 				{
 					@Override
 					public boolean onPreferenceClick (Preference preference)
@@ -199,11 +202,14 @@ public class PreferencesActivity extends AppCompatActivity
 
 						return true;
 					}
-				}
-			);
+				});
+			}
 
-			this.findPreference ("dummy_pin_default_apps").setOnPreferenceClickListener (
-				new Preference.OnPreferenceClickListener ()
+			final Preference pinDefaultApps = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.DEV_PIN_DEFAULT_APPS.getName ());
+			if (pinDefaultApps != null)
+			{
+				pinDefaultApps.setOnPreferenceClickListener (new Preference.OnPreferenceClickListener ()
 				{
 					@Override
 					public boolean onPreferenceClick (Preference preference)
@@ -215,8 +221,8 @@ public class PreferencesActivity extends AppCompatActivity
 
 						return true;
 					}
-				}
-			);
+				});
+			}
 
 			this.findPreference ("dummy_set_default_launcher").setOnPreferenceClickListener (
 				new Preference.OnPreferenceClickListener ()

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -285,12 +285,6 @@ public class PreferencesActivity extends AppCompatActivity
 
 		private void clearDevPreferences ()
 		{
-			final SharedPreferences prefs = Preferences.getSharedPreferences (this.requireContext ());
-			prefs.edit ()
-				.remove (be.robinj.distrohopper.preferences.Preference.DEV_LOG_TOASTER.getName ())
-				.remove (be.robinj.distrohopper.preferences.Preference.DEV_WIDGET_RESIZE_ANY.getName ())
-				.apply ();
-
 			final SwitchPreferenceCompat logToaster = this.findPreference (
 				be.robinj.distrohopper.preferences.Preference.DEV_LOG_TOASTER.getName ());
 			if (logToaster != null)
@@ -300,6 +294,15 @@ public class PreferencesActivity extends AppCompatActivity
 				be.robinj.distrohopper.preferences.Preference.DEV_WIDGET_RESIZE_ANY.getName ());
 			if (widgetResize != null)
 				widgetResize.setChecked (false);
+
+			// setChecked(false) keeps the visible switches in sync but persists
+			// false; remove afterwards so disabling developer mode truly clears
+			// developer-only state rather than saving disabled values. //
+			Preferences.getSharedPreferences (this.requireContext ())
+				.edit ()
+				.remove (be.robinj.distrohopper.preferences.Preference.DEV_LOG_TOASTER.getName ())
+				.remove (be.robinj.distrohopper.preferences.Preference.DEV_WIDGET_RESIZE_ANY.getName ())
+				.apply ();
 		}
 
 		private void clearAppCaches ()

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -160,7 +160,9 @@ public class PreferencesActivity extends AppCompatActivity
 				}
 			);
 
-			this.findPreference ("dummy_clear_cache").setOnPreferenceClickListener (
+			this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.DEV_CLEAR_CACHE.getName ())
+				.setOnPreferenceClickListener (
 				new Preference.OnPreferenceClickListener ()
 				{
 					@Override

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -36,7 +36,6 @@ import be.robinj.distrohopper.InsetsHelper;
 import be.robinj.distrohopper.R;
 import be.robinj.distrohopper.cache.AppIconCache;
 import be.robinj.distrohopper.cache.AppLabelCache;
-import be.robinj.distrohopper.cache.ExpiringCache;
 import be.robinj.distrohopper.home.DefaultPinnedApps;
 import be.robinj.distrohopper.onboarding.OnboardingGate;
 
@@ -285,34 +284,33 @@ public class PreferencesActivity extends AppCompatActivity
 
 		private void clearDevPreferences ()
 		{
-			final SwitchPreferenceCompat logToaster = this.findPreference (
-				be.robinj.distrohopper.preferences.Preference.DEV_LOG_TOASTER.getName ());
-			if (logToaster != null)
-				logToaster.setChecked (false);
+			final SharedPreferences.Editor editor = Preferences
+				.getSharedPreferences (this.requireContext ())
+				.edit ();
 
-			final SwitchPreferenceCompat widgetResize = this.findPreference (
-				be.robinj.distrohopper.preferences.Preference.DEV_WIDGET_RESIZE_ANY.getName ());
-			if (widgetResize != null)
-				widgetResize.setChecked (false);
+			for (final be.robinj.distrohopper.preferences.Preference devPref
+				: be.robinj.distrohopper.preferences.Preference.values ())
+			{
+				if (! devPref.isDevChild ())
+					continue;
 
-			// setChecked(false) keeps the visible switches in sync but persists
-			// false; remove afterwards so disabling developer mode truly clears
-			// developer-only state rather than saving disabled values. //
-			Preferences.getSharedPreferences (this.requireContext ())
-				.edit ()
-				.remove (be.robinj.distrohopper.preferences.Preference.DEV_LOG_TOASTER.getName ())
-				.remove (be.robinj.distrohopper.preferences.Preference.DEV_WIDGET_RESIZE_ANY.getName ())
-				.apply ();
+				final SwitchPreferenceCompat toggle = this.findPreference (devPref.getName ());
+				if (toggle != null)
+					toggle.setChecked (false);
+
+				// setChecked(false) keeps the visible switch in sync but persists
+				// false; remove afterwards so disabling developer mode truly clears
+				// developer-only state rather than saving disabled values. //
+				editor.remove (devPref.getName ());
+			}
+
+			editor.apply ();
 		}
 
 		private void clearAppCaches ()
 		{
 			new AppLabelCache (this.requireContext ().getApplicationContext ()).clear ();
-			new ExpiringCache<> (
-				this.requireContext ().getApplicationContext (),
-				new AppIconCache (this.requireContext ().getApplicationContext ()),
-				AppIconCache.EXPIRATION)
-				.clear ();
+			AppIconCache.clearAll (this.requireContext ().getApplicationContext ());
 		}
 
 		private void initLauncherPinModePreference ()

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -161,10 +161,11 @@ public class PreferencesActivity extends AppCompatActivity
 				}
 			);
 
-			this.findPreference (
-				be.robinj.distrohopper.preferences.Preference.DEV_CLEAR_CACHE.getName ())
-				.setOnPreferenceClickListener (
-				new Preference.OnPreferenceClickListener ()
+			final Preference clearCache = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.DEV_CLEAR_CACHE.getName ());
+			if (clearCache != null)
+			{
+				clearCache.setOnPreferenceClickListener (new Preference.OnPreferenceClickListener ()
 				{
 					@Override
 					public boolean onPreferenceClick (Preference preference)
@@ -182,8 +183,8 @@ public class PreferencesActivity extends AppCompatActivity
 
 						return true;
 					}
-				}
-			);
+				});
+			}
 
 			this.findPreference ("dummy_rerun_onboarding").setOnPreferenceClickListener (
 				new Preference.OnPreferenceClickListener ()
@@ -266,6 +267,11 @@ public class PreferencesActivity extends AppCompatActivity
 				be.robinj.distrohopper.preferences.Preference.DEV.getName ());
 			if (pref == null)
 				return;
+
+			if (! pref.isChecked ())
+			{
+				this.clearDevPreferences ();
+			}
 
 			pref.setOnPreferenceChangeListener ((preference, newValue) ->
 			{

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -298,10 +298,7 @@ public class PreferencesActivity extends AppCompatActivity
 				if (toggle instanceof SwitchPreferenceCompat)
 					((SwitchPreferenceCompat) toggle).setChecked (false);
 
-				// Explicitly write false rather than removing the key: if a child
-				// preference ever defaults to true, remove() would leave the feature
-				// active after the parent preference is turned off. //
-				editor.putBoolean (child.getName (), false);
+				editor.remove (child.getName ());
 			}
 
 			editor.apply ();

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
@@ -156,18 +156,23 @@ class WidgetContainer internal constructor(
 
 				val cellW = parent.cellWidth
 				val cellH = parent.cellHeight
+				val allowUnsupportedResize = this.allowUnsupportedResize
 
 				// The drag itself is limited to whole cells within the active size
 				// policy (provider limits normally, grid-only limits for the developer
 				// override), so the preview can never exceed what a release would commit //
+				val minResizeWidth = this.minResizeWidthPx(allowUnsupportedResize)
+				val maxResizeWidth = this.maxResizeWidthPx(allowUnsupportedResize)
+				val minResizeHeight = this.minResizeHeightPx(allowUnsupportedResize)
+				val maxResizeHeight = this.maxResizeHeightPx(allowUnsupportedResize)
 				val minColSpan = WidgetGrid.clampSpan(
-					1, this.minResizeWidthPx(), this.maxResizeWidthPx(), cellW, WidgetGrid.COLS)
+					1, minResizeWidth, maxResizeWidth, cellW, WidgetGrid.COLS)
 				val maxColSpan = WidgetGrid.clampSpan(
-					WidgetGrid.COLS, this.minResizeWidthPx(), this.maxResizeWidthPx(), cellW, WidgetGrid.COLS)
+					WidgetGrid.COLS, minResizeWidth, maxResizeWidth, cellW, WidgetGrid.COLS)
 				val minRowSpan = WidgetGrid.clampSpan(
-					1, this.minResizeHeightPx(), this.maxResizeHeightPx(), cellH, WidgetGrid.ROWS)
+					1, minResizeHeight, maxResizeHeight, cellH, WidgetGrid.ROWS)
 				val maxRowSpan = WidgetGrid.clampSpan(
-					WidgetGrid.ROWS, this.minResizeHeightPx(), this.maxResizeHeightPx(), cellH, WidgetGrid.ROWS)
+					WidgetGrid.ROWS, minResizeHeight, maxResizeHeight, cellH, WidgetGrid.ROWS)
 
 				val gridLeft = parent.paddingLeft
 				val gridTop = parent.paddingTop
@@ -247,15 +252,19 @@ class WidgetContainer internal constructor(
 		return false
 	}
 
-	private fun minResizeWidthPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.minResizeWidth ?: 0
+	private fun minResizeWidthPx(allowUnsupportedResize: Boolean): Int =
+		if (allowUnsupportedResize) 0 else this.info?.minResizeWidth ?: 0
 
-	private fun minResizeHeightPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.minResizeHeight ?: 0
+	private fun minResizeHeightPx(allowUnsupportedResize: Boolean): Int =
+		if (allowUnsupportedResize) 0 else this.info?.minResizeHeight ?: 0
 
 	/** The provider's maximum resize width in px, or 0 when unspecified. */
-	private fun maxResizeWidthPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.maxResizeWidth ?: 0
+	private fun maxResizeWidthPx(allowUnsupportedResize: Boolean): Int =
+		if (allowUnsupportedResize) 0 else this.info?.maxResizeWidth ?: 0
 
 	/** The provider's maximum resize height in px, or 0 when unspecified. */
-	private fun maxResizeHeightPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.maxResizeHeight ?: 0
+	private fun maxResizeHeightPx(allowUnsupportedResize: Boolean): Int =
+		if (allowUnsupportedResize) 0 else this.info?.maxResizeHeight ?: 0
 
 	private fun startMoveDrag(parent: WidgetsContainer, e: MotionEvent) {
 		val location = IntArray(2)
@@ -286,12 +295,19 @@ class WidgetContainer internal constructor(
 		val colEnd = WidgetGrid.snapToCell(lp.previewLeftPx + lp.previewWidthPx - parent.paddingLeft, cellWidth, WidgetGrid.COLS)
 		val rowEnd = WidgetGrid.snapToCell(lp.previewTopPx + lp.previewHeightPx - parent.paddingTop, cellHeight, WidgetGrid.ROWS)
 
+		val allowUnsupportedResize = this.allowUnsupportedResize
 		val colSpan = WidgetGrid.clampSpan(
-			max(1, colEnd - col), this.minResizeWidthPx(), this.maxResizeWidthPx(),
-			cellWidth, WidgetGrid.COLS)
+			max(1, colEnd - col),
+			this.minResizeWidthPx(allowUnsupportedResize),
+			this.maxResizeWidthPx(allowUnsupportedResize),
+			cellWidth,
+			WidgetGrid.COLS)
 		val rowSpan = WidgetGrid.clampSpan(
-			max(1, rowEnd - row), this.minResizeHeightPx(), this.maxResizeHeightPx(),
-			cellHeight, WidgetGrid.ROWS)
+			max(1, rowEnd - row),
+			this.minResizeHeightPx(allowUnsupportedResize),
+			this.maxResizeHeightPx(allowUnsupportedResize),
+			cellHeight,
+			WidgetGrid.ROWS)
 
 		val candidate = WidgetLayout(this.appWidgetId, col, row, colSpan, rowSpan)
 

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
@@ -11,6 +11,8 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.R
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.Preferences
 import be.robinj.distrohopper.home.LauncherBarBinder
 import kotlin.math.abs
 import kotlin.math.max
@@ -50,6 +52,10 @@ class WidgetContainer internal constructor(
 	private val info: AppWidgetProviderInfo?
 		get() = this.widget.appWidgetInfo
 
+	private val allowUnsupportedResize: Boolean
+		get() = Preferences.getSharedPreferences(this.context)
+			.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false)
+
 	var editMode = false
 		set(value) {
 			if (value) {
@@ -61,9 +67,10 @@ class WidgetContainer internal constructor(
 			field = value
 
 			val info = this.info
-			val canResizeH = info == null ||
+			val allowUnsupportedResize = this.allowUnsupportedResize
+			val canResizeH = allowUnsupportedResize || info == null ||
 				info.resizeMode and AppWidgetProviderInfo.RESIZE_HORIZONTAL != 0
-			val canResizeV = info == null ||
+			val canResizeV = allowUnsupportedResize || info == null ||
 				info.resizeMode and AppWidgetProviderInfo.RESIZE_VERTICAL != 0
 
 			this.container.alpha = if (value) 0.8F else 1.0F
@@ -149,18 +156,17 @@ class WidgetContainer internal constructor(
 
 				val cellW = parent.cellWidth
 				val cellH = parent.cellHeight
-				val info = this.info
 
 				// The drag itself is limited to whole cells within the sizes the widget
 				// supports, so the preview can never exceed what a release would commit //
 				val minColSpan = WidgetGrid.clampSpan(
-					1, info?.minResizeWidth ?: 0, this.maxResizeWidthPx(), cellW, WidgetGrid.COLS)
+					1, this.minResizeWidthPx(), this.maxResizeWidthPx(), cellW, WidgetGrid.COLS)
 				val maxColSpan = WidgetGrid.clampSpan(
-					WidgetGrid.COLS, info?.minResizeWidth ?: 0, this.maxResizeWidthPx(), cellW, WidgetGrid.COLS)
+					WidgetGrid.COLS, this.minResizeWidthPx(), this.maxResizeWidthPx(), cellW, WidgetGrid.COLS)
 				val minRowSpan = WidgetGrid.clampSpan(
-					1, info?.minResizeHeight ?: 0, this.maxResizeHeightPx(), cellH, WidgetGrid.ROWS)
+					1, this.minResizeHeightPx(), this.maxResizeHeightPx(), cellH, WidgetGrid.ROWS)
 				val maxRowSpan = WidgetGrid.clampSpan(
-					WidgetGrid.ROWS, info?.minResizeHeight ?: 0, this.maxResizeHeightPx(), cellH, WidgetGrid.ROWS)
+					WidgetGrid.ROWS, this.minResizeHeightPx(), this.maxResizeHeightPx(), cellH, WidgetGrid.ROWS)
 
 				val gridLeft = parent.paddingLeft
 				val gridTop = parent.paddingTop
@@ -240,11 +246,15 @@ class WidgetContainer internal constructor(
 		return false
 	}
 
+	private fun minResizeWidthPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.minResizeWidth ?: 0
+
+	private fun minResizeHeightPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.minResizeHeight ?: 0
+
 	/** The provider's maximum resize width in px, or 0 when unspecified. */
-	private fun maxResizeWidthPx(): Int = this.info?.maxResizeWidth ?: 0
+	private fun maxResizeWidthPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.maxResizeWidth ?: 0
 
 	/** The provider's maximum resize height in px, or 0 when unspecified. */
-	private fun maxResizeHeightPx(): Int = this.info?.maxResizeHeight ?: 0
+	private fun maxResizeHeightPx(): Int = if (this.allowUnsupportedResize) 0 else this.info?.maxResizeHeight ?: 0
 
 	private fun startMoveDrag(parent: WidgetsContainer, e: MotionEvent) {
 		val location = IntArray(2)
@@ -275,12 +285,11 @@ class WidgetContainer internal constructor(
 		val colEnd = WidgetGrid.snapToCell(lp.previewLeftPx + lp.previewWidthPx - parent.paddingLeft, cellWidth, WidgetGrid.COLS)
 		val rowEnd = WidgetGrid.snapToCell(lp.previewTopPx + lp.previewHeightPx - parent.paddingTop, cellHeight, WidgetGrid.ROWS)
 
-		val info = this.info
 		val colSpan = WidgetGrid.clampSpan(
-			max(1, colEnd - col), info?.minResizeWidth ?: 0, this.maxResizeWidthPx(),
+			max(1, colEnd - col), this.minResizeWidthPx(), this.maxResizeWidthPx(),
 			cellWidth, WidgetGrid.COLS)
 		val rowSpan = WidgetGrid.clampSpan(
-			max(1, rowEnd - row), info?.minResizeHeight ?: 0, this.maxResizeHeightPx(),
+			max(1, rowEnd - row), this.minResizeHeightPx(), this.maxResizeHeightPx(),
 			cellHeight, WidgetGrid.ROWS)
 
 		val candidate = WidgetLayout(this.appWidgetId, col, row, colSpan, rowSpan)

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
@@ -157,8 +157,9 @@ class WidgetContainer internal constructor(
 				val cellW = parent.cellWidth
 				val cellH = parent.cellHeight
 
-				// The drag itself is limited to whole cells within the sizes the widget
-				// supports, so the preview can never exceed what a release would commit //
+				// The drag itself is limited to whole cells within the active size
+				// policy (provider limits normally, grid-only limits for the developer
+				// override), so the preview can never exceed what a release would commit //
 				val minColSpan = WidgetGrid.clampSpan(
 					1, this.minResizeWidthPx(), this.maxResizeWidthPx(), cellW, WidgetGrid.COLS)
 				val maxColSpan = WidgetGrid.clampSpan(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,11 @@
     <string name="option_dev">Developer mode</string>
     <string name="hint_dev">Access debug logs and other technical information. Enabling this will negatively impact performance and stability.</string>
     <string name="option_dev_logs">Logs</string>
+    <string name="option_clear_cache">Clear cache</string>
+    <string name="hint_clear_cache">Remove cached app labels and icons. They will be rebuilt the next time apps load.</string>
+    <string name="toast_cache_cleared">Cache cleared</string>
+    <string name="option_widget_resize_any">Allow unsupported widget sizes</string>
+    <string name="hint_widget_resize_any">Show every resize handle and ignore provider size limits while resizing widgets.</string>
     <string name="option_rerun_onboarding">Run setup wizard again</string>
     <string name="hint_rerun_onboarding">The first-run setup wizard will be shown the next time DistroHopper starts.</string>
     <string name="toast_rerun_onboarding">Setup wizard will run on next start</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,11 +74,11 @@
     <string name="option_dev">Developer mode</string>
     <string name="hint_dev">Access debug logs and other technical information. Enabling this will negatively impact performance and stability.</string>
     <string name="option_dev_logs">Logs</string>
-    <string name="option_clear_cache">Clear cache</string>
-    <string name="hint_clear_cache">Remove cached app labels and icons. They will be rebuilt the next time apps load.</string>
+    <string name="option_clear_cache">Clear app caches</string>
+    <string name="hint_clear_cache">Remove cached app labels and icons so they are rebuilt the next time apps load.</string>
     <string name="toast_cache_cleared">Cache cleared</string>
-    <string name="option_widget_resize_any">Allow unsupported widget sizes</string>
-    <string name="hint_widget_resize_any">Show every resize handle and ignore provider size limits while resizing widgets.</string>
+    <string name="option_widget_resize_any">Allow unsupported widget dimensions</string>
+    <string name="hint_widget_resize_any">Allow widgets to be resized beyond the dimensions reported by their providers.</string>
     <string name="option_rerun_onboarding">Run setup wizard again</string>
     <string name="hint_rerun_onboarding">The first-run setup wizard will be shown the next time DistroHopper starts.</string>
     <string name="toast_rerun_onboarding">Setup wizard will run on next start</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,10 +75,9 @@
     <string name="hint_dev">Access debug logs and other technical information. Enabling this will negatively impact performance and stability.</string>
     <string name="option_dev_logs">Logs</string>
     <string name="option_clear_cache">Clear app caches</string>
-    <string name="hint_clear_cache">Remove cached app labels and icons so they are rebuilt the next time apps load.</string>
     <string name="toast_cache_cleared">Cache cleared</string>
     <string name="option_widget_resize_any">Allow unsupported widget dimensions</string>
-    <string name="hint_widget_resize_any">Allow widgets to be resized beyond the dimensions reported by their providers.</string>
+    <string name="hint_widget_resize_any">Allow widgets to be resized beyond their supported size constraints.</string>
     <string name="option_rerun_onboarding">Run setup wizard again</string>
     <string name="hint_rerun_onboarding">The first-run setup wizard will be shown the next time DistroHopper starts.</string>
     <string name="toast_rerun_onboarding">Setup wizard will run on next start</string>

--- a/app/src/main/res/xml/pref_dev.xml
+++ b/app/src/main/res/xml/pref_dev.xml
@@ -18,8 +18,7 @@
 	<Preference
 		android:key="dummy_clear_cache"
 		android:dependency="dev"
-		android:title="@string/option_clear_cache"
-		android:summary="@string/hint_clear_cache" />
+		android:title="@string/option_clear_cache" />
 
 	<SwitchPreferenceCompat
 		android:key="dev_widget_resize_any"

--- a/app/src/main/res/xml/pref_dev.xml
+++ b/app/src/main/res/xml/pref_dev.xml
@@ -1,7 +1,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<Preference
-		android:key="dummy_dev_logs"
 		android:dependency="dev"
 		android:title="@string/option_dev_logs">
 		<intent

--- a/app/src/main/res/xml/pref_dev.xml
+++ b/app/src/main/res/xml/pref_dev.xml
@@ -16,6 +16,19 @@
 		android:defaultValue="false" />
 
 	<Preference
+		android:key="dummy_clear_cache"
+		android:dependency="dev"
+		android:title="@string/option_clear_cache"
+		android:summary="@string/hint_clear_cache" />
+
+	<SwitchPreferenceCompat
+		android:key="dev_widget_resize_any"
+		android:dependency="dev"
+		android:title="@string/option_widget_resize_any"
+		android:summary="@string/hint_widget_resize_any"
+		android:defaultValue="false" />
+
+	<Preference
 		android:key="dummy_rerun_onboarding"
 		android:dependency="dev"
 		android:title="@string/option_rerun_onboarding"

--- a/app/src/main/res/xml/pref_dev.xml
+++ b/app/src/main/res/xml/pref_dev.xml
@@ -1,6 +1,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<Preference
+		android:key="dummy_dev_logs"
 		android:dependency="dev"
 		android:title="@string/option_dev_logs">
 		<intent

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -59,6 +59,8 @@ class DevPreferenceTest {
 		assertFalse(prefs.getBoolean(Preference.DEV.getName(), true))
 		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), false))
 		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false))
+		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
+		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
 	}
 
 	@Test fun openingPreferencesWithDeveloperModeOffClearsStaleDeveloperToggles() {
@@ -84,6 +86,8 @@ class DevPreferenceTest {
 		val prefs = Preferences.getSharedPreferences(this.application)
 		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), false))
 		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false))
+		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
+		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
 	}
 
 	@Test fun clickingClearCacheClearsLabelIconAndExpirationCaches() {

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -1,0 +1,47 @@
+package be.robinj.distrohopper.preferences
+
+import android.app.Application
+import androidx.preference.SwitchPreferenceCompat
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.R
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class DevPreferenceTest {
+	private lateinit var application: Application
+
+	@Before fun setUp() {
+		this.application = ApplicationProvider.getApplicationContext()
+		Preferences.getSharedPreferences(this.application).edit()
+			.clear()
+			.putBoolean(Preference.DEV.getName(), true)
+			.putBoolean(Preference.DEV_LOG_TOASTER.getName(), true)
+			.putBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true)
+			.commit()
+	}
+
+	@Test fun disablingDeveloperModeClearsDeveloperToggles() {
+		ActivityScenario.launch(PreferencesActivity::class.java).use { scenario ->
+			scenario.onActivity { activity ->
+				val fragment = activity.supportFragmentManager
+					.findFragmentById(R.id.preferences_container)
+					as PreferencesActivity.PreferencesFragment
+				val dev = fragment.findPreference<SwitchPreferenceCompat>(Preference.DEV.getName())!!
+
+				dev.performClick()
+			}
+		}
+
+		val prefs = Preferences.getSharedPreferences(this.application)
+		assertFalse(prefs.getBoolean(Preference.DEV.getName(), true))
+		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), false))
+		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false))
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -9,7 +9,6 @@ import be.robinj.distrohopper.R
 import be.robinj.distrohopper.cache.AppIconCache
 import be.robinj.distrohopper.cache.AppLabelCache
 import be.robinj.distrohopper.cache.ExpiringCache
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -111,7 +110,13 @@ class DevPreferenceTest {
 			}
 		}
 
-		assertEquals(0, labelCache.size)
-		assertEquals(0, iconCache.size)
+		val freshLabelCache = AppLabelCache(this.application)
+		val freshIconCache = ExpiringCache(
+			this.application,
+			AppIconCache(this.application),
+			AppIconCache.EXPIRATION,
+		)
+		assertFalse(freshLabelCache.containsKey("label-key"))
+		assertFalse(freshIconCache.containsKey("icon-key"))
 	}
 }

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -1,11 +1,17 @@
 package be.robinj.distrohopper.preferences
 
 import android.app.Application
+import android.graphics.drawable.ColorDrawable
 import androidx.preference.SwitchPreferenceCompat
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import be.robinj.distrohopper.R
+import be.robinj.distrohopper.cache.AppIconCache
+import be.robinj.distrohopper.cache.AppLabelCache
+import be.robinj.distrohopper.cache.ExpiringCache
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,8 +40,18 @@ class DevPreferenceTest {
 					.findFragmentById(R.id.preferences_container)
 					as PreferencesActivity.PreferencesFragment
 				val dev = fragment.findPreference<SwitchPreferenceCompat>(Preference.DEV.getName())!!
+				val logToaster = fragment.findPreference<SwitchPreferenceCompat>(
+					Preference.DEV_LOG_TOASTER.getName())!!
+				val widgetResize = fragment.findPreference<SwitchPreferenceCompat>(
+					Preference.DEV_WIDGET_RESIZE_ANY.getName())!!
+
+				assertTrue(logToaster.isChecked)
+				assertTrue(widgetResize.isChecked)
 
 				dev.performClick()
+
+				assertFalse(logToaster.isChecked)
+				assertFalse(widgetResize.isChecked)
 			}
 		}
 
@@ -43,5 +59,56 @@ class DevPreferenceTest {
 		assertFalse(prefs.getBoolean(Preference.DEV.getName(), true))
 		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), false))
 		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false))
+	}
+
+	@Test fun openingPreferencesWithDeveloperModeOffClearsStaleDeveloperToggles() {
+		Preferences.getSharedPreferences(this.application).edit()
+			.putBoolean(Preference.DEV.getName(), false)
+			.commit()
+
+		ActivityScenario.launch(PreferencesActivity::class.java).use { scenario ->
+			scenario.onActivity { activity ->
+				val fragment = activity.supportFragmentManager
+					.findFragmentById(R.id.preferences_container)
+					as PreferencesActivity.PreferencesFragment
+				val logToaster = fragment.findPreference<SwitchPreferenceCompat>(
+					Preference.DEV_LOG_TOASTER.getName())!!
+				val widgetResize = fragment.findPreference<SwitchPreferenceCompat>(
+					Preference.DEV_WIDGET_RESIZE_ANY.getName())!!
+
+				assertFalse(logToaster.isChecked)
+				assertFalse(widgetResize.isChecked)
+			}
+		}
+
+		val prefs = Preferences.getSharedPreferences(this.application)
+		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), false))
+		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false))
+	}
+
+	@Test fun clickingClearCacheClearsLabelIconAndExpirationCaches() {
+		val labelCache = AppLabelCache(this.application)
+		val iconCache = ExpiringCache(
+			this.application,
+			AppIconCache(this.application),
+			AppIconCache.EXPIRATION,
+		)
+		labelCache["label-key"] = "Label"
+		iconCache["icon-key"] = ColorDrawable(0xff00ff)
+
+		ActivityScenario.launch(PreferencesActivity::class.java).use { scenario ->
+			scenario.onActivity { activity ->
+				val fragment = activity.supportFragmentManager
+					.findFragmentById(R.id.preferences_container)
+					as PreferencesActivity.PreferencesFragment
+
+				fragment.findPreference<androidx.preference.Preference>(
+					Preference.DEV_CLEAR_CACHE.getName())!!
+					.performClick()
+			}
+		}
+
+		assertEquals(0, labelCache.size)
+		assertEquals(0, iconCache.size)
 	}
 }

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -56,10 +56,8 @@ class DevPreferenceTest {
 
 		val prefs = Preferences.getSharedPreferences(this.application)
 		assertFalse(prefs.getBoolean(Preference.DEV.getName(), true))
-		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), false))
-		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false))
-		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
-		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
+		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), true))
+		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true))
 	}
 
 	@Test fun openingPreferencesWithDeveloperModeOffClearsStaleDeveloperToggles() {
@@ -83,10 +81,8 @@ class DevPreferenceTest {
 		}
 
 		val prefs = Preferences.getSharedPreferences(this.application)
-		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), false))
-		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), false))
-		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
-		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
+		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), true))
+		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true))
 	}
 
 	@Test fun clickingClearCacheClearsLabelIconAndExpirationCaches() {

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -56,8 +56,8 @@ class DevPreferenceTest {
 
 		val prefs = Preferences.getSharedPreferences(this.application)
 		assertFalse(prefs.getBoolean(Preference.DEV.getName(), true))
-		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), true))
-		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true))
+		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
+		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
 	}
 
 	@Test fun openingPreferencesWithDeveloperModeOffClearsStaleDeveloperToggles() {
@@ -81,8 +81,8 @@ class DevPreferenceTest {
 		}
 
 		val prefs = Preferences.getSharedPreferences(this.application)
-		assertFalse(prefs.getBoolean(Preference.DEV_LOG_TOASTER.getName(), true))
-		assertFalse(prefs.getBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true))
+		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
+		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
 	}
 
 	@Test fun clickingClearCacheClearsLabelIconAndExpirationCaches() {

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -102,8 +102,7 @@ class DevPreferenceTest {
 					.findFragmentById(R.id.preferences_container)
 					as PreferencesActivity.PreferencesFragment
 
-				fragment.findPreference<androidx.preference.Preference>(
-					Preference.DEV_CLEAR_CACHE.getName())!!
+				fragment.findPreference<androidx.preference.Preference>("dummy_clear_cache")!!
 					.performClick()
 			}
 		}

--- a/app/src/test/java/be/robinj/distrohopper/preferences/PreferencesDefaultPinnedAppsOptionTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/PreferencesDefaultPinnedAppsOptionTest.kt
@@ -35,7 +35,8 @@ class PreferencesDefaultPinnedAppsOptionTest {
 					.findFragmentById(R.id.preferences_container)
 					as PreferencesActivity.PreferencesFragment
 
-				fragment.findPreference<androidx.preference.Preference>("dummy_pin_default_apps")!!
+				fragment.findPreference<androidx.preference.Preference>(
+					Preference.DEV_PIN_DEFAULT_APPS.getName())!!
 					.performClick()
 			}
 		}

--- a/app/src/test/java/be/robinj/distrohopper/preferences/PreferencesDefaultPinnedAppsOptionTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/PreferencesDefaultPinnedAppsOptionTest.kt
@@ -35,8 +35,7 @@ class PreferencesDefaultPinnedAppsOptionTest {
 					.findFragmentById(R.id.preferences_container)
 					as PreferencesActivity.PreferencesFragment
 
-				fragment.findPreference<androidx.preference.Preference>(
-					Preference.DEV_PIN_DEFAULT_APPS.getName())!!
+				fragment.findPreference<androidx.preference.Preference>("dummy_pin_default_apps")!!
 					.performClick()
 			}
 		}

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetContainerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetContainerTest.kt
@@ -8,6 +8,8 @@ import androidx.test.core.app.ActivityScenario
 import be.robinj.distrohopper.ActivityTestSupport
 import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.R
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.Preferences
 import be.robinj.distrohopper.widgets.WidgetTestSupport.CELL
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -25,7 +27,15 @@ class WidgetContainerTest {
 	private lateinit var scenario: ActivityScenario<HomeActivity>
 
 	@Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
-	@After fun tearDown() { scenario.close() }
+	@After fun tearDown() {
+		scenario.onActivity { activity ->
+			Preferences.getSharedPreferences(activity)
+				.edit()
+				.remove(Preference.DEV_WIDGET_RESIZE_ANY.getName())
+				.commit()
+		}
+		scenario.close()
+	}
 
 	private class Fixture(
 		val grid: WidgetsContainer,
@@ -104,6 +114,41 @@ class WidgetContainerTest {
 			assertEquals(View.VISIBLE, container.findViewById<View>(R.id.llEdgeRight).visibility)
 			assertEquals(View.GONE, container.findViewById<View>(R.id.llEdgeTop).visibility)
 			assertEquals(View.GONE, container.findViewById<View>(R.id.llEdgeBottom).visibility)
+		}
+	}
+
+	@Test fun developerResizeOverrideShowsAllResizeEdges() {
+		scenario.onActivity { activity ->
+			Preferences.getSharedPreferences(activity)
+				.edit()
+				.putBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true)
+				.commit()
+			val container = widgetAt22(activity,
+				WidgetTestSupport.providerInfo(AppWidgetProviderInfo.RESIZE_HORIZONTAL)).container
+
+			container.editMode = true
+
+			assertEquals(View.VISIBLE, container.findViewById<View>(R.id.llEdgeLeft).visibility)
+			assertEquals(View.VISIBLE, container.findViewById<View>(R.id.llEdgeRight).visibility)
+			assertEquals(View.VISIBLE, container.findViewById<View>(R.id.llEdgeTop).visibility)
+			assertEquals(View.VISIBLE, container.findViewById<View>(R.id.llEdgeBottom).visibility)
+		}
+	}
+
+	@Test fun developerResizeOverrideIgnoresProviderSizeLimits() {
+		scenario.onActivity { activity ->
+			Preferences.getSharedPreferences(activity)
+				.edit()
+				.putBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true)
+				.commit()
+			val container = widgetAt22(activity,
+				WidgetTestSupport.providerInfo(maxResizeWidth = 2 * CELL)).container
+
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_DOWN, 400F, 300F)
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_MOVE, 400F + CELL, 300F)
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_UP, 400F + CELL, 300F)
+
+			assertEquals(3, lp(container).colSpan)
 		}
 	}
 

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetTestSupport.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetTestSupport.kt
@@ -32,10 +32,14 @@ internal object WidgetTestSupport {
 		resizeMode: Int = AppWidgetProviderInfo.RESIZE_BOTH,
 		minResizeWidth: Int = 0,
 		minResizeHeight: Int = 0,
+		maxResizeWidth: Int = 0,
+		maxResizeHeight: Int = 0,
 	): AppWidgetProviderInfo = AppWidgetProviderInfo().apply {
 		this.resizeMode = resizeMode
 		this.minResizeWidth = minResizeWidth
 		this.minResizeHeight = minResizeHeight
+		this.maxResizeWidth = maxResizeWidth
+		this.maxResizeHeight = maxResizeHeight
 	}
 
 	/**


### PR DESCRIPTION
### Motivation
- Provide developer-only maintenance and debugging controls to speed iteration and diagnostics. 
- Add a one-shot cache purge for app icon/label caches and a developer override to explore widget resizing beyond provider limits.

### Description
- Add a new developer preference key `DEV_WIDGET_RESIZE_ANY` and new developer UI entries in `res/xml/pref_dev.xml` with strings in `res/values/strings.xml` to expose `Clear cache` and `Allow unsupported widget sizes` options.
- Wire the `Clear cache` preference in `PreferencesActivity` to clear `AppIconCache` and `AppLabelCache` and show a confirmation toast.
- Make `WidgetContainer` honor the developer override by reading the new preference and, when enabled, showing all resize handles and treating provider `min`/`maxResize*` as unspecified (effectively ignoring provider size limits during resize and commit).
- Add Robolectric unit tests and test helpers (`WidgetContainerTest.kt`, `WidgetTestSupport.kt`) that cover the developer-resize behaviour, and update `AGENTS.md` to document the new developer options.

### Testing
- Ran repository checks (`git diff --check`) and committed the changes successfully.
- Added Robolectric tests for the widget-resize override, but running `./gradlew testDebugUnitTest --tests be.robinj.distrohopper.widgets.WidgetContainerTest` in this environment failed because the Android SDK location is not configured (missing `ANDROID_HOME` / `local.properties` `sdk.dir`), so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d61c4f7ac8322bfa9a384fe1cb4da)