### PR TITLE
Add option to focus search box when dash opens

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
@@ -212,11 +212,14 @@ class DashController(
 		val llPanel = this.viewFinder.get<LinearLayout>(R.id.llPanel)
 
 		if (this.prefs.getBoolean(Preference.DASH_SEARCH_FOCUS_ON_OPEN, false)) {
+			val llDashContent = this.viewFinder.get<LinearLayout>(R.id.llDashContent)
 			val etDashSearch = this.viewFinder.get<EditText>(R.id.etDashSearch)
 			// Defer until the dash view is laid out/visible so the focus and
-			// keyboard request take effect.
+			// keyboard request take effect. Skip in customise mode, where
+			// llDashContent (which holds the search field) is hidden — otherwise
+			// the keyboard would pop up over the customise controls.
 			etDashSearch.post {
-				if (etDashSearch.requestFocus()) {
+				if (llDashContent.visibility == View.VISIBLE && etDashSearch.requestFocus()) {
 					val imm = this.activity.getSystemService(Context.INPUT_METHOD_SERVICE)
 						as InputMethodManager?
 					imm?.showSoftInput(etDashSearch, InputMethodManager.SHOW_IMPLICIT)

--- a/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import be.robinj.distrohopper.R
 import be.robinj.distrohopper.ViewFinder
 import be.robinj.distrohopper.desktop.Wallpaper
+import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
 import be.robinj.distrohopper.preferences.PreferencesRepository
 import be.robinj.distrohopper.theme.Theme
@@ -206,9 +207,22 @@ class DashController(
 	private fun blurRadiusPx(): Int =
 		this.activity.resources.getDimensionPixelSize(this.theme.dash_blur_radius)
 
-	/** The non-dash side of opening: the panel's close button and backgrounds. */
+	/** The non-dash side of opening: the panel's close button, backgrounds and search focus. */
 	private fun applyOpenedChrome() {
 		val llPanel = this.viewFinder.get<LinearLayout>(R.id.llPanel)
+
+		if (this.prefs.getBoolean(Preference.DASH_SEARCH_FOCUS_ON_OPEN, false)) {
+			val etDashSearch = this.viewFinder.get<EditText>(R.id.etDashSearch)
+			// Defer until the dash view is laid out/visible so the focus and
+			// keyboard request take effect.
+			etDashSearch.post {
+				if (etDashSearch.requestFocus()) {
+					val imm = this.activity.getSystemService(Context.INPUT_METHOD_SERVICE)
+						as InputMethodManager?
+					imm?.showSoftInput(etDashSearch, InputMethodManager.SHOW_IMPLICIT)
+				}
+			}
+		}
 
 		if (this.activity.resources.getInteger(this.theme.panel_close_location) != -1)
 			this.viewFinder.get<ImageButton>(llPanel, R.id.ibPanelDashClose).visibility = View.VISIBLE

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -11,6 +11,7 @@ public enum Preference {
 	LAUNCHERICON_WIDTH("launchericon_width"),
 	LAUNCHERSERVICE_ENABLED("launcherservice_enabled"),
 	DASH_SEARCH_FULL("dashsearch_full"),
+	DASH_SEARCH_FOCUS_ON_OPEN("dashsearch_focus_on_open", false),
 	DASH_SEARCH_LENSES_MAX_RESULTS("dashsearch_lenses_maxresults"),
 	DASHICON_WIDTH("dashicon_width", 24),
 	CRASH_REPORTING_ENABLED("crash_reporting_enabled"),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
     <string name="hint_launcher_edge">To which screen edge the Launcher should be attached.</string>
     <string name="widget_picker_title">Add widget</string>
     <string name="widget_no_room">There is no room left on the home screen for this widget.</string>
+    <string name="option_dashsearch_focus_on_open">Focus search on open</string>
+    <string name="hint_dashsearch_focus_on_open">Focus the search box and show the keyboard when the dash is opened.</string>
     <string name="option_dev_log_toaster">Log toasts</string>
     <string name="hint_dev_log_toaster">Show log items in toast messages.</string>
     <string name="option_customise">Customise</string>

--- a/app/src/main/res/xml/pref_functionality.xml
+++ b/app/src/main/res/xml/pref_functionality.xml
@@ -6,6 +6,12 @@
         android:title="@string/option_pin_per_desktop"
         android:summary="@string/hint_pin_per_desktop" />
 
+    <SwitchPreferenceCompat
+        android:key="dashsearch_focus_on_open"
+        android:title="@string/option_dashsearch_focus_on_open"
+        android:summary="@string/hint_dashsearch_focus_on_open"
+        android:defaultValue="false" />
+
     <Preference
        android:title="@string/option_lenses"
        android:summary="@string/hint_lenses">


### PR DESCRIPTION
## Summary
This PR adds a new user preference that automatically focuses the search box and displays the keyboard when the dash panel is opened.

## Key Changes
- Added new `DASH_SEARCH_FOCUS_ON_OPEN` preference to the `Preference` enum with a default value of `false`
- Implemented focus and keyboard display logic in `DashController.applyOpenedChrome()` that:
  - Checks if the preference is enabled
  - Requests focus on the search EditText
  - Shows the soft input keyboard using `InputMethodManager`
  - Defers the focus request using `post()` to ensure the view is laid out before attempting to focus
- Added UI preference option in `pref_functionality.xml` as a `SwitchPreferenceCompat`
- Added user-facing strings for the preference title and hint in `strings.xml`
- Updated the `applyOpenedChrome()` method documentation to reflect the new search focus functionality

## Implementation Details
- The focus request is deferred using `EditText.post()` to ensure the view hierarchy is properly laid out and visible before attempting to focus and show the keyboard
- The keyboard is shown implicitly using `InputMethodManager.SHOW_IMPLICIT` flag
- The preference defaults to `false` to maintain backward compatibility with existing behavior

https://claude.ai/code/session_01JkinTejPH5FE2PT6SNdeJt