### PR TITLE
Allow apps to be pinned to desktops, like widgets

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/AppManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/AppManager.java
@@ -242,6 +242,10 @@ public class AppManager implements Iterable<App>
 		this.getBinder ().removePinnedAppView (app);
 		this.savePinnedApps ();
 
+		// And remove its desktop pin, if any //
+		if (this.parent.getDesktopAppHost () != null)
+			this.parent.getDesktopAppHost ().unpinFromAllDesktops (app);
+
 		this.getBinder ().notifyDashAdapterChanged ();
 
 		return modified;

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -73,6 +73,7 @@ import be.robinj.distrohopper.desktop.launcher.AppLauncher;
 import be.robinj.distrohopper.desktop.launcher.LauncherDragListener;
 import be.robinj.distrohopper.desktop.launcher.TrashDragListener;
 import be.robinj.distrohopper.desktop.launcher.service.LauncherService;
+import be.robinj.distrohopper.widgets.DesktopAppHost;
 import be.robinj.distrohopper.widgets.WidgetHost;
 import be.robinj.distrohopper.widgets.WidgetHost_LongClickListener;
 import be.robinj.distrohopper.widgets.WidgetsContainer_DragListener;
@@ -85,6 +86,7 @@ public class HomeActivity extends AppCompatActivity
 	private AppManager apps;
 	private AppWidgetManager widgetManager;
 	private WidgetHost widgetHost;
+	private DesktopAppHost desktopAppHost;
 
 	private ViewFinder viewFinder;
 
@@ -659,6 +661,11 @@ public class HomeActivity extends AppCompatActivity
 		return this.apps;
 	}
 
+	public DesktopAppHost getDesktopAppHost ()
+	{
+		return this.desktopAppHost;
+	}
+
 	public ViewFinder getViewFinder() {
 		return this.viewFinder;
 	}
@@ -677,11 +684,18 @@ public class HomeActivity extends AppCompatActivity
 			// Runs searches on the activity's lifecycleScope + dispatchers, like StartupLoader //
 			this.lenses.setSearchLoader (new SearchLoader (this, DependencyContainer.of (this).getDispatchers ()));
 
-			// Desktops is the authority for how many desktops exist (widgets + pins);
-			// wire it now that the app model is loaded and re-derive the desktop row //
-			this.desktops = new Desktops (this.widgetHost, this.apps);
+			// Desktop-pinned apps: own host alongside the widget host. Created now,
+			// not in onCreate, because their stored keys only resolve once the app
+			// model has loaded (AppRepository.installedAppsMap) //
 			final WidgetsPager vgWidgets = this.viewFinder.get (R.id.vgWidgets);
+			this.desktopAppHost = new DesktopAppHost (this, vgWidgets, this.apps.getRepository ());
+
+			// Desktops is the authority for how many desktops exist (widgets + pins
+			// + desktop apps); wire it now that the app model is loaded //
+			this.desktops = new Desktops (this.widgetHost, this.apps, this.desktopAppHost);
 			vgWidgets.setOccupiedDesktopSupplier (() -> this.desktops.highestOccupiedDesktop ());
+
+			this.desktopAppHost.restore ();
 			vgWidgets.pagesChanged ();
 
 			EditText etDashSearch = this.viewFinder.get(R.id.etDashSearch);

--- a/app/src/main/java/be/robinj/distrohopper/desktop/launcher/AppLauncherDragListener.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/launcher/AppLauncherDragListener.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import be.robinj.distrohopper.App;
 import be.robinj.distrohopper.AppManager;
 import be.robinj.distrohopper.ExceptionHandler;
+import be.robinj.distrohopper.widgets.DesktopAppView;
 import be.robinj.distrohopper.widgets.WidgetContainer;
 
 /**
@@ -27,8 +28,11 @@ public class AppLauncherDragListener implements ViewGroup.OnDragListener
 		try
 		{
 			// Widget drags are handled by WidgetsContainer_DragListener and the trash's
-			// own listener //
-			if (event.getLocalState () instanceof WidgetContainer)
+			// own listener. A desktop app dragged onto the bar is a move-to-bar,
+			// handled by the bar container's LauncherDragListener (and the trash) —
+			// not here, where it would be misread as a reorder of this icon //
+			if (event.getLocalState () instanceof WidgetContainer
+					|| event.getLocalState () instanceof DesktopAppView)
 				return false;
 
 			AppLauncher appLauncher = (AppLauncher) view;

--- a/app/src/main/java/be/robinj/distrohopper/desktop/launcher/LauncherDragListener.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/launcher/LauncherDragListener.java
@@ -6,6 +6,8 @@ import android.view.ViewGroup;
 
 import be.robinj.distrohopper.AppManager;
 import be.robinj.distrohopper.ExceptionHandler;
+import be.robinj.distrohopper.widgets.DesktopAppHost;
+import be.robinj.distrohopper.widgets.DesktopAppView;
 import be.robinj.distrohopper.widgets.WidgetContainer;
 
 /**
@@ -29,6 +31,33 @@ public class LauncherDragListener implements ViewGroup.OnDragListener
 			// own listener; reacting here would hide the trash mid-drag //
 			if (event.getLocalState () instanceof WidgetContainer)
 				return false;
+
+			// A desktop app dragged onto the bar is a move: unpin it from the
+			// desktop and pin it to the bar. The reorder placeholder machinery
+			// doesn't apply (it was never a bar icon), so handle it separately //
+			if (event.getLocalState () instanceof DesktopAppView)
+			{
+				final DesktopAppView appView = (DesktopAppView) event.getLocalState ();
+
+				switch (event.getAction ())
+				{
+					case DragEvent.ACTION_DROP:
+						final DesktopAppHost host = this.appManager.getParent ().getDesktopAppHost ();
+						if (host != null)
+						{
+							host.remove (appView);
+							this.appManager.pin (appView.getApp (), true, false, true);
+						}
+						this.appManager.stoppedDraggingPinnedApp ();
+						break;
+					case DragEvent.ACTION_DRAG_ENDED:
+						// Restores the bar chrome (trash/bfb) once the drag is over //
+						view.post (() -> this.appManager.stoppedDraggingPinnedApp ());
+						break;
+				}
+
+				return true;
+			}
 
 			switch (event.getAction ())
 			{

--- a/app/src/main/java/be/robinj/distrohopper/desktop/launcher/TrashDragListener.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/launcher/TrashDragListener.java
@@ -10,6 +10,8 @@ import be.robinj.distrohopper.AppManager;
 import be.robinj.distrohopper.ExceptionHandler;
 import be.robinj.distrohopper.HomeActivity;
 import be.robinj.distrohopper.home.LauncherBarBinder;
+import be.robinj.distrohopper.widgets.DesktopAppHost;
+import be.robinj.distrohopper.widgets.DesktopAppView;
 import be.robinj.distrohopper.widgets.WidgetContainer;
 
 /**
@@ -48,6 +50,12 @@ public class TrashDragListener implements ViewGroup.OnDragListener
 					if (event.getLocalState () instanceof WidgetContainer)
 					{
 						((WidgetContainer) event.getLocalState ()).removeWidget ();
+					}
+					else if (event.getLocalState () instanceof DesktopAppView)
+					{
+						final DesktopAppHost host = this.activity.getDesktopAppHost ();
+						if (host != null)
+							host.remove ((DesktopAppView) event.getLocalState ());
 					}
 					else if (event.getLocalState () instanceof App)
 					{

--- a/app/src/main/java/be/robinj/distrohopper/home/Desktops.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/Desktops.kt
@@ -1,15 +1,17 @@
 package be.robinj.distrohopper.home
 
 import be.robinj.distrohopper.AppManager
+import be.robinj.distrohopper.widgets.DesktopAppHost
 import be.robinj.distrohopper.widgets.WidgetHost
 import kotlin.math.max
 
 /**
- * The single authority over the home screen's desktops, spanning their two
- * owners — widgets ([WidgetHost]) and per-desktop pinned launcher apps
- * ([AppManager]) — which share one 0-based desktop index. It derives how many
- * desktops exist (so `WidgetsPager` doesn't reach into the app model) and owns
- * the structural operations that must touch both at once.
+ * The single authority over the home screen's desktops, spanning their three
+ * owners — widgets ([WidgetHost]), per-desktop pinned launcher apps
+ * ([AppManager]) and apps pinned to the desktop itself ([DesktopAppHost]) —
+ * which share one 0-based desktop index. It derives how many desktops exist (so
+ * `WidgetsPager` doesn't reach into the app model) and owns the structural
+ * operations that must touch all of them at once.
  *
  * There is no delete-desktop UI yet; [deleteDesktop] is the data-layer
  * operation that one will call, kept here so widgets and pins can never drift
@@ -18,18 +20,22 @@ import kotlin.math.max
 class Desktops(
 	private val widgetHost: WidgetHost,
 	private val appManager: AppManager,
+	private val desktopAppHost: DesktopAppHost,
 ) {
-	/** Highest occupied desktop index across widgets and pins (or -1 when empty). */
+	/** Highest occupied desktop index across widgets, pins and desktop apps (or -1 when empty). */
 	fun highestOccupiedDesktop(): Int =
-		max(this.widgetHost.highestWidgetDesktop(), this.appManager.highestPinnedDesktop())
+		max(
+			max(this.widgetHost.highestWidgetDesktop(), this.appManager.highestPinnedDesktop()),
+			this.desktopAppHost.highestDesktop())
 
 	/**
-	 * Deletes desktop [page]: removes its widgets and its pinned apps, and shifts
-	 * every higher desktop down by one.
+	 * Deletes desktop [page]: removes its widgets, its pinned apps and its desktop
+	 * apps, and shifts every higher desktop down by one.
 	 */
 	fun deleteDesktop(page: Int) {
 		this.appManager.removePinnedDesktop(page)
 		this.appManager.savePinnedApps()
+		this.desktopAppHost.removeDesktopPage(page)
 		// Re-derives the pager (which reads the now-updated pinned desktops too) //
 		this.widgetHost.removeWidgetPage(page)
 	}

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preferences.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preferences.java
@@ -8,6 +8,7 @@ public class Preferences {
 	public static final String PINNED_APPS = "pinned";
 	public static final String LENSES = "lenses";
 	public static final String WIDGETS = "widgets";
+	public static final String DESKTOP_APPS = "desktop_apps";
 	public static final String APP_USAGE = "app_usage";
 
 	public static SharedPreferences getSharedPreferences(final Context context) {

--- a/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppHost.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppHost.kt
@@ -1,0 +1,259 @@
+package be.robinj.distrohopper.widgets
+
+import be.robinj.distrohopper.App
+import be.robinj.distrohopper.AppRepository
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.dev.Log
+
+/**
+ * Owns the apps pinned to the desktops — the app-world counterpart of
+ * [WidgetHost]. Desktop apps live as 1x1 [DesktopAppView] children inside the
+ * same [WidgetsContainer] grid as the widgets, one page per desktop, and are
+ * persisted independently of both the widgets and the launcher-bar pins.
+ *
+ * The single source of truth for a desktop app's position is its view's
+ * [WidgetsContainer.LayoutParams] and the index of the page it sits in (so a
+ * view moved between pages re-pages itself on [persist], exactly like widgets).
+ *
+ * Invariant: **at most one desktop pin per app** ([App.getProfileScopedKey]),
+ * across all desktops. A launcher-bar pin for the same app is allowed and
+ * independent (a separate store). Enforced in one place — [pinAt].
+ */
+class DesktopAppHost(
+	private val parent: HomeActivity,
+	private val vgWidgets: WidgetsPager,
+	private val repository: AppRepository,
+) {
+	private val persistence = DesktopAppPersistence(parent.applicationContext)
+
+	/**
+	 * Recreates the views for every persisted desktop app, resolving each against
+	 * the installed apps: prunes the ones whose app is gone, drops duplicate keys
+	 * (keeping the first), and re-packs any whose saved cell now collides with a
+	 * widget or another desktop app. Must run once the app model has loaded (the
+	 * keys only resolve through [AppRepository.installedAppsMap]).
+	 */
+	fun restore() {
+		val appMap = this.repository.installedAppsMap()
+		val seen = HashSet<String>()
+		var changed = false
+
+		for (layout in this.persistence.load()) {
+			val app = appMap[layout.key]
+			if (app == null) {
+				changed = true // Pruned: the app is no longer installed //
+
+				Log.getInstance().w(this.javaClass.simpleName, "Pruned stale desktop app: ${layout.key}")
+
+				continue
+			}
+
+			if (! seen.add(layout.key)) {
+				changed = true // De-duplicated: this key is already placed //
+
+				continue
+			}
+
+			val page = layout.page.coerceIn(0, WidgetsPager.MAX_PAGES - 1)
+			val container = this.vgWidgets.pageAt(page)
+			val occupied = container.collectOccupied(null)
+
+			val placed = if (WidgetGrid.fits(occupied, WidgetLayout(
+					DesktopAppLayout.NO_WIDGET_ID, layout.col, layout.row, 1, 1))) {
+				DesktopAppLayout(layout.key, layout.col, layout.row, page)
+			} else {
+				// The saved cell is taken (e.g. by a widget restored before us):
+				// re-pack into the first free cell, or drop it if the page is full //
+				val free = WidgetGrid.findFreeRect(occupied, 1, 1)
+				changed = true
+
+				if (free == null) {
+					Log.getInstance().w(this.javaClass.simpleName,
+						"No room for desktop app on page $page: ${layout.key}")
+
+					continue
+				}
+
+				DesktopAppLayout(layout.key, free.col, free.row, page)
+			}
+
+			this.addAppView(app, placed)
+		}
+
+		this.vgWidgets.pagesChanged()
+
+		if (changed) {
+			this.persist()
+		}
+	}
+
+	/**
+	 * Pins [app] onto desktop [page] at (or near) ([col], [row]). Enforces the
+	 * single-copy invariant: any existing desktop pin for the same app — on any
+	 * desktop — is removed first, so this both *adds* a new pin and *relocates* an
+	 * existing one (never duplicates). Falls back to the first free cell if the
+	 * requested one is taken; a no-op returning false if the desktop is full.
+	 */
+	fun pinAt(app: App, col: Int, row: Int, page: Int): Boolean {
+		// Cross-desktop single copy: drop any existing pin for this app first, so
+		// the dropped cell (which may be the one it is vacating) is free again //
+		this.removeViewsForKey(app.profileScopedKey)
+
+		val targetPage = page.coerceIn(0, WidgetsPager.MAX_PAGES - 1)
+		val container = this.vgWidgets.pageAt(targetPage)
+		val occupied = container.collectOccupied(null)
+
+		val candidate = WidgetLayout(DesktopAppLayout.NO_WIDGET_ID, col, row, 1, 1)
+		val target = if (WidgetGrid.fits(occupied, candidate)) {
+			candidate
+		} else {
+			WidgetGrid.findFreeRect(occupied, 1, 1)
+		} ?: return false
+
+		this.addAppView(app, DesktopAppLayout(app.profileScopedKey, target.col, target.row, targetPage))
+
+		this.persist()
+		this.vgWidgets.pagesChanged()
+
+		return true
+	}
+
+	/**
+	 * Moves [view] to ([col], [row]) on its current desktop, keeping it put if the
+	 * cell is taken by a widget or another desktop app.
+	 */
+	fun moveTo(view: DesktopAppView, col: Int, row: Int) {
+		val container = view.parent as? WidgetsContainer ?: return
+		val lp = view.layoutParams as WidgetsContainer.LayoutParams
+
+		val candidate = WidgetLayout(DesktopAppLayout.NO_WIDGET_ID, col, row, 1, 1)
+		if (! WidgetGrid.fits(container.collectOccupied(view), candidate)) {
+			return // Revert to the previous position //
+		}
+
+		lp.col = col
+		lp.row = row
+
+		container.requestLayout()
+		this.persist()
+	}
+
+	/** Removes [view] from its desktop (e.g. dropped on the trash). */
+	fun remove(view: DesktopAppView) {
+		(view.parent as? WidgetsContainer)?.removeView(view)
+
+		this.persist()
+		this.vgWidgets.pagesChanged()
+	}
+
+	/**
+	 * Removes every desktop app on [page] and shifts the apps on higher desktops
+	 * down by one, for desktop deletion — mirrors [WidgetHost.removeWidgetPage] so
+	 * widgets and desktop apps shift together. Coordinated by
+	 * [be.robinj.distrohopper.home.Desktops].
+	 */
+	fun removeDesktopPage(page: Int) {
+		if (page in 0 until this.vgWidgets.childCount) {
+			val container = this.vgWidgets.pageAt(page)
+			for (view in this.appsOf(container)) {
+				container.removeView(view)
+			}
+
+			for (higher in (page + 1) until this.vgWidgets.childCount) {
+				val from = this.vgWidgets.pageAt(higher)
+				val to = this.vgWidgets.pageAt(higher - 1)
+				for (view in this.appsOf(from)) {
+					val layoutParams = view.layoutParams
+					from.removeView(view)
+					to.addView(view, layoutParams)
+				}
+			}
+		}
+
+		this.persist()
+		this.vgWidgets.pagesChanged()
+	}
+
+	/** Removes [app]'s desktop pin from every desktop (e.g. when it is uninstalled). */
+	fun unpinFromAllDesktops(app: App) {
+		if (this.removeViewsForKey(app.profileScopedKey)) {
+			this.persist()
+			this.vgWidgets.pagesChanged()
+		}
+	}
+
+	fun isPinnedOnDesktop(app: App): Boolean = this.viewForKey(app.profileScopedKey) != null
+
+	/** Highest desktop holding a pinned app (or -1), for the `home/Desktops` coordinator. */
+	fun highestDesktop(): Int {
+		for (i in this.vgWidgets.childCount - 1 downTo 0) {
+			val container = this.vgWidgets.pageAt(i)
+			for (j in 0 until container.childCount) {
+				if (container.getChildAt(j) is DesktopAppView) {
+					return i
+				}
+			}
+		}
+
+		return -1
+	}
+
+	/**
+	 * Saves the current placements, reading each app's position from its view's
+	 * layout params and the index of the page it sits in — so views moved between
+	 * pages (page-shift on delete) re-page themselves automatically.
+	 */
+	fun persist() {
+		val layouts = mutableListOf<DesktopAppLayout>()
+
+		for (page in 0 until this.vgWidgets.childCount) {
+			val container = this.vgWidgets.pageAt(page)
+			for (view in this.appsOf(container)) {
+				val lp = view.layoutParams as WidgetsContainer.LayoutParams
+				layouts.add(DesktopAppLayout(view.key, lp.col, lp.row, page))
+			}
+		}
+
+		this.persistence.save(layouts)
+	}
+
+	private fun addAppView(app: App, layout: DesktopAppLayout) {
+		val view = DesktopAppView(this.parent, app, layout)
+		this.vgWidgets.pageAt(layout.page).addView(
+			view, WidgetsContainer.LayoutParams(layout.col, layout.row, 1, 1))
+	}
+
+	/** @return whether any view was removed. */
+	private fun removeViewsForKey(key: String): Boolean {
+		var removed = false
+
+		for (page in 0 until this.vgWidgets.childCount) {
+			val container = this.vgWidgets.pageAt(page)
+			for (i in container.childCount - 1 downTo 0) {
+				val child = container.getChildAt(i) as? DesktopAppView ?: continue
+				if (child.key == key) {
+					container.removeView(child)
+					removed = true
+				}
+			}
+		}
+
+		return removed
+	}
+
+	fun viewForKey(key: String): DesktopAppView? {
+		for (page in 0 until this.vgWidgets.childCount) {
+			val container = this.vgWidgets.pageAt(page)
+			for (view in this.appsOf(container)) {
+				if (view.key == key) {
+					return view
+				}
+			}
+		}
+
+		return null
+	}
+
+	private fun appsOf(container: WidgetsContainer): List<DesktopAppView> =
+		(0 until container.childCount).mapNotNull { container.getChildAt(it) as? DesktopAppView }
+}

--- a/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppLayout.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppLayout.kt
@@ -1,0 +1,48 @@
+package be.robinj.distrohopper.widgets
+
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Position of an app pinned to the home screen grid, plus which desktop (page)
+ * it lives on. Unlike a widget, a desktop app always occupies a single 1x1
+ * cell, so it has no span; it is identified by its app's [App.profileScopedKey]
+ * (so the same package in a different profile stays distinct).
+ *
+ * @see WidgetLayout for the widget equivalent.
+ */
+data class DesktopAppLayout @JvmOverloads constructor(
+	@JvmField var key: String,
+	@JvmField var col: Int,
+	@JvmField var row: Int,
+	@JvmField var page: Int = 0,
+) {
+	/**
+	 * The 1x1 grid rectangle this app occupies, as a [WidgetLayout] (with no
+	 * widget id), so it can be fed to [WidgetGrid]'s collision maths alongside
+	 * the real widgets.
+	 */
+	fun toGridRect(): WidgetLayout = WidgetLayout(NO_WIDGET_ID, this.col, this.row, 1, 1, this.page)
+
+	@Throws(JSONException::class)
+	fun toJson(): JSONObject = JSONObject().apply {
+		put("key", key)
+		put("col", col)
+		put("row", row)
+		put("page", page)
+	}
+
+	companion object {
+		/** The [WidgetLayout.appWidgetId] used for a desktop app's grid rectangle. */
+		const val NO_WIDGET_ID = -1
+
+		@JvmStatic
+		@Throws(JSONException::class)
+		fun fromJson(json: JSONObject): DesktopAppLayout = DesktopAppLayout(
+			json.getString("key"),
+			json.getInt("col"),
+			json.getInt("row"),
+			json.optInt("page", 0),
+		)
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppPersistence.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppPersistence.kt
@@ -1,0 +1,59 @@
+package be.robinj.distrohopper.widgets
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONException
+import be.robinj.distrohopper.dev.Log
+import be.robinj.distrohopper.preferences.Preferences
+
+/**
+ * Saves and loads desktop-pinned app placements as JSON in a dedicated
+ * preferences file, kept separate from the widgets and the launcher-bar pins.
+ *
+ * @see WidgetPersistence for the widget equivalent.
+ */
+class DesktopAppPersistence(context: Context) {
+	private val prefs = Preferences.getSharedPreferences(context, Preferences.DESKTOP_APPS)
+
+	fun save(layouts: List<DesktopAppLayout>) {
+		val json = JSONArray()
+
+		for (layout in layouts) {
+			try {
+				json.put(layout.toJson())
+			} catch (ex: JSONException) {
+				Log.getInstance().e(this.javaClass.simpleName,
+					"Failed to serialise desktop app ${layout.key}")
+			}
+		}
+
+		this.prefs.edit().putString(KEY, json.toString()).apply()
+	}
+
+	fun load(): List<DesktopAppLayout> {
+		val layouts = mutableListOf<DesktopAppLayout>()
+		val str = this.prefs.getString(KEY, null) ?: return layouts
+
+		try {
+			val json = JSONArray(str)
+
+			for (i in 0 until json.length()) {
+				try {
+					layouts.add(DesktopAppLayout.fromJson(json.getJSONObject(i)))
+				} catch (ex: JSONException) {
+					Log.getInstance().e(this.javaClass.simpleName,
+						"Skipping malformed desktop app entry: ${ex.message}")
+				}
+			}
+		} catch (ex: JSONException) {
+			Log.getInstance().e(this.javaClass.simpleName,
+				"Failed to parse saved desktop apps: ${ex.message}")
+		}
+
+		return layouts
+	}
+
+	companion object {
+		private const val KEY = "desktop_apps"
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppView.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppView.kt
@@ -1,0 +1,84 @@
+package be.robinj.distrohopper.widgets
+
+import android.content.ClipData
+import android.content.Context
+import android.view.MotionEvent
+import android.view.View
+import be.robinj.distrohopper.App
+import be.robinj.distrohopper.ExceptionHandler
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.R
+import be.robinj.distrohopper.home.LauncherBarBinder
+
+/**
+ * An app pinned to a desktop: a label-bearing icon living in a single
+ * [WidgetsContainer] grid cell — the app-world counterpart of [WidgetContainer].
+ * Built on the base [be.robinj.distrohopper.desktop.AppLauncher] (the
+ * label-capable one) rather than the no-label launcher-bar subclass, so a
+ * desktop app always shows its label.
+ *
+ * Tap launches the app; long-press starts a system drag with the view itself as
+ * the drag's local state (mirroring [WidgetContainer]), so the existing drag
+ * listeners can recognise it with a single `instanceof` and let it be moved on
+ * the grid, moved to the launcher bar, or dropped on the trash.
+ */
+class DesktopAppView(
+	context: Context,
+	private val pinnedApp: App,
+	@JvmField var layout: DesktopAppLayout,
+) : be.robinj.distrohopper.desktop.AppLauncher(
+	context, pinnedApp, R.layout.widget_desktop_applauncher, R.layout.widget_desktop_applauncher,
+) {
+	// Where the finger grabbed the icon, relative to its top-left corner; used
+	// by WidgetsContainer_DragListener to position the landing indicator //
+	internal var dragGrabOffsetX = 0
+	internal var dragGrabOffsetY = 0
+
+	private var lastDownRawX = 0F
+	private var lastDownRawY = 0F
+
+	val key: String get() = this.layout.key
+
+	init {
+		this.isClickable = true
+		this.isLongClickable = true
+
+		this.setOnClickListener {
+			try {
+				this.pinnedApp.launch()
+			} catch (ex: Exception) {
+				ExceptionHandler(ex).show(this.context)
+			}
+		}
+		this.setOnLongClickListener {
+			this.startMoveDrag()
+			true
+		}
+	}
+
+	// Remember where the finger went down so the long-press drag can offset the
+	// landing indicator from the icon's corner (a long click carries no coords) //
+	override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+		if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+			this.lastDownRawX = ev.rawX
+			this.lastDownRawY = ev.rawY
+		}
+
+		return super.dispatchTouchEvent(ev)
+	}
+
+	private fun startMoveDrag() {
+		val parent = this.parent as? WidgetsContainer ?: return
+
+		val location = IntArray(2)
+		parent.getLocationOnScreen(location)
+		this.dragGrabOffsetX = (this.lastDownRawX - location[0]).toInt() - this.left
+		this.dragGrabOffsetY = (this.lastDownRawY - location[1]).toInt() - this.top
+
+		val clip = ClipData.newPlainText("desktopApp", this.key)
+		this.startDragAndDrop(clip, View.DragShadowBuilder(this), this, 0)
+
+		// Not via appManager: keep this view-only, like WidgetContainer's drag //
+		(this.context as? HomeActivity)?.let { LauncherBarBinder.startedDragging(it) }
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
@@ -311,7 +311,7 @@ class WidgetContainer internal constructor(
 
 		val candidate = WidgetLayout(this.appWidgetId, col, row, colSpan, rowSpan)
 
-		if (!WidgetGrid.fits(parent.collectLayouts(this), candidate)) {
+		if (!WidgetGrid.fits(parent.collectOccupied(this), candidate)) {
 			return // Revert to the previous position //
 		}
 
@@ -332,7 +332,7 @@ class WidgetContainer internal constructor(
 
 		val candidate = WidgetLayout(this.appWidgetId, col, row, lp.colSpan, lp.rowSpan)
 
-		if (!WidgetGrid.fits(parent.collectLayouts(this), candidate)) {
+		if (!WidgetGrid.fits(parent.collectOccupied(this), candidate)) {
 			return // Revert to the previous position //
 		}
 

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetHost.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetHost.kt
@@ -83,7 +83,8 @@ class WidgetHost(
 		// on purpose; only the grid bounds and overlaps are still enforced //
 		val unrestricted = this.allowUnsupportedResize()
 
-		val kept = ArrayList<WidgetLayout>()
+		// Seed with the desktop apps' cells so re-clamped widgets avoid them //
+		val kept = ArrayList<WidgetLayout>(container.collectAppCells(null))
 		var changed = false
 
 		for (i in 0 until container.childCount) {
@@ -329,7 +330,7 @@ class WidgetHost(
 			}
 
 			val layout = WidgetGrid.findFreeRect(
-				pageContainer.collectLayouts(null), spans.first, spans.second)
+				pageContainer.collectOccupied(null), spans.first, spans.second)
 
 			if (layout == null) {
 				this.deleteAppWidgetId(appWidgetId)

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer.java
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer.java
@@ -229,6 +229,47 @@ public class WidgetsContainer extends ViewGroup
 		return layouts;
 	}
 
+	/**
+	 * Grid cells occupied by the desktop-pinned apps (1x1 each), optionally
+	 * excluding one (e.g. the one being moved). The app world's counterpart to
+	 * {@link #collectLayouts(View)}; the returned {@link WidgetLayout}s carry no
+	 * widget id ({@link DesktopAppLayout#NO_WIDGET_ID}) — only their rectangle
+	 * matters for collision.
+	 */
+	public List<WidgetLayout> collectAppCells (final View exclude)
+	{
+		final List<WidgetLayout> layouts = new ArrayList<> ();
+
+		for (int i = 0; i < this.getChildCount (); i++)
+		{
+			final View child = this.getChildAt (i);
+
+			if (child == exclude || ! (child instanceof DesktopAppView))
+				continue;
+
+			final LayoutParams lp = (LayoutParams) child.getLayoutParams ();
+
+			layouts.add (new WidgetLayout (
+				DesktopAppLayout.NO_WIDGET_ID, lp.col, lp.row, lp.colSpan, lp.rowSpan));
+		}
+
+		return layouts;
+	}
+
+	/**
+	 * Every occupied rectangle on this desktop — widgets <em>and</em> desktop
+	 * apps — so collision checks keep the two kinds from overlapping. Every
+	 * placement/move/resize path must validate against this, not the
+	 * widgets-only {@link #collectLayouts(View)}.
+	 */
+	public List<WidgetLayout> collectOccupied (final View exclude)
+	{
+		final List<WidgetLayout> layouts = this.collectLayouts (exclude);
+		layouts.addAll (this.collectAppCells (exclude));
+
+		return layouts;
+	}
+
 	public void exitEditMode ()
 	{
 		for (int i = 0; i < this.getChildCount (); i++)

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer_DragListener.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer_DragListener.kt
@@ -2,15 +2,23 @@ package be.robinj.distrohopper.widgets
 
 import android.view.DragEvent
 import android.view.View
+import be.robinj.distrohopper.App
 import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.home.LauncherBarBinder
 
 /**
- * Handles widget drops over the topmost desktop layer while the system drag shadow
- * follows the finger. The underlying widget grid draws the snapped landing target.
- * All coordinates target the pager's current desktop: the pages cannot change
- * mid-drag (the drag owns the touch stream), so that is also the desktop the
- * dragged widget came from.
+ * Handles drops over the topmost desktop layer while the system drag shadow
+ * follows the finger. The underlying widget grid draws the snapped landing
+ * target. All coordinates target the pager's current desktop: the pages cannot
+ * change mid-drag (the drag owns the touch stream), so that is also the desktop
+ * a moved widget or desktop app came from.
+ *
+ * Four kinds of drag land here, told apart by the drag's local state:
+ *  - a [WidgetContainer] — a widget being moved on its grid;
+ *  - a [DesktopAppView] — a desktop app being moved on its grid;
+ *  - an [App] — a not-yet-pinned app dragged from the dash, pinned to the desktop;
+ *  - otherwise the launcher-bar reorder clip (label = pinned index) — an existing
+ *    launcher icon, **moved** onto the desktop (pinned here, unpinned from the bar).
  */
 internal class WidgetsContainer_DragListener(
 	private val parent: HomeActivity,
@@ -20,24 +28,13 @@ internal class WidgetsContainer_DragListener(
 		get() = this.pager.currentPageContainer
 
 	override fun onDrag(view: View, event: DragEvent): Boolean {
-		val container = event.localState as? WidgetContainer ?: return false
+		val kind = this.kindOf(event) ?: return false
 
 		when (event.action) {
-			DragEvent.ACTION_DRAG_LOCATION -> {
-				val (col, row) = this.snap(view, container, event)
-				val lp = container.layoutParams as WidgetsContainer.LayoutParams
-				val candidate = WidgetLayout(
-					container.appWidgetId, col, row, lp.colSpan, lp.rowSpan)
-				val fits = WidgetGrid.fits(this.vgWidgets.collectLayouts(container), candidate)
-
-				this.vgWidgets.showMoveTarget(col, row, lp.colSpan, lp.rowSpan, fits)
-			}
-			DragEvent.ACTION_DROP -> {
-				val (col, row) = this.snap(view, container, event)
-
-				container.commitMove(col, row)
-				this.vgWidgets.hideMoveTarget()
-			}
+			// Must claim the drag here to receive LOCATION/DROP for it //
+			DragEvent.ACTION_DRAG_STARTED -> return true
+			DragEvent.ACTION_DRAG_LOCATION -> this.showTarget(view, event, kind)
+			DragEvent.ACTION_DROP -> this.commit(view, event, kind)
 			DragEvent.ACTION_DRAG_EXITED -> this.vgWidgets.hideMoveTarget()
 			DragEvent.ACTION_DRAG_ENDED -> {
 				this.vgWidgets.hideMoveTarget()
@@ -52,12 +49,33 @@ internal class WidgetsContainer_DragListener(
 		return true
 	}
 
-	private fun snap(
-		receiver: View,
-		container: WidgetContainer,
-		event: DragEvent,
-	): Pair<Int, Int> {
-		val lp = container.layoutParams as WidgetsContainer.LayoutParams
+	private fun showTarget(receiver: View, event: DragEvent, kind: Drag) {
+		val (col, row) = this.snap(receiver, event, kind)
+		val candidate = WidgetLayout(kind.widgetId, col, row, kind.colSpan, kind.rowSpan)
+		val fits = WidgetGrid.fits(this.vgWidgets.collectOccupied(kind.exclude), candidate)
+
+		this.vgWidgets.showMoveTarget(col, row, kind.colSpan, kind.rowSpan, fits)
+	}
+
+	private fun commit(receiver: View, event: DragEvent, kind: Drag) {
+		val (col, row) = this.snap(receiver, event, kind)
+		this.vgWidgets.hideMoveTarget()
+
+		when (kind) {
+			is Drag.Widget -> kind.container.commitMove(col, row)
+			is Drag.DesktopApp -> kind.host.moveTo(kind.view, col, row)
+			is Drag.DashApp -> kind.host.pinAt(kind.app, col, row, this.pager.currentPage)
+			is Drag.LauncherPin -> {
+				// Move: pin onto the desktop, then unpin from the bar //
+				if (kind.host.pinAt(kind.app, col, row, this.pager.currentPage)) {
+					this.parent.appManager?.unpin(kind.app, false)
+				}
+			}
+		}
+	}
+
+	/** Snaps the drag to a grid cell, centring the non-view (dash/launcher) drags. */
+	private fun snap(receiver: View, event: DragEvent, kind: Drag): Pair<Int, Int> {
 		val receiverLocation = IntArray(2)
 		val gridLocation = IntArray(2)
 		receiver.getLocationOnScreen(receiverLocation)
@@ -65,13 +83,86 @@ internal class WidgetsContainer_DragListener(
 
 		val gridX = event.x.toInt() + receiverLocation[0] - gridLocation[0]
 		val gridY = event.y.toInt() + receiverLocation[1] - gridLocation[1]
-		val left = gridX - container.dragGrabOffsetX - this.vgWidgets.paddingLeft
-		val top = gridY - container.dragGrabOffsetY - this.vgWidgets.paddingTop
+		val left = gridX - kind.grabOffsetX(this.vgWidgets) - this.vgWidgets.paddingLeft
+		val top = gridY - kind.grabOffsetY(this.vgWidgets) - this.vgWidgets.paddingTop
 		val col = WidgetGrid.snapToCell(
-			left, this.vgWidgets.cellWidth, WidgetGrid.COLS - lp.colSpan)
+			left, this.vgWidgets.cellWidth, WidgetGrid.COLS - kind.colSpan)
 		val row = WidgetGrid.snapToCell(
-			top, this.vgWidgets.cellHeight, WidgetGrid.ROWS - lp.rowSpan)
+			top, this.vgWidgets.cellHeight, WidgetGrid.ROWS - kind.rowSpan)
 
 		return col to row
+	}
+
+	private fun kindOf(event: DragEvent): Drag? {
+		when (val localState = event.localState) {
+			is WidgetContainer -> return Drag.Widget(localState)
+			is DesktopAppView -> {
+				val host = this.parent.desktopAppHost ?: return null
+
+				return Drag.DesktopApp(localState, host)
+			}
+			is App -> {
+				val host = this.parent.desktopAppHost ?: return null
+
+				return Drag.DashApp(localState, host)
+			}
+		}
+
+		// Otherwise it is a launcher-bar pin reorder: the clip's label is the
+		// dragged icon's index into the current desktop's pinned list //
+		val host = this.parent.desktopAppHost ?: return null
+		val appManager = this.parent.appManager ?: return null
+		val index = event.clipDescription?.label?.toString()?.toIntOrNull() ?: return null
+		val app = appManager.pinned.getOrNull(index) ?: return null
+
+		return Drag.LauncherPin(app, host)
+	}
+
+	/**
+	 * The drag's kind, carrying its grid footprint and how to find its grab
+	 * offset (the distance from the dragged thing's top-left to the finger).
+	 */
+	private sealed class Drag {
+		abstract val widgetId: Int
+		abstract val colSpan: Int
+		abstract val rowSpan: Int
+		/** The view to ignore in collision checks (the dragged one), or null. */
+		abstract val exclude: View?
+
+		abstract fun grabOffsetX(grid: WidgetsContainer): Int
+		abstract fun grabOffsetY(grid: WidgetsContainer): Int
+
+		class Widget(val container: WidgetContainer) : Drag() {
+			private val lp get() = this.container.layoutParams as WidgetsContainer.LayoutParams
+			override val widgetId get() = this.container.appWidgetId
+			override val colSpan get() = this.lp.colSpan
+			override val rowSpan get() = this.lp.rowSpan
+			override val exclude get() = this.container
+			override fun grabOffsetX(grid: WidgetsContainer) = this.container.dragGrabOffsetX
+			override fun grabOffsetY(grid: WidgetsContainer) = this.container.dragGrabOffsetY
+		}
+
+		class DesktopApp(val view: DesktopAppView, val host: DesktopAppHost) : Drag() {
+			override val widgetId = DesktopAppLayout.NO_WIDGET_ID
+			override val colSpan = 1
+			override val rowSpan = 1
+			override val exclude get() = this.view
+			override fun grabOffsetX(grid: WidgetsContainer) = this.view.dragGrabOffsetX
+			override fun grabOffsetY(grid: WidgetsContainer) = this.view.dragGrabOffsetY
+		}
+
+		/** A non-view drag (from the dash or the bar): centre the 1x1 under the finger. */
+		sealed class IncomingApp : Drag() {
+			override val widgetId = DesktopAppLayout.NO_WIDGET_ID
+			override val colSpan = 1
+			override val rowSpan = 1
+			override val exclude: View? = null
+			override fun grabOffsetX(grid: WidgetsContainer) = grid.cellWidth / 2
+			override fun grabOffsetY(grid: WidgetsContainer) = grid.cellHeight / 2
+		}
+
+		class DashApp(val app: App, val host: DesktopAppHost) : IncomingApp()
+
+		class LauncherPin(val app: App, val host: DesktopAppHost) : IncomingApp()
 	}
 }

--- a/app/src/main/res/layout/widget_desktop_applauncher.xml
+++ b/app/src/main/res/layout/widget_desktop_applauncher.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    An app pinned to a desktop. Like a dash icon (icon on top, label below)
+    rather than a launcher-bar icon (no label) — a desktop app always shows its
+    label. Lives in a single WidgetsContainer grid cell.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+      android:id="@+id/llDesktopAppLauncher"
+      android:orientation="vertical"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:gravity="center"
+      android:padding="@dimen/dash_applauncher_padding">
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/imgIcon"
+        android:layout_weight="1"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="[Label]"
+        android:id="@+id/tvLabel"
+        android:textColor="@android:color/white"
+        android:layout_weight="0"
+        android:gravity="center"
+        android:textSize="@dimen/dash_applauncher_textsize"
+        android:maxLines="@integer/dash_applauncher_label_maxlines"
+        android:ellipsize="marquee"
+        android:textAppearance="@style/textshadow_2px_black" />
+
+</LinearLayout>

--- a/app/src/test/java/be/robinj/distrohopper/home/DesktopsTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/DesktopsTest.kt
@@ -7,6 +7,7 @@ import be.robinj.distrohopper.R
 import be.robinj.distrohopper.widgets.WidgetContainer
 import be.robinj.distrohopper.widgets.WidgetTestSupport
 import be.robinj.distrohopper.widgets.WidgetsPager
+import be.robinj.distrohopper.widgets.DesktopAppView
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -37,12 +38,19 @@ class DesktopsTest {
 			.map { it.appWidgetId }
 	}
 
+	private fun desktopAppKeysOn(pager: WidgetsPager, page: Int): List<String> {
+		val container = pager.pageAt(page)
+		return (0 until container.childCount)
+			.mapNotNull { container.getChildAt(it) as? DesktopAppView }
+			.map { it.key }
+	}
+
 	@Test fun highestOccupiedDesktopCombinesWidgetsAndPins() {
 		this.scenario.onActivity { activity ->
 			val pager = activity.findViewById<WidgetsPager>(R.id.vgWidgets)
 			val host = WidgetTestSupport.host(activity)
 			val appManager = requireNotNull(activity.appManager)
-			val desktops = Desktops(host, appManager)
+			val desktops = Desktops(host, appManager, requireNotNull(activity.desktopAppHost))
 
 			// A widget on desktop 1, a pin on desktop 3 //
 			WidgetTestSupport.addWidget(activity, host, pager.pageAt(1), 11, 0, 0, 2, 2)
@@ -50,6 +58,20 @@ class DesktopsTest {
 				appManager.findAppsByPackageName("com.example.alpha").first(), 3)
 
 			assertEquals(3, desktops.highestOccupiedDesktop())
+		}
+	}
+
+	@Test fun highestOccupiedDesktopCountsDesktopApps() {
+		this.scenario.onActivity { activity ->
+			val host = WidgetTestSupport.host(activity)
+			val appManager = requireNotNull(activity.appManager)
+			val desktopAppHost = requireNotNull(activity.desktopAppHost)
+			val desktops = Desktops(host, appManager, desktopAppHost)
+
+			// Only a desktop app, on desktop 4 //
+			desktopAppHost.pinAt(WidgetTestSupport.app(activity, "com.example.alpha"), 0, 0, 4)
+
+			assertEquals(4, desktops.highestOccupiedDesktop())
 		}
 	}
 
@@ -70,7 +92,7 @@ class DesktopsTest {
 			host.persist()
 			pager.pagesChanged()
 
-			Desktops(host, appManager).deleteDesktop(1)
+			Desktops(host, appManager, requireNotNull(activity.desktopAppHost)).deleteDesktop(1)
 			ActivityTestSupport.drainTasks()
 
 			// Desktop 1's own contents are gone //
@@ -79,6 +101,29 @@ class DesktopsTest {
 			assertTrue(repo.isPinnedOn(appB, 1))
 			assertEquals(1, repo.highestPinnedDesktop())
 			assertEquals(listOf(22), this.widgetIdsOn(pager, 1))
+		}
+	}
+
+	@Test fun deleteDesktopRemovesDesktopAppsAndShiftsHigherOnesDown() {
+		this.scenario.onActivity { activity ->
+			val pager = activity.findViewById<WidgetsPager>(R.id.vgWidgets)
+			val host = WidgetTestSupport.host(activity)
+			val appManager = requireNotNull(activity.appManager)
+			val desktopAppHost = requireNotNull(activity.desktopAppHost)
+			val appA = WidgetTestSupport.app(activity, "com.example.alpha")
+			val appB = WidgetTestSupport.app(activity, "com.example.beta")
+
+			// Desktop 1: appA; desktop 2: appB //
+			desktopAppHost.pinAt(appA, 0, 0, 1)
+			desktopAppHost.pinAt(appB, 0, 0, 2)
+
+			Desktops(host, appManager, desktopAppHost).deleteDesktop(1)
+			ActivityTestSupport.drainTasks()
+
+			// appA (desktop 1) gone; appB shifted down from desktop 2 to desktop 1 //
+			assertFalse(desktopAppHost.isPinnedOnDesktop(appA))
+			assertTrue(desktopAppHost.isPinnedOnDesktop(appB))
+			assertEquals(listOf(appB.profileScopedKey), this.desktopAppKeysOn(pager, 1))
 		}
 	}
 }

--- a/app/src/test/java/be/robinj/distrohopper/widgets/DesktopAppDragListenerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/DesktopAppDragListenerTest.kt
@@ -1,0 +1,242 @@
+package be.robinj.distrohopper.widgets
+
+import android.content.ClipData
+import android.view.DragEvent
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.DragEvents
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.R
+import be.robinj.distrohopper.desktop.launcher.LauncherDragListener
+import be.robinj.distrohopper.desktop.launcher.TrashDragListener
+import be.robinj.distrohopper.widgets.WidgetTestSupport.CELL
+import be.robinj.distrohopper.widgets.WidgetTestSupport.GRID_SIZE
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+import org.robolectric.util.ReflectionHelpers
+
+/**
+ * The desktop grid's drop routing for apps: launcher icons and dash apps pinned
+ * onto a desktop (and the launcher icon *moved* off its bar), desktop apps
+ * repositioned, moved back to the bar, and trashed — plus widget/app collision.
+ */
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class DesktopAppDragListenerTest {
+	private lateinit var scenario: ActivityScenario<HomeActivity>
+
+	@Before fun setUp() { this.scenario = ActivityTestSupport.launchHome() }
+	@After fun tearDown() { this.scenario.close() }
+
+	private class Fixture(
+		val receiver: View,
+		val grid: WidgetsContainer,
+		val pager: WidgetsPager,
+		val host: DesktopAppHost,
+		val listener: WidgetsContainer_DragListener,
+	)
+
+	/**
+	 * A detached pager (so getLocationOnScreen is [0,0] and event coords are
+	 * grid-space) whose [DesktopAppHost] is injected as the activity's, so the
+	 * listener — which resolves the host from the activity — drives it.
+	 */
+	private fun fixture(activity: HomeActivity): Fixture {
+		val root = FrameLayout(activity)
+		val grid = WidgetTestSupport.standaloneGrid(activity)
+		val pager = WidgetTestSupport.pagerOf(grid)
+		val receiver = View(activity)
+
+		root.addView(pager, FrameLayout.LayoutParams(GRID_SIZE, GRID_SIZE))
+		root.addView(receiver, FrameLayout.LayoutParams(GRID_SIZE, GRID_SIZE))
+		root.measure(
+			View.MeasureSpec.makeMeasureSpec(GRID_SIZE, View.MeasureSpec.EXACTLY),
+			View.MeasureSpec.makeMeasureSpec(GRID_SIZE, View.MeasureSpec.EXACTLY))
+		root.layout(0, 0, GRID_SIZE, GRID_SIZE)
+
+		val host = DesktopAppHost(activity, pager, activity.appManager.repository)
+		ReflectionHelpers.setField(activity, "desktopAppHost", host)
+
+		return Fixture(receiver, grid, pager, host,
+			WidgetsContainer_DragListener(activity, pager))
+	}
+
+	private fun cell(col: Int, row: Int): Pair<Float, Float> =
+		(col * CELL + CELL / 2).toFloat() to (row * CELL + CELL / 2).toFloat()
+
+	private fun lp(view: View): WidgetsContainer.LayoutParams =
+		view.layoutParams as WidgetsContainer.LayoutParams
+
+	/** The clip a launcher-bar icon drag carries: its pinned index as the label. */
+	private fun launcherPinClip(index: Int): ClipData =
+		ClipData.newPlainText(index.toString(), "app")
+
+	private fun drag(f: Fixture, action: Int, col: Int, row: Int,
+			localState: Any? = null, clip: ClipData? = null) {
+		val (x, y) = cell(col, row)
+		f.listener.onDrag(f.receiver, DragEvents.obtain(action, x, y, localState,
+			clipDescription = clip?.description, clipData = clip))
+	}
+
+	@Test fun dashAppDroppedOnTheDesktopIsPinnedThere() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+
+			this.drag(f, DragEvent.ACTION_DRAG_LOCATION, 3, 2, localState = alpha)
+			this.drag(f, DragEvent.ACTION_DROP, 3, 2, localState = alpha)
+
+			val view = WidgetTestSupport.desktopAppsOn(f.grid).single()
+			assertEquals(alpha.profileScopedKey, view.key)
+			assertEquals(3, lp(view).col)
+			assertEquals(2, lp(view).row)
+		}
+	}
+
+	@Test fun launcherIconDroppedOnTheDesktopMovesOffTheBar() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			activity.appManager.pin(alpha, false, false, true)
+			assertTrue(activity.appManager.isPinned(alpha))
+
+			this.drag(f, DragEvent.ACTION_DROP, 4, 1,
+				localState = null, clip = launcherPinClip(0))
+
+			// Moved: now a desktop pin, gone from the bar //
+			assertTrue(f.host.isPinnedOnDesktop(alpha))
+			assertFalse(activity.appManager.isPinned(alpha))
+			assertEquals(4, lp(WidgetTestSupport.desktopAppsOn(f.grid).single()).col)
+		}
+	}
+
+	@Test fun desktopAppDroppedElsewhereOnItsGridIsRepositioned() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			f.host.pinAt(alpha, 0, 0, 0)
+			val view = WidgetTestSupport.desktopAppsOn(f.grid).single()
+			view.dragGrabOffsetX = CELL / 2
+			view.dragGrabOffsetY = CELL / 2
+
+			this.drag(f, DragEvent.ACTION_DROP, 6, 5, localState = view)
+
+			assertEquals(6, lp(view).col)
+			assertEquals(5, lp(view).row)
+			assertEquals(1, WidgetTestSupport.desktopAppsOn(f.grid).size)
+		}
+	}
+
+	@Test fun droppingAnAppOnAnOccupiedCellShowsAnInvalidTarget() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val widgetHost = WidgetTestSupport.host(activity, f.grid)
+			WidgetTestSupport.addWidget(activity, widgetHost, f.grid, 42, 3, 3, 2, 2)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+
+			// Hover a dash app over the widget's cell //
+			this.drag(f, DragEvent.ACTION_DRAG_LOCATION, 3, 3, localState = alpha)
+
+			assertTrue(f.grid.isMoveTargetVisible)
+			// Dropping there is rejected: no desktop app is created //
+			this.drag(f, DragEvent.ACTION_DROP, 3, 3, localState = alpha)
+			// pinAt falls back to a free cell rather than overlapping the widget //
+			val view = WidgetTestSupport.desktopAppsOn(f.grid).single()
+			assertFalse(lp(view).col in 3..4 && lp(view).row in 3..4)
+		}
+	}
+
+	@Test fun draggingAnAppAlreadyPinnedElsewhereRelocatesIt() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			f.host.pinAt(alpha, 0, 0, 0)
+
+			// Drop the same app (as a dash drag) onto another cell //
+			this.drag(f, DragEvent.ACTION_DROP, 5, 5, localState = alpha)
+
+			val view = WidgetTestSupport.desktopAppsOn(f.grid).single()
+			assertEquals(5, lp(view).col)
+			assertEquals(5, lp(view).row)
+			assertEquals(1, WidgetTestSupport.desktopAppsOn(f.grid).size)
+		}
+	}
+
+	@Test fun moveTargetValidatesAgainstBothWidgetsAndDesktopApps() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			f.host.pinAt(alpha, 2, 2, 0)
+			val beta = WidgetTestSupport.app(activity, "com.example.beta")
+
+			// Hovering a second app over the first app's cell is invalid //
+			this.drag(f, DragEvent.ACTION_DRAG_LOCATION, 2, 2, localState = beta)
+
+			assertTrue(f.grid.isMoveTargetVisible)
+			assertEquals(2, f.grid.moveTargetCol)
+			assertEquals(2, f.grid.moveTargetRow)
+		}
+	}
+
+	@Test fun desktopAppDroppedOnTheBarMovesToTheLauncher() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			f.host.pinAt(alpha, 0, 0, 0)
+			val view = WidgetTestSupport.desktopAppsOn(f.grid).single()
+			val barListener = LauncherDragListener(activity.appManager)
+
+			barListener.onDrag(activity.findViewById(R.id.llLauncher),
+				DragEvents.obtain(DragEvent.ACTION_DROP, localState = view))
+
+			// Moved: pinned to the bar, gone from the desktop //
+			assertTrue(activity.appManager.isPinned(alpha))
+			assertFalse(f.host.isPinnedOnDesktop(alpha))
+		}
+	}
+
+	@Test fun aWidgetCannotBeMovedOntoADesktopAppCell() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			f.host.pinAt(alpha, 4, 4, 0)
+			val widgetHost = WidgetTestSupport.host(activity, f.grid)
+			val widget = WidgetTestSupport.addWidget(activity, widgetHost, f.grid, 42, 0, 0, 1, 1)
+			widget.dragGrabOffsetX = CELL / 2
+			widget.dragGrabOffsetY = CELL / 2
+
+			// Try to drop the widget onto the desktop app's cell //
+			this.drag(f, DragEvent.ACTION_DROP, 4, 4, localState = widget)
+
+			// Rejected: the widget stays put, the app keeps its cell //
+			assertEquals(0, lp(widget).col)
+			assertEquals(0, lp(widget).row)
+			assertEquals(4, lp(WidgetTestSupport.desktopAppsOn(f.grid).single()).col)
+		}
+	}
+
+	@Test fun desktopAppDroppedOnTheTrashIsRemoved() {
+		this.scenario.onActivity { activity ->
+			val f = this.fixture(activity)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			f.host.pinAt(alpha, 0, 0, 0)
+			val view = WidgetTestSupport.desktopAppsOn(f.grid).single()
+			val trash = TrashDragListener(activity)
+
+			trash.onDrag(activity.findViewById(R.id.lalTrash),
+				DragEvents.obtain(DragEvent.ACTION_DROP, localState = view))
+
+			assertFalse(f.host.isPinnedOnDesktop(alpha))
+			assertEquals(0, WidgetTestSupport.desktopAppsOn(f.grid).size)
+		}
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/widgets/DesktopAppHostTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/DesktopAppHostTest.kt
@@ -1,0 +1,239 @@
+package be.robinj.distrohopper.widgets
+
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.HomeActivity
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+
+/**
+ * The desktop-app host: restore (prune/de-dup/collision-repair), the
+ * cross-desktop single-copy invariant, moving, removal and page shifting.
+ */
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class DesktopAppHostTest {
+	private lateinit var scenario: ActivityScenario<HomeActivity>
+
+	@Before fun setUp() { this.scenario = ActivityTestSupport.launchHome() }
+	@After fun tearDown() { this.scenario.close() }
+
+	private fun writeStored(activity: HomeActivity, vararg layouts: DesktopAppLayout) {
+		DesktopAppPersistence(activity.applicationContext).save(layouts.toList())
+	}
+
+	private fun keysOf(grid: WidgetsContainer): List<String> =
+		WidgetTestSupport.desktopAppsOn(grid).map { it.key }
+
+	@Test fun restorePrunesAppsThatAreNoLongerInstalled() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			this.writeStored(activity,
+				DesktopAppLayout(alpha.profileScopedKey, 0, 0, 0),
+				DesktopAppLayout("com.example.gone\nGoneActivity", 1, 0, 0))
+
+			host.restore()
+
+			assertEquals(listOf(alpha.profileScopedKey), this.keysOf(grid))
+			// The pruned entry is dropped from persistence too //
+			assertEquals(1, DesktopAppPersistence(activity.applicationContext).load().size)
+		}
+	}
+
+	@Test fun restoreDeDupsTheSameAppAcrossPagesKeepingTheFirst() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val pager = WidgetTestSupport.pagerOf(grid)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			this.writeStored(activity,
+				DesktopAppLayout(alpha.profileScopedKey, 0, 0, 0),
+				DesktopAppLayout(alpha.profileScopedKey, 1, 1, 1))
+
+			host.restore()
+
+			// Only the first placement survives, on page 0 //
+			assertEquals(listOf(alpha.profileScopedKey), this.keysOf(pager.pageAt(0)))
+			assertEquals(emptyList<String>(), this.keysOf(pager.pageAt(1)))
+			assertEquals(1, DesktopAppPersistence(activity.applicationContext).load().size)
+		}
+	}
+
+	@Test fun restoreRepacksAnAppWhoseCellCollidesWithAWidget() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val widgetHost = WidgetTestSupport.host(activity, grid)
+			// A 2x2 widget occupying cols 0-1, rows 0-1 //
+			WidgetTestSupport.addWidget(activity, widgetHost, grid, 42, 0, 0, 2, 2)
+
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			this.writeStored(activity, DesktopAppLayout(alpha.profileScopedKey, 0, 0, 0))
+
+			host.restore()
+
+			val view = WidgetTestSupport.desktopAppsOn(grid).single()
+			val lp = view.layoutParams as WidgetsContainer.LayoutParams
+			// First free cell row-major past the 2x2 widget is (col 2, row 0) //
+			assertEquals(2, lp.col)
+			assertEquals(0, lp.row)
+		}
+	}
+
+	@Test fun pinAtEnforcesCrossDesktopSingleCopy() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val pager = WidgetTestSupport.pagerOf(grid)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+
+			host.pinAt(alpha, 0, 0, 0)
+			host.pinAt(alpha, 3, 4, 1) // Same app, different desktop //
+
+			// Exactly one pin, relocated to desktop 1 //
+			assertEquals(emptyList<String>(), this.keysOf(pager.pageAt(0)))
+			assertEquals(listOf(alpha.profileScopedKey), this.keysOf(pager.pageAt(1)))
+			assertEquals(1, DesktopAppPersistence(activity.applicationContext).load().size)
+		}
+	}
+
+	@Test fun pinAtKeepsSamePackageInDifferentProfilesDistinct() {
+		ActivityTestSupport.addWorkProfile()
+		val workUser = ActivityTestSupport.workProfileHandle()
+		ActivityTestSupport.addWorkProfileApp(
+			workUser, "com.example.alpha", "AlphaActivity", "Alpha")
+
+		ActivityTestSupport.launchHome().use { scenario ->
+			scenario.onActivity { activity ->
+				val grid = WidgetTestSupport.standaloneGrid(activity)
+				val host = WidgetTestSupport.desktopHost(activity, grid)
+				val matches = activity.appManager.findAppsByPackageName("com.example.alpha")
+				val personal = matches.first { it.user == null }
+				val work = matches.first { it.user != null }
+
+				host.pinAt(personal, 0, 0, 0)
+				host.pinAt(work, 1, 0, 0)
+
+				// Distinct profile-scoped keys → both pins coexist //
+				assertTrue(host.isPinnedOnDesktop(personal))
+				assertTrue(host.isPinnedOnDesktop(work))
+				assertEquals(2, WidgetTestSupport.desktopAppsOn(grid).size)
+			}
+		}
+	}
+
+	@Test fun pinAtRelocatesWhenTheRequestedCellIsTakenByAnotherApp() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			val beta = WidgetTestSupport.app(activity, "com.example.beta")
+
+			host.pinAt(alpha, 0, 0, 0)
+			host.pinAt(beta, 0, 0, 0) // Same cell — must fall back to a free one //
+
+			val betaView = WidgetTestSupport.desktopAppsOn(grid).first { it.key == beta.profileScopedKey }
+			val lp = betaView.layoutParams as WidgetsContainer.LayoutParams
+			assertFalse(lp.col == 0 && lp.row == 0)
+			assertEquals(2, WidgetTestSupport.desktopAppsOn(grid).size)
+		}
+	}
+
+	@Test fun moveToRepositionsWithinTheDesktop() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			host.pinAt(alpha, 0, 0, 0)
+			val view = WidgetTestSupport.desktopAppsOn(grid).single()
+
+			host.moveTo(view, 5, 6)
+
+			val lp = view.layoutParams as WidgetsContainer.LayoutParams
+			assertEquals(5, lp.col)
+			assertEquals(6, lp.row)
+			val persisted = DesktopAppPersistence(activity.applicationContext).load().single()
+			assertEquals(5, persisted.col)
+			assertEquals(6, persisted.row)
+		}
+	}
+
+	@Test fun moveToOntoAWidgetCellIsRejected() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val widgetHost = WidgetTestSupport.host(activity, grid)
+			WidgetTestSupport.addWidget(activity, widgetHost, grid, 42, 4, 4, 2, 2)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			host.pinAt(alpha, 0, 0, 0)
+			val view = WidgetTestSupport.desktopAppsOn(grid).single()
+
+			host.moveTo(view, 4, 4) // Onto the widget //
+
+			val lp = view.layoutParams as WidgetsContainer.LayoutParams
+			assertEquals(0, lp.col) // Unchanged //
+			assertEquals(0, lp.row)
+		}
+	}
+
+	@Test fun removeTakesItOffTheDesktopAndOutOfPersistence() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			host.pinAt(alpha, 0, 0, 0)
+			val view = WidgetTestSupport.desktopAppsOn(grid).single()
+
+			host.remove(view)
+
+			assertEquals(0, WidgetTestSupport.desktopAppsOn(grid).size)
+			assertFalse(host.isPinnedOnDesktop(alpha))
+			assertTrue(DesktopAppPersistence(activity.applicationContext).load().isEmpty())
+		}
+	}
+
+	@Test fun unpinFromAllDesktopsRemovesTheAppOnUninstall() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			host.pinAt(alpha, 2, 2, 1)
+
+			host.unpinFromAllDesktops(alpha)
+
+			assertFalse(host.isPinnedOnDesktop(alpha))
+			assertNull(host.viewForKey(alpha.profileScopedKey))
+		}
+	}
+
+	@Test fun highestDesktopAndRemoveDesktopPageShiftHigherPagesDown() {
+		this.scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			val pager = WidgetTestSupport.pagerOf(grid)
+			val host = WidgetTestSupport.desktopHost(activity, grid)
+			val alpha = WidgetTestSupport.app(activity, "com.example.alpha")
+			val beta = WidgetTestSupport.app(activity, "com.example.beta")
+			host.pinAt(alpha, 0, 0, 1)
+			host.pinAt(beta, 0, 0, 3)
+
+			assertEquals(3, host.highestDesktop())
+
+			host.removeDesktopPage(1)
+
+			// beta shifts from desktop 3 down to desktop 2 //
+			assertEquals(2, host.highestDesktop())
+			assertEquals(listOf(beta.profileScopedKey), this.keysOf(pager.pageAt(2)))
+			assertFalse(host.isPinnedOnDesktop(alpha))
+		}
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/widgets/DesktopAppPersistenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/DesktopAppPersistenceTest.kt
@@ -1,0 +1,79 @@
+package be.robinj.distrohopper.widgets
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.preferences.Preferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DesktopAppPersistenceTest {
+	private lateinit var application: Application
+
+	@Before fun setUp() {
+		application = ApplicationProvider.getApplicationContext()
+		application.getSharedPreferences(Preferences.DESKTOP_APPS, 0).edit().clear().commit()
+	}
+
+	@Test fun loadReturnsEmptyListWhenNothingSaved() {
+		assertTrue(DesktopAppPersistence(application).load().isEmpty())
+	}
+
+	@Test fun saveAndLoadRoundTripAcrossDesktops() {
+		val persistence = DesktopAppPersistence(application)
+		val layouts = listOf(
+			DesktopAppLayout("com.example.alpha\nAlphaActivity", 0, 0, 0),
+			DesktopAppLayout("com.example.beta\nBetaActivity", 3, 5, 2),
+		)
+
+		persistence.save(layouts)
+
+		assertEquals(layouts, DesktopAppPersistence(application).load())
+	}
+
+	@Test fun profileScopedKeySurvivesRoundTrip() {
+		val persistence = DesktopAppPersistence(application)
+		// A work-profile key carries the trailing profile serial //
+		val workKey = "com.example.alpha\nAlphaActivity\n10"
+		val layouts = listOf(DesktopAppLayout(workKey, 1, 1, 0))
+
+		persistence.save(layouts)
+
+		val loaded = DesktopAppPersistence(application).load().single()
+		assertEquals(workKey, loaded.key)
+	}
+
+	@Test fun saveEmptyListClearsPreviousState() {
+		val persistence = DesktopAppPersistence(application)
+
+		persistence.save(listOf(DesktopAppLayout("com.example.alpha\nAlphaActivity", 0, 0, 0)))
+		persistence.save(emptyList())
+
+		assertTrue(persistence.load().isEmpty())
+	}
+
+	@Test fun loadIgnoresCorruptedJson() {
+		application.getSharedPreferences(Preferences.DESKTOP_APPS, 0)
+			.edit().putString("desktop_apps", "not json at all").commit()
+
+		assertTrue(DesktopAppPersistence(application).load().isEmpty())
+	}
+
+	@Test fun loadSkipsMalformedEntries() {
+		application.getSharedPreferences(Preferences.DESKTOP_APPS, 0)
+			.edit()
+			.putString(
+				"desktop_apps",
+				"""[{"key":"a","col":0,"row":0,"page":0},{"col":3,"row":1}]""",
+			)
+			.commit()
+
+		val layouts = DesktopAppPersistence(application).load()
+
+		assertEquals(listOf(DesktopAppLayout("a", 0, 0, 0)), layouts)
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetTestSupport.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetTestSupport.kt
@@ -3,6 +3,7 @@ package be.robinj.distrohopper.widgets
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProviderInfo
 import android.view.View
+import be.robinj.distrohopper.App
 import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.R
 
@@ -62,6 +63,33 @@ internal object WidgetTestSupport {
 		grid.addView(container, WidgetsContainer.LayoutParams(col, row, colSpan, rowSpan))
 		return container
 	}
+
+	/**
+	 * A [DesktopAppHost] bound to the given grid's pager, with the pager's
+	 * occupied-desktop supplier widened to count desktop apps too (production
+	 * wires this through `home/Desktops`; a standalone test pager otherwise only
+	 * counts widgets and would trim the page a desktop app was just placed on).
+	 */
+	fun desktopHost(
+		activity: HomeActivity,
+		grid: WidgetsContainer =
+			activity.findViewById<WidgetsPager>(R.id.vgWidgets).pageAt(0),
+	): DesktopAppHost {
+		val pager = pagerOf(grid)
+		val host = DesktopAppHost(activity, pager, activity.appManager.repository)
+		val widgets = pager.occupiedDesktopSupplier
+		pager.occupiedDesktopSupplier = { maxOf(widgets(), host.highestDesktop()) }
+
+		return host
+	}
+
+	/** The (first) installed app for a seeded test package. */
+	fun app(activity: HomeActivity, packageName: String): App =
+		activity.appManager.findAppsByPackageName(packageName).first()
+
+	/** The desktop-app views on a grid page, in child order. */
+	fun desktopAppsOn(grid: WidgetsContainer): List<DesktopAppView> =
+		(0 until grid.childCount).mapNotNull { grid.getChildAt(it) as? DesktopAppView }
 
 	/** Measures and lays out the grid so cell sizes are non-zero. */
 	fun layoutGrid(grid: WidgetsContainer) {


### PR DESCRIPTION
Apps can now be pinned to the desktop grid alongside widgets. A
desktop-pinned app always shows its label, is specific to each desktop,
and there is at most one desktop copy of each app (per profile) across
all desktops — though it may also be pinned to the launcher bar (the two
stores are independent). Apps move (not copy) between the launcher and
the desktop, dash apps can be dragged straight onto a desktop, and a
desktop app is removed by dragging it onto the trash.

Desktop apps are a sibling of the widget system rather than an extension
of the launcher-bar pins: they live as 1x1 DesktopAppView children in
the same WidgetsContainer grid, owned by a new DesktopAppHost (modelled
on WidgetHost) and persisted to their own preferences file. The single
source of truth for a placement is the view's layout params plus its
page index, so views re-page themselves on persist.

Collision detection now considers widgets and desktop apps together
(WidgetsContainer.collectOccupied), so neither can overlap the other.
The cross-desktop single-copy invariant is enforced in one place
(DesktopAppHost.pinAt: remove-then-add), and desktop deletion shifts
desktop apps down in lockstep with widgets via home/Desktops.

Drag routing: WidgetsContainer_DragListener handles widget moves, desktop
app moves, dash-app pins and launcher-icon moves onto the desktop; the
trash and launcher-bar listeners recognise the new DesktopAppView local
state for trashing and move-to-bar.

Adds heavy unit coverage around uniqueness, move-vs-copy between launcher
and desktop, persistence round-trips (incl. profile-scoped keys),
restore prune/de-dup/collision-repair, trash removal, desktop-delete page
shifting, and widget/app collision both ways.