### PR TITLE
Improve widget resize handles and swipe gesture handling

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -288,6 +288,11 @@ public class HomeActivity extends AppCompatActivity
 
 				return handled;
 			});
+			// Swipe-ups that start on a widget are handed off here: the widget
+			// consumes the touch so they never reach the listener above, so the
+			// pager forwards them to the same gestures (priming with the DOWN) //
+			vgWidgets.setSwipeGestureForwarder (event ->
+					this.gestures != null && this.gestures.onHomeTouchEvent (event));
 
 			// Per-desktop pins: the launcher morphs/rebuilds as the desktops are
 			// swiped between. The desktop count follows widgets + pins via the

--- a/app/src/main/java/be/robinj/distrohopper/home/HomeGestureController.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/HomeGestureController.kt
@@ -144,8 +144,10 @@ class HomeGestureController(
 		val dx = ev.x - this.downX
 		val dy = ev.y - this.downY
 
-		if (abs(dx) > this.touchSlop && abs(dx) > abs(dy) * 2F) {
-			// Sideways: pan between the widget desktops //
+		if (!this.pager.hasEditModeChild()
+				&& abs(dx) > this.touchSlop && abs(dx) > abs(dy) * 2F) {
+			// Sideways: pan between the widget desktops (not while a widget is
+			// being edited — one less gesture to compete with the resize handles) //
 			this.pager.panBegin()
 			this.state = State.TRACKING_PAGES
 			this.downX = ev.x // Track from where the swipe was recognised //

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
@@ -106,6 +106,48 @@ class WidgetContainer internal constructor(
 		this.widgetHost.removeWidget(this)
 	}
 
+	override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+		super.onSizeChanged(w, h, oldw, oldh)
+		this.updateEdgeTouchTargets(w, h)
+	}
+
+	/**
+	 * Widen each resize handle's *touch* target (not its visible pill, which is a
+	 * centred child) so the edges are easier to grab. Capped at a third of the
+	 * relevant dimension so the two opposing edges never meet — a central
+	 * move-zone (the overlay) always survives, even on a one-cell widget.
+	 */
+	private fun updateEdgeTouchTargets(w: Int, h: Int) {
+		if (w <= 0 || h <= 0) {
+			return
+		}
+
+		val maxTarget = (EDGE_TOUCH_TARGET_DP * this.resources.displayMetrics.density).toInt()
+		val horizontalThickness = min(maxTarget, h / 3)
+		val verticalThickness = min(maxTarget, w / 3)
+
+		this.edgeTop.updateLayoutHeight(horizontalThickness)
+		this.edgeBottom.updateLayoutHeight(horizontalThickness)
+		this.edgeLeft.updateLayoutWidth(verticalThickness)
+		this.edgeRight.updateLayoutWidth(verticalThickness)
+	}
+
+	private fun View.updateLayoutHeight(height: Int) {
+		val lp = this.layoutParams
+		if (lp.height != height) {
+			lp.height = height
+			this.layoutParams = lp
+		}
+	}
+
+	private fun View.updateLayoutWidth(width: Int) {
+		val lp = this.layoutParams
+		if (lp.width != width) {
+			lp.width = width
+			this.layoutParams = lp
+		}
+	}
+
 	override fun onTouch(view: View, e: MotionEvent): Boolean {
 		val parent = this.parent as? WidgetsContainer ?: return false
 		val lp = this.layoutParams as WidgetsContainer.LayoutParams
@@ -341,5 +383,10 @@ class WidgetContainer internal constructor(
 
 		this.widgetHost.persist()
 		parent.requestLayout()
+	}
+
+	companion object {
+		/** Largest resize-handle touch target (the thin dimension), in dp. */
+		private const val EDGE_TOUCH_TARGET_DP = 48F
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsPager.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsPager.kt
@@ -70,6 +70,14 @@ class WidgetsPager @JvmOverloads constructor(
 	/** Fired once a desktop is settled on (the launcher rebuilds to it). */
 	var onPageSettled: PageSettledListener? = null
 
+	/**
+	 * Feeds a touch stream to the home-screen swipe gestures (HomeActivity wires
+	 * it to HomeGestureController). Used to hand off swipe-ups that start on a
+	 * widget so the dash opens just as it does on empty desktop space — see
+	 * [onInterceptTouchEvent]. Sideways pans are still handled here directly.
+	 */
+	var swipeGestureForwarder: ((MotionEvent) -> Boolean)? = null
+
 	private var insetLeft = 0
 	private var insetTop = 0
 	private var insetRight = 0
@@ -86,6 +94,7 @@ class WidgetsPager @JvmOverloads constructor(
 	private var panning = false
 	private var panStartScrollX = 0
 	private var velocityTracker: VelocityTracker? = null
+	private var downEvent: MotionEvent? = null
 
 	/*
 	 * A row of dots overlaid on the desktops while they are being swiped
@@ -233,6 +242,7 @@ class WidgetsPager @JvmOverloads constructor(
 				this.clearGesture()
 				this.downX = ev.x
 				this.downY = ev.y
+				this.downEvent = MotionEvent.obtain(ev)
 				this.velocityTracker = VelocityTracker.obtain().also { it.addMovement(ev) }
 			}
 			MotionEvent.ACTION_MOVE -> {
@@ -240,11 +250,25 @@ class WidgetsPager @JvmOverloads constructor(
 
 				val dx = ev.x - this.downX
 				val dy = ev.y - this.downY
-				if (!this.hasEditModeChild()
-						&& abs(dx) > this.touchSlop && abs(dx) > abs(dy) * 2F) {
+				if (this.hasEditModeChild()) {
+					// A widget is being resized/moved: leave its handles the touches //
+					return false
+				}
+
+				if (abs(dx) > this.touchSlop && abs(dx) > abs(dy) * 2F) {
 					this.panning = true
 					this.panOriginX = ev.x
 					this.panBegin()
+
+					return true
+				}
+
+				// Swipe up that started on a widget: hand the stream to the home
+				// gestures (priming them with the original DOWN they never saw, since
+				// the widget consumed it) so the dash opens just like on empty space //
+				if (abs(dy) > this.touchSlop && abs(dy) > abs(dx) * 2F && dy < 0F) {
+					this.downEvent?.let { this.swipeGestureForwarder?.invoke(it) }
+					this.recycleDownEvent()
 
 					return true
 				}
@@ -287,6 +311,12 @@ class WidgetsPager @JvmOverloads constructor(
 		this.panning = false
 		this.velocityTracker?.recycle()
 		this.velocityTracker = null
+		this.recycleDownEvent()
+	}
+
+	private fun recycleDownEvent() {
+		this.downEvent?.recycle()
+		this.downEvent = null
 	}
 
 	//# Aggregates over the pages #//


### PR DESCRIPTION
## Summary
This PR enhances the widget editing experience by making resize handles easier to grab and improving gesture handling when swiping on widgets. It ensures that upward swipes initiated on widgets properly trigger the home gesture (opening the dash), while sideways pans are still handled by the pager.

## Key Changes

- **Dynamic resize handle touch targets**: Added `onSizeChanged()` callback to `WidgetContainer` that dynamically adjusts the touch target sizes of resize handles (top, bottom, left, right edges) based on the container dimensions. Touch targets are capped at 48dp or one-third of the relevant dimension, whichever is smaller, ensuring the central move zone always remains accessible.

- **Swipe gesture forwarding**: Implemented a `swipeGestureForwarder` callback in `WidgetsPager` that allows upward swipes starting on widgets to be forwarded to the home gesture controller, enabling the dash to open just as it does on empty desktop space.

- **Improved touch event handling**: Modified `WidgetsPager.onTouchEvent()` to:
  - Preserve the original DOWN event when a touch stream begins on a widget
  - Detect upward swipes (vertical motion > horizontal) and forward them to the gesture controller
  - Properly recycle the stored DOWN event to prevent memory leaks
  - Return early when a widget is in edit mode to avoid gesture conflicts

- **Gesture conflict prevention**: Updated `HomeGestureController` to check if a widget is being edited before handling sideways pans, reducing gesture competition with resize handles.

- **Wiring in HomeActivity**: Connected the pager's swipe gesture forwarder to the home gesture controller so forwarded events are processed correctly.

## Notable Implementation Details

- Touch targets use density-aware conversion (DP to pixels) for consistent sizing across devices
- Layout parameter updates are optimized to only trigger layout when dimensions actually change
- The central overlay/move zone is guaranteed to survive even on single-cell widgets through the one-third cap
- DOWN events are properly obtained and recycled to prevent memory leaks

https://claude.ai/code/session_0154Q9ym9RGKPq61ZUieQp3p