### PR TITLE
Prevent DistroHopper from appearing as app in other profiles

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/AppRepository.kt
+++ b/app/src/main/java/be/robinj/distrohopper/AppRepository.kt
@@ -113,8 +113,15 @@ class AppRepository(private val context: Context) {
 		val launcherApps = this.context.getSystemService(LauncherApps::class.java)
 			?: return emptyList()
 
+		// Skip our own package the way the personal-profile load does
+		// (AppsLoader): a DistroHopper installed in another profile would
+		// otherwise show up as an app in that profile's dash tab, and tapping
+		// it would launch HomeActivity in that profile straight into the
+		// first-run wizard. A second launcher inside a work profile is never
+		// useful anyway.
 		return Profiles.otherProfiles(this.context)
 			.flatMap { launcherApps.getActivityList(null, it) }
+			.filter { it.componentName.packageName != this.context.packageName }
 	}
 
 	/**

--- a/app/src/main/java/be/robinj/distrohopper/broadcast/WorkProfileAppsCallback.kt
+++ b/app/src/main/java/be/robinj/distrohopper/broadcast/WorkProfileAppsCallback.kt
@@ -18,6 +18,13 @@ import be.robinj.distrohopper.dev.Log
  */
 class WorkProfileAppsCallback(private val parent: HomeActivity) : LauncherApps.Callback() {
 	override fun onPackageAdded(packageName: String, user: UserHandle) {
+		// Never add our own package as an app in another profile (see
+		// AppRepository.queryOtherProfileApps): tapping a work-profile copy of
+		// DistroHopper would drop the user into that profile's first-run wizard.
+		if (packageName == this.parent.packageName) {
+			return
+		}
+
 		this.handle(user) { appManager ->
 			val launcherApps = this.parent.getSystemService(LauncherApps::class.java)
 


### PR DESCRIPTION
## Summary
This change prevents DistroHopper from appearing as an installable app when viewing other user profiles (such as work profiles). This avoids a confusing user experience where tapping the app would launch it in that profile's first-run wizard.

## Key Changes
- **AppRepository.kt**: Added filtering in `queryOtherProfileApps()` to exclude DistroHopper's own package from the list of apps retrieved from other profiles
- **WorkProfileAppsCallback.kt**: Added early return in `onPackageAdded()` to skip processing when DistroHopper itself is installed in another profile

## Implementation Details
- Both changes follow the same pattern already used in the personal-profile app loading logic (AppsLoader)
- The filtering is based on comparing the component's package name against the current context's package name
- This prevents the scenario where a user could tap on a work-profile instance of DistroHopper and be taken to that profile's first-run wizard
- The rationale is that having a second launcher instance in a work profile is never useful to the user

https://claude.ai/code/session_01DyfHGNd7ccSVCjPqF33G1o