### PR TITLE
Add frosted glass fallback for devices without cross-window blur

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/ExceptionHandler.java
+++ b/app/src/main/java/be/robinj/distrohopper/ExceptionHandler.java
@@ -8,6 +8,7 @@ import android.text.Html;
 import org.acra.ACRA;
 
 import be.robinj.distrohopper.dev.Log;
+import be.robinj.distrohopper.desktop.FrostedGlass;
 
 /**
  * Created by robin on 8/22/14.
@@ -67,7 +68,10 @@ public class ExceptionHandler {
 			dlg.setCancelable (true);
 			dlg.setNeutralButton (android.R.string.ok, null);
 
-			dlg.show ();
+			final AlertDialog dialog = dlg.create ();
+			// Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
+			dialog.setOnShowListener (d -> FrostedGlass.INSTANCE.applyDialogFallback (dialog.getWindow ()));
+			dialog.show ();
 		}
 		catch (Exception ex2)
 		{

--- a/app/src/main/java/be/robinj/distrohopper/desktop/FrostedFallbackDrawable.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/FrostedFallbackDrawable.kt
@@ -1,0 +1,120 @@
+package be.robinj.distrohopper.desktop
+
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.graphics.RectF
+import android.graphics.Shader
+import android.graphics.drawable.Drawable
+import android.view.Window
+import be.robinj.distrohopper.R
+
+/**
+ * Cross-window blur is optional on Android. When an OEM disables it (notably Samsung), a
+ * translucent tint plus fine grain reduces background detail showing through a semi-transparent
+ * surface, without needing the wallpaper bitmap. The dash uses this full-bleed behind its
+ * content; pop-up dialogs use it (with a [cornerRadius]) in place of their blurred card.
+ *
+ * [fraction] scales both layers so a ValueAnimator can ramp the effect in or out.
+ */
+internal class FrostedFallbackDrawable(
+    private val tint: Int,
+    private val cornerRadius: Float = 0F,
+) : Drawable() {
+    private val tintPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = tint }
+    private val grainPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        shader = BitmapShader(GRAIN, Shader.TileMode.REPEAT, Shader.TileMode.REPEAT)
+    }
+
+    var fraction: Float = 0F
+        set(value) {
+            field = value
+            this.invalidateSelf()
+        }
+
+    override fun draw(canvas: Canvas) {
+        this.tintPaint.alpha = (Color.alpha(this.tint) * this.fraction).toInt()
+        this.fill(canvas, this.tintPaint)
+
+        this.grainPaint.alpha = (18 * this.fraction).toInt()
+        this.fill(canvas, this.grainPaint)
+    }
+
+    private fun fill(canvas: Canvas, paint: Paint) {
+        if (this.cornerRadius > 0F) {
+            canvas.drawRoundRect(RectF(this.bounds), this.cornerRadius, this.cornerRadius, paint)
+        } else {
+            canvas.drawRect(this.bounds, paint)
+        }
+    }
+
+    override fun setAlpha(alpha: Int) {
+        this.fraction = alpha / 255F
+    }
+
+    override fun setColorFilter(colorFilter: ColorFilter?) {
+        this.tintPaint.colorFilter = colorFilter
+        this.grainPaint.colorFilter = colorFilter
+    }
+
+    @Deprecated("Deprecated in Android")
+    override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+
+    companion object {
+        // The grain is identical everywhere it's used, so it's generated once for the process.
+        private val GRAIN: Bitmap by lazy { createGrain() }
+
+        private fun createGrain(): Bitmap {
+            val size = 48
+            val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+            var state = 0x4d595df4
+
+            for (y in 0 until size) {
+                for (x in 0 until size) {
+                    state = state * 1664525 + 1013904223
+                    val white = if ((state ushr 28) >= 8) 255 else 0
+                    bitmap.setPixel(x, y, Color.argb(255, white, white, white))
+                }
+            }
+
+            return bitmap
+        }
+    }
+}
+
+/**
+ * Applies the frosted [FrostedFallbackDrawable] to pop-up dialogs that rely on cross-window
+ * blur (via [be.robinj.distrohopper.R.style] `ModernDialogTheme`) wherever that blur is
+ * unavailable, keeping their text legible over a busy wallpaper.
+ */
+object FrostedGlass {
+    /** The same capability the dash checks; injectable so tests can drive both branches. */
+    internal var crossWindowBlurEnabled: (Window) -> Boolean = {
+        it.windowManager.isCrossWindowBlurEnabled
+    }
+
+    /**
+     * When blur is unavailable, replace the dialog's window background (the rounded
+     * `ModernDialogTheme` card) with the grain drawable, and return it. The surface colour and
+     * corner radius match the theme's card, so blur-capable and blur-less devices look identical
+     * apart from the added grain. A no-op returning null when blur works.
+     */
+    fun applyDialogFallback(window: Window): Drawable? {
+        if (this.crossWindowBlurEnabled(window)) {
+            return null
+        }
+
+        val context = window.context
+        val tint = context.getColor(R.color.dialog_surface)
+        val radius = context.resources.getDimension(R.dimen.dialog_corner_radius)
+
+        val fallback = FrostedFallbackDrawable(tint, radius).apply { fraction = 1F }
+        window.setBackgroundDrawable(fallback)
+
+        return fallback
+    }
+}

--- a/app/src/main/java/be/robinj/distrohopper/desktop/Wallpaper.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/Wallpaper.kt
@@ -2,14 +2,7 @@ package be.robinj.distrohopper.desktop
 
 import android.app.WallpaperManager
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.BitmapShader
-import android.graphics.Canvas
 import android.graphics.Color
-import android.graphics.ColorFilter
-import android.graphics.Paint
-import android.graphics.PixelFormat
-import android.graphics.Shader
 import android.util.AttributeSet
 import android.view.Window
 import android.widget.ImageView
@@ -158,61 +151,6 @@ class Wallpaper : ImageView {
             val wallpaperColour = primary ?: Color.rgb(32, 33, 36)
             val darkened = ColorUtils.blendARGB(wallpaperColour, Color.BLACK, 0.68F)
             return ColorUtils.setAlphaComponent(darkened, 178)
-        }
-    }
-
-    /**
-     * Cross-window blur is optional on Android. When an OEM disables it, a colour-adaptive
-     * translucent layer plus fine grain reduces wallpaper detail without needing its bitmap.
-     */
-    private class FrostedFallbackDrawable(private val tint: Int) : android.graphics.drawable.Drawable() {
-        private val tintPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = tint }
-        private val grainPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            shader = BitmapShader(createGrain(), Shader.TileMode.REPEAT, Shader.TileMode.REPEAT)
-        }
-
-        var fraction: Float = 0F
-            set(value) {
-                field = value
-                this.invalidateSelf()
-            }
-
-        override fun draw(canvas: Canvas) {
-            this.tintPaint.alpha = (Color.alpha(this.tint) * this.fraction).toInt()
-            canvas.drawRect(this.bounds, this.tintPaint)
-
-            this.grainPaint.alpha = (18 * this.fraction).toInt()
-            canvas.drawRect(this.bounds, this.grainPaint)
-        }
-
-        override fun setAlpha(alpha: Int) {
-            this.fraction = alpha / 255F
-        }
-
-        override fun setColorFilter(colorFilter: ColorFilter?) {
-            this.tintPaint.colorFilter = colorFilter
-            this.grainPaint.colorFilter = colorFilter
-        }
-
-        @Deprecated("Deprecated in Android")
-        override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
-
-        companion object {
-            private fun createGrain(): Bitmap {
-                val size = 48
-                val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
-                var state = 0x4d595df4
-
-                for (y in 0 until size) {
-                    for (x in 0 until size) {
-                        state = state * 1664525 + 1013904223
-                        val white = if ((state ushr 28) >= 8) 255 else 0
-                        bitmap.setPixel(x, y, Color.argb(255, white, white, white))
-                    }
-                }
-
-                return bitmap
-            }
         }
     }
 }

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/Lens.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/Lens.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import be.robinj.distrohopper.R
+import be.robinj.distrohopper.desktop.FrostedGlass
 import java.io.BufferedInputStream
 import java.io.BufferedReader
 import java.io.ByteArrayOutputStream
@@ -100,7 +101,11 @@ abstract class Lens(protected val context: Context) {
         dlg.setMessage(message)
         dlg.setCancelable(true)
         dlg.setNeutralButton(android.R.string.ok, null)
-        dlg.show()
+
+        val dialog = dlg.create()
+        // Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
+        dialog.setOnShowListener { dialog.window?.let(FrostedGlass::applyDialogFallback) }
+        dialog.show()
     }
 
     protected open fun openConnection(url: String): URLConnection {

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -1,5 +1,6 @@
 package be.robinj.distrohopper.preferences;
 
+import android.app.Dialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -13,12 +14,15 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.NavUtils;
+import androidx.fragment.app.DialogFragment;
 import androidx.preference.ListPreference;
+import androidx.preference.ListPreferenceDialogFragmentCompat;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.SwitchPreferenceCompat;
 
+import be.robinj.distrohopper.desktop.FrostedGlass;
 import be.robinj.distrohopper.home.PinnedAppsMigration;
 
 import java.util.ArrayList;
@@ -300,6 +304,32 @@ public class PreferencesActivity extends AppCompatActivity
 			}
 		}
 
+		// The icon-pack and app-sort-order pickers are framework-created ListPreference
+		// dialogs, so they can't take an OnShowListener at a builder. Route them through a
+		// subclass that applies the frosted fallback once shown, keeping them legible where
+		// cross-window blur is unavailable (e.g. Samsung). //
+		private static final String DIALOG_FRAGMENT_TAG =
+			"androidx.preference.PreferenceFragment.DIALOG";
+
+		@Override
+		public void onDisplayPreferenceDialog (final Preference preference)
+		{
+			if (this.getParentFragmentManager ().findFragmentByTag (DIALOG_FRAGMENT_TAG) != null)
+				return;
+
+			if (preference instanceof ListPreference)
+			{
+				final DialogFragment fragment =
+					FrostedListPreferenceDialogFragment.newInstance (preference.getKey ());
+				fragment.setTargetFragment (this, 0);
+				fragment.show (this.getParentFragmentManager (), DIALOG_FRAGMENT_TAG);
+			}
+			else
+			{
+				super.onDisplayPreferenceDialog (preference);
+			}
+		}
+
 		private PreferenceCategory addCategory (final int titleRes, final int prefsRes)
 		{
 			final PreferenceCategory header = new PreferenceCategory (this.requireContext ());
@@ -543,6 +573,35 @@ public class PreferencesActivity extends AppCompatActivity
 			{
 				new ExceptionHandler (ex).logAndTrack ();
 			}
+		}
+	}
+
+	/**
+	 * A {@link ListPreferenceDialogFragmentCompat} that paints the frosted fallback over its
+	 * surface once shown, so the picker stays legible where cross-window blur is unavailable.
+	 * Public + static so the framework can recreate it across configuration changes.
+	 */
+	public static class FrostedListPreferenceDialogFragment extends ListPreferenceDialogFragmentCompat
+	{
+		static FrostedListPreferenceDialogFragment newInstance (final String key)
+		{
+			final FrostedListPreferenceDialogFragment fragment =
+				new FrostedListPreferenceDialogFragment ();
+			final Bundle args = new Bundle (1);
+			args.putString (ARG_KEY, key);
+			fragment.setArguments (args);
+
+			return fragment;
+		}
+
+		@Override
+		public void onStart ()
+		{
+			super.onStart ();
+
+			final Dialog dialog = this.getDialog ();
+			if (dialog != null && dialog.getWindow () != null)
+				FrostedGlass.INSTANCE.applyDialogFallback (dialog.getWindow ());
 		}
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -583,7 +583,7 @@ public class PreferencesActivity extends AppCompatActivity
 	 */
 	public static class FrostedListPreferenceDialogFragment extends ListPreferenceDialogFragmentCompat
 	{
-		static FrostedListPreferenceDialogFragment newInstance (final String key)
+		public static FrostedListPreferenceDialogFragment newInstance (final String key)
 		{
 			final FrostedListPreferenceDialogFragment fragment =
 				new FrostedListPreferenceDialogFragment ();

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetPickerDialog.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetPickerDialog.kt
@@ -15,6 +15,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import java.text.Collator
 import be.robinj.distrohopper.R
+import be.robinj.distrohopper.desktop.FrostedGlass
 
 /**
  * Lists the installed app widget providers, grouped by application.
@@ -49,6 +50,9 @@ class WidgetPickerDialog(
 				this.widgetHost.onProviderChosen(info)
 			}
 		}
+
+		// Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
+		dialog.setOnShowListener { dialog.window?.let(FrostedGlass::applyDialogFallback) }
 
 		dialog.show()
 	}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/FrostedFallbackDrawableTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/FrostedFallbackDrawableTest.kt
@@ -1,0 +1,64 @@
+package be.robinj.distrohopper.desktop
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.PixelFormat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class FrostedFallbackDrawableTest {
+	private val opaqueTint = Color.argb(255, 40, 40, 40)
+
+	private fun render(drawable: FrostedFallbackDrawable, size: Int = 100): Bitmap {
+		val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+		drawable.setBounds(0, 0, size, size)
+		drawable.draw(Canvas(bitmap))
+
+		return bitmap
+	}
+
+	@Test fun opacityIsTranslucent() {
+		assertEquals(PixelFormat.TRANSLUCENT, FrostedFallbackDrawable(this.opaqueTint).opacity)
+	}
+
+	@Test fun setAlphaDrivesTheFraction() {
+		val drawable = FrostedFallbackDrawable(this.opaqueTint)
+
+		drawable.alpha = 255
+		assertEquals(1F, drawable.fraction, 0.001F)
+
+		drawable.alpha = 0
+		assertEquals(0F, drawable.fraction, 0.001F)
+	}
+
+	@Test fun nothingIsPaintedAtZeroFraction() {
+		val drawable = FrostedFallbackDrawable(this.opaqueTint).apply { fraction = 0F }
+
+		assertEquals(0, Color.alpha(this.render(drawable).getPixel(50, 50)))
+	}
+
+	@Test fun fullBleedFillsRightUpToTheCorner() {
+		val drawable = FrostedFallbackDrawable(this.opaqueTint).apply { fraction = 1F }
+
+		val bitmap = this.render(drawable)
+		assertTrue(Color.alpha(bitmap.getPixel(0, 0)) > 0)
+		assertTrue(Color.alpha(bitmap.getPixel(50, 50)) > 0)
+	}
+
+	@Test fun roundedVariantLeavesTheCornerTransparentButFillsTheCentre() {
+		val drawable = FrostedFallbackDrawable(this.opaqueTint, cornerRadius = 40F)
+			.apply { fraction = 1F }
+
+		val bitmap = this.render(drawable)
+		// The extreme corner falls outside the rounded card, so it stays clear. //
+		assertEquals(0, Color.alpha(bitmap.getPixel(0, 0)))
+		assertTrue(Color.alpha(bitmap.getPixel(50, 50)) > 0)
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/FrostedGlassTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/FrostedGlassTest.kt
@@ -1,0 +1,44 @@
+package be.robinj.distrohopper.desktop
+
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.HomeActivity
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class FrostedGlassTest {
+	private lateinit var scenario: ActivityScenario<HomeActivity>
+
+	@Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
+	@After fun tearDown() {
+		scenario.close()
+		// The injected predicate lives on a shared object; restore the real one. //
+		FrostedGlass.crossWindowBlurEnabled = { it.windowManager.isCrossWindowBlurEnabled }
+	}
+
+	@Test fun dialogGetsTheGrainFallbackWhenCrossWindowBlurIsUnavailable() {
+		scenario.onActivity { activity ->
+			FrostedGlass.crossWindowBlurEnabled = { false }
+
+			val applied = FrostedGlass.applyDialogFallback(activity.window)
+
+			assertTrue(applied is FrostedFallbackDrawable)
+		}
+	}
+
+	@Test fun dialogKeepsItsThemedSurfaceWhenCrossWindowBlurIsAvailable() {
+		scenario.onActivity { activity ->
+			FrostedGlass.crossWindowBlurEnabled = { true }
+
+			assertNull(FrostedGlass.applyDialogFallback(activity.window))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Implements a frosted glass visual fallback for dialogs and overlays on devices where cross-window blur is unavailable (notably Samsung devices). This ensures UI surfaces remain legible over busy wallpapers by applying a translucent tint with fine grain texture.

## Key Changes
- **New `FrostedFallbackDrawable` class**: Extracted from `Wallpaper.kt` into a reusable, standalone component that renders a translucent tint with procedurally-generated grain texture. Supports optional rounded corners for dialog surfaces.
- **New `FrostedGlass` object**: Provides `applyDialogFallback()` to conditionally apply the frosted effect when cross-window blur is unavailable. Includes injectable `crossWindowBlurEnabled` predicate for testability.
- **Updated dialog implementations**: Applied frosted fallback to:
  - `PreferencesActivity`: ListPreference dialogs via new `FrostedListPreferenceDialogFragment`
  - `Lens`: Error/info dialogs
  - `ExceptionHandler`: Exception dialogs
  - `WidgetPickerDialog`: Widget picker surface
- **Comprehensive test coverage**: Added unit tests for `FrostedFallbackDrawable` rendering and `FrostedGlass` conditional logic.

## Implementation Details
- The grain texture is generated once per process using a linear congruential generator (LCG) and cached as a `BitmapShader` for efficient reuse
- `FrostedFallbackDrawable` supports animation via the `fraction` property, allowing smooth fade-in/out effects
- The fallback is only applied when blur is unavailable, maintaining the original blurred appearance on capable devices
- Dialog corner radius is read from theme resources to match the `ModernDialogTheme` card styling

https://claude.ai/code/session_01Fbi5KnCdL2JjRSrqAjWDv4