### PR TITLE
Fix 'set as home screen' doing nothing on Samsung

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,12 @@ etc/                                        — design assets (SVG/XCF sources, 
   - `IconPackHelper`, `Image`, `Utils`, `ViewFinder`, `InsetsHelper`,
     `Permission`, `RequestCode`, `ExceptionHandler`, `HomeRole` —
     support/utilities. `HomeRole` wraps the HOME-role (default launcher)
-    checks/request intent used by the wizard and the preferences screen.
+    checks/request intents used by the wizard and the preferences screen. The
+    native role dialog (`roleRequestIntent`) is unreliable on some OEM builds
+    (notably Samsung One UI), where it returns without ever showing a picker, so
+    both callers observe its result and fall back to the system home-settings
+    screen (`homeSettingsIntent`, `Settings.ACTION_HOME_SETTINGS`) when the role
+    still isn't held afterwards.
     `InsetsHelper` handles system bar / display cutout insets (e.g. keeping
     UI clear of the 3-button navigation bar).
   - `Observed`/`IObserver` — small homegrown observer pattern.

--- a/app/src/main/java/be/robinj/distrohopper/HomeRole.kt
+++ b/app/src/main/java/be/robinj/distrohopper/HomeRole.kt
@@ -16,18 +16,29 @@ object HomeRole {
 			?.isRoleHeld(RoleManager.ROLE_HOME) == true
 
 	/**
-	 * An intent prompting the user to make this app the default home app: the
-	 * system's role dialog, or the home settings screen where the role is
-	 * unavailable.
+	 * The system's HOME-role dialog asking the user to make this app the default
+	 * home app, or `null` where the role is unavailable.
+	 *
+	 * The dialog is unreliable on some OEM builds (notably Samsung One UI), where
+	 * it returns without ever showing a picker. Callers should observe its result
+	 * and, when the role still isn't [held][isHeld], fall back to
+	 * [homeSettingsIntent].
 	 */
 	@JvmStatic
-	fun requestIntent(context: Context): Intent {
+	fun roleRequestIntent(context: Context): Intent? {
 		val roleManager = context.getSystemService(RoleManager::class.java)
 
 		return if (roleManager != null && roleManager.isRoleAvailable(RoleManager.ROLE_HOME)) {
 			roleManager.createRequestRoleIntent(RoleManager.ROLE_HOME)
 		} else {
-			Intent(Settings.ACTION_HOME_SETTINGS)
+			null
 		}
 	}
+
+	/**
+	 * The system home-settings screen (the "default home app" picker): the
+	 * fallback used where the role is unavailable or its dialog did nothing.
+	 */
+	@JvmStatic
+	fun homeSettingsIntent(): Intent = Intent(Settings.ACTION_HOME_SETTINGS)
 }

--- a/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/onboarding/OnboardingActivity.kt
@@ -51,6 +51,20 @@ class OnboardingActivity : AppCompatActivity() {
 
 	private val roleRequest = this.registerForActivityResult(
 		ActivityResultContracts.StartActivityForResult()
+	) {
+		// The native HOME-role dialog is broken on some OEM builds (notably
+		// Samsung): it returns without ever showing a picker. When the role still
+		// isn't held after it closes, fall back to the system home settings. //
+		if (!HomeRole.isHeld(this)) {
+			this.homeSettingsRequest.launch(HomeRole.homeSettingsIntent())
+		}
+		this.adapter.rebind(OnboardingPage.DEFAULT_LAUNCHER)
+	}
+
+	// A separate launcher so the home-settings result never re-triggers the
+	// fallback above (which would loop). //
+	private val homeSettingsRequest = this.registerForActivityResult(
+		ActivityResultContracts.StartActivityForResult()
 	) { this.adapter.rebind(OnboardingPage.DEFAULT_LAUNCHER) }
 
 	/**
@@ -171,8 +185,13 @@ class OnboardingActivity : AppCompatActivity() {
 		view.findViewById<Button>(R.id.btnOnboardingSetDefault).apply {
 			this.visibility = if (isDefault) View.GONE else View.VISIBLE
 			this.setOnClickListener {
-				this@OnboardingActivity.roleRequest
-					.launch(HomeRole.requestIntent(this@OnboardingActivity))
+				val roleIntent = HomeRole.roleRequestIntent(this@OnboardingActivity)
+				if (roleIntent != null) {
+					this@OnboardingActivity.roleRequest.launch(roleIntent)
+				} else {
+					this@OnboardingActivity.homeSettingsRequest
+						.launch(HomeRole.homeSettingsIntent())
+				}
 			}
 		}
 		view.findViewById<TextView>(R.id.tvOnboardingAlreadyDefault)

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -9,6 +9,8 @@ import android.widget.Toast;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.NavUtils;
 import androidx.preference.ListPreference;
@@ -106,6 +108,25 @@ public class PreferencesActivity extends AppCompatActivity
 	public static class PreferencesFragment extends PreferenceFragmentCompat
 	{
 		private PreferenceCategory devCategory;
+
+		// The native HOME-role dialog is broken on some OEM builds (notably
+		// Samsung): it returns without ever showing a picker. When the role still
+		// isn't held after it closes, fall back to the system home settings;
+		// homeSettingsRequest is a separate launcher so its result never
+		// re-triggers that fallback (which would loop). //
+		private final ActivityResultLauncher<Intent> roleRequest =
+			this.registerForActivityResult (
+				new ActivityResultContracts.StartActivityForResult (),
+				result ->
+				{
+					if (! HomeRole.isHeld (this.requireContext ()))
+						this.homeSettingsRequest.launch (HomeRole.homeSettingsIntent ());
+				});
+
+		private final ActivityResultLauncher<Intent> homeSettingsRequest =
+			this.registerForActivityResult (
+				new ActivityResultContracts.StartActivityForResult (),
+				result -> { /* onResume re-checks the option's visibility */ });
 
 		@Override
 		public void onCreatePreferences (Bundle savedInstanceState, String rootKey)
@@ -227,7 +248,12 @@ public class PreferencesActivity extends AppCompatActivity
 					{
 						try
 						{
-							startActivity (HomeRole.requestIntent (requireContext ()));
+							final Intent roleIntent =
+								HomeRole.roleRequestIntent (requireContext ());
+							if (roleIntent != null)
+								roleRequest.launch (roleIntent);
+							else
+								homeSettingsRequest.launch (HomeRole.homeSettingsIntent ());
 						}
 						catch (Exception ex)
 						{

--- a/app/src/test/java/be/robinj/distrohopper/HomeRoleTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/HomeRoleTest.kt
@@ -1,0 +1,48 @@
+package be.robinj.distrohopper
+
+import android.app.Application
+import android.app.role.RoleManager
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadow.api.Shadow
+import org.robolectric.shadows.ShadowRoleManager
+
+@RunWith(RobolectricTestRunner::class)
+class HomeRoleTest {
+    private val context: Application = ApplicationProvider.getApplicationContext()
+
+    private fun roleManagerShadow(): ShadowRoleManager =
+        Shadow.extract(context.getSystemService(RoleManager::class.java))
+
+    @Test fun roleRequestIntentIsGivenWhenTheHomeRoleIsAvailable() {
+        this.roleManagerShadow().addAvailableRole(RoleManager.ROLE_HOME)
+
+        assertNotNull(HomeRole.roleRequestIntent(this.context))
+    }
+
+    @Test fun roleRequestIntentIsNullWhenTheHomeRoleIsUnavailable() {
+        // Nothing is made available, so the broken-on-some-OEMs role dialog is
+        // skipped and callers fall back to the home-settings screen //
+        assertNull(HomeRole.roleRequestIntent(this.context))
+    }
+
+    @Test fun homeSettingsIntentOpensTheDefaultHomeAppPicker() {
+        assertEquals(Settings.ACTION_HOME_SETTINGS, HomeRole.homeSettingsIntent().action)
+    }
+
+    @Test fun isHeldReflectsWhetherTheHomeRoleIsHeld() {
+        assertFalse(HomeRole.isHeld(this.context))
+
+        this.roleManagerShadow().addHeldRole(RoleManager.ROLE_HOME)
+
+        assertTrue(HomeRole.isHeld(this.context))
+    }
+}


### PR DESCRIPTION
The native HOME-role dialog (RoleManager.createRequestRoleIntent) is broken
on some OEM builds, notably Samsung One UI: isRoleAvailable(ROLE_HOME) returns
true but launching the dialog returns immediately without ever showing a
picker, so 'Set as home screen' appeared to do nothing.

Split HomeRole.requestIntent into roleRequestIntent (nullable role dialog) and
homeSettingsIntent (Settings.ACTION_HOME_SETTINGS). Both the onboarding wizard
and the preferences screen now observe the role dialog's result and fall back
to the system home-settings picker when the role still isn't held afterwards,
which works on Samsung.

https://claude.ai/code/session_01RRgfCEQnJZDx3VJermPHHi