### PR TITLE
Revise launcher chrome now that the dash always exposes settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,7 +353,17 @@ etc/                                        — design assets (SVG/XCF sources, 
   theme (Budgie) drive the status bar off the launcher edge instead of the
   panel — opaque (`statusbar_background`) when the launcher is at the top,
   transparent (`statusbar_background_when_panel_not_top`) otherwise, resolved
-  in `Theme.statusbar_background_resolved`.
+  in `Theme.statusbar_background_resolved`. A third opt-in,
+  `launcher_bfb_user_toggleable`, lets a theme (Pantheon, COSMIC) expose a
+  "menu button" (the launcher BFB) show/hide checkbox in customise mode;
+  `launcher_bfb_visible_by_default` is its default state and
+  `Theme.launcherBfbVisible` resolves the live value (pref → default), with
+  non-toggleable themes simply following `launcher_bfb_location`. The launcher
+  preferences icon was removed from every theme (`launcher_preferences_location`
+  is `none`); settings are reached via the panel cog or the dash's customise
+  cog, and the dash is always reachable by swiping up — so the old
+  `launcher_preferences_location_when_panel_hidden` fallback is now `none` too.
+  Removed icons keep their drawables.
 - **`widgets/`** — home-screen widget hosting (mostly Kotlin): `WidgetHost`
   (AppWidgetHost), `WidgetPersistence`, `WidgetPickerDialog`.
   `WidgetsPager` (`R.id.vgWidgets`) is a horizontal pager of widget

--- a/app/src/main/java/be/robinj/distrohopper/home/CustomiseModeUi.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/CustomiseModeUi.kt
@@ -5,6 +5,7 @@ import android.content.res.ColorStateList
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.Spinner
@@ -129,6 +130,25 @@ class CustomiseModeUi(
 				currentPanelEdge, spiCustomiseSpinnerTextColour, Preference.PANEL_EDGE)
 		} else {
 			this.viewFinder.get<View>(llDashCustomise, R.id.llCustomisePanelEdge).visibility = View.GONE
+		}
+
+		// Menu button (BFB) // Only themes that allow it (Pantheon, COSMIC) offer
+		// the toggle; the choice is applied by re-running the theme on relaunch.
+		val llCustomiseMenuButton =
+			this.viewFinder.get<View>(llDashCustomise, R.id.llCustomiseMenuButton)
+		if (res.getBoolean(this.theme.launcher_bfb_user_toggleable)) {
+			llCustomiseMenuButton.visibility = View.VISIBLE
+			val cbCustomiseMenuButton = this.viewFinder.get<CheckBox>(R.id.cbCustomiseMenuButton)
+			cbCustomiseMenuButton.isChecked = prefs.getBoolean(
+				Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(),
+				res.getBoolean(this.theme.launcher_bfb_visible_by_default))
+			cbCustomiseMenuButton.setOnCheckedChangeListener { _, checked ->
+				prefsEdit.putBoolean(Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(), checked)
+				prefsEdit.commit()
+				this.relaunchInCustomiseMode.run()
+			}
+		} else {
+			llCustomiseMenuButton.visibility = View.GONE
 		}
 	}
 

--- a/app/src/main/java/be/robinj/distrohopper/home/ThemeApplier.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/ThemeApplier.kt
@@ -87,12 +87,18 @@ class ThemeApplier(
 				lalPreferences.visibility = View.VISIBLE
 		}
 
-		when (Location.of(res.getInteger(this.theme.launcher_bfb_location))) {
+		// The menu button (BFB) is hidden either when the theme has no BFB or when
+		// the user has hidden it on a theme that lets them (see launcherBfbVisible).
+		if (!this.theme.launcherBfbVisible(res, prefs)) {
+			llBfbSpinnerWrapper.visibility = View.GONE
+		} else when (Location.of(res.getInteger(this.theme.launcher_bfb_location))) {
 			Location.NONE ->
 				llBfbSpinnerWrapper.visibility = View.GONE
 			Location.TOP, Location.LEFT ->
 				llBfbSpinnerWrapper.visibility = View.VISIBLE
 			Location.RIGHT, Location.BOTTOM -> {
+				llBfbSpinnerWrapper.visibility = View.VISIBLE
+
 				val posLalPreferences = llLauncher.indexOfChild(lalPreferences)
 				val posLalTrash = llLauncher.indexOfChild(lalTrash)
 				val posLlBfbSpinnerWrapper =

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -6,6 +6,7 @@ public enum Preference {
 	PANEL_EDGE("panel_edge_v2"),
 	PANEL_OPACITY("panel_opacity"),
 	LAUNCHER_EDGE("launcher_edge_v2"),
+	LAUNCHER_MENU_BUTTON_VISIBLE("launcher_menu_button_visible"),
 	LAUNCHER_SHOW_RUNNING_APPS("launcher_running_show"),
 	LAUNCHER_APP_PIN_MODE("launcher_app_pin_mode", "desktop"),
 	LAUNCHERICON_WIDTH("launchericon_width"),

--- a/app/src/main/java/be/robinj/distrohopper/theme/Budgie.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Budgie.java
@@ -29,6 +29,8 @@ public class Budgie extends Theme
 		this.launcher_bfb_image = R.drawable.theme_budgie_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_budgie_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_budgie_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_budgie_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_budgie_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_budgie_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_budgie_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_budgie_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Cinnamon.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Cinnamon.java
@@ -29,6 +29,8 @@ public class Cinnamon extends Theme
 		this.launcher_bfb_image = R.drawable.theme_cinnamon_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_cinnamon_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_cinnamon_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_cinnamon_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_cinnamon_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_cinnamon_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_cinnamon_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_cinnamon_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Cosmic.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Cosmic.java
@@ -29,6 +29,8 @@ public class Cosmic extends Theme
 		this.launcher_bfb_image = R.drawable.theme_cosmic_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_cosmic_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_cosmic_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_cosmic_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_cosmic_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_cosmic_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_cosmic_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_cosmic_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Default.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Default.java
@@ -29,6 +29,8 @@ public class Default extends Theme
 		this.launcher_bfb_image = R.drawable.theme_default_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_default_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_default_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_default_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_default_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_default_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_default_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_default_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Elementary.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Elementary.java
@@ -29,6 +29,8 @@ public class Elementary extends Theme
 		this.launcher_bfb_image = R.drawable.theme_elementary_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_elementary_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_elementary_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_elementary_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_elementary_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_elementary_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_elementary_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_elementary_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Gnome.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Gnome.java
@@ -29,6 +29,8 @@ public class Gnome extends Theme
 		this.launcher_bfb_image = R.drawable.theme_gnome_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_gnome_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_gnome_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_gnome_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_gnome_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_gnome_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_gnome_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_gnome_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Mate.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Mate.java
@@ -29,6 +29,8 @@ public class Mate extends Theme
 		this.launcher_bfb_image = R.drawable.theme_mate_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_mate_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_mate_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_mate_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_mate_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_mate_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_mate_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_mate_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Plasma.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Plasma.java
@@ -29,6 +29,8 @@ public class Plasma extends Theme
 		this.launcher_bfb_image = R.drawable.theme_plasma_launcher_bfb_image;
 		this.launcher_bfb_image_vertical = R.drawable.theme_plasma_launcher_bfb_image_vertical;
 		this.launcher_bfb_hide_while_dragging = R.bool.theme_plasma_launcher_bfb_hide_while_dragging;
+		this.launcher_bfb_user_toggleable = R.bool.theme_plasma_launcher_bfb_user_toggleable;
+		this.launcher_bfb_visible_by_default = R.bool.theme_plasma_launcher_bfb_visible_by_default;
 		this.launcher_preferences_location = R.integer.theme_plasma_launcher_preferences_location;
 		this.launcher_preferences_image = R.drawable.theme_plasma_launcher_preferences_image;
 		this.launcher_preferences_location_when_panel_hidden = R.integer.theme_plasma_launcher_preferences_location_when_panel_hidden;

--- a/app/src/main/java/be/robinj/distrohopper/theme/Theme.java
+++ b/app/src/main/java/be/robinj/distrohopper/theme/Theme.java
@@ -47,6 +47,13 @@ public abstract class Theme
 	public int launcher_bfb_image;
 	public int launcher_bfb_image_vertical;
 	public int launcher_bfb_hide_while_dragging;
+	/*
+	 * Whether the launcher's menu button (the "BFB") can be shown or hidden by
+	 * the user in customise mode, and its default state when it can. Themes that
+	 * are not toggleable always follow launcher_bfb_location.
+	 */
+	public int launcher_bfb_user_toggleable;
+	public int launcher_bfb_visible_by_default;
 	public int launcher_preferences_location;
 	public int launcher_preferences_image;
 	public int launcher_preferences_location_when_panel_hidden;
@@ -154,6 +161,21 @@ public abstract class Theme
 			return this.statusbar_background_when_panel_not_top;
 
 		return this.statusbar_background;
+	}
+
+	/*
+	 * Whether the launcher's menu button (BFB) should be shown. For themes that
+	 * let the user toggle it (Pantheon, COSMIC) this follows the user's choice,
+	 * falling back to the theme's default; other themes simply follow whether
+	 * their themed BFB location is set at all.
+	 */
+	public boolean launcherBfbVisible(final Resources res, final SharedPreferences prefs) {
+		if (res.getBoolean(this.launcher_bfb_user_toggleable)) {
+			return prefs.getBoolean(Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(),
+					res.getBoolean(this.launcher_bfb_visible_by_default));
+		}
+
+		return Location.of(res.getInteger(this.launcher_bfb_location)) != Location.NONE;
 	}
 
 	public Location lalPreferences_getLocation(final Resources res, final SharedPreferences prefs) {

--- a/app/src/main/java/be/robinj/distrohopper/theme/ThemeCards.kt
+++ b/app/src/main/java/be/robinj/distrohopper/theme/ThemeCards.kt
@@ -75,6 +75,8 @@ class ThemeCards(
 				this.putString(Preference.THEME.getName(), theme.getName())
 				this.putInt(Preference.LAUNCHER_EDGE.getName(), res.getInteger(theme.launcher_location))
 				this.putInt(Preference.PANEL_EDGE.getName(), res.getInteger(theme.panel_location))
+				this.putBoolean(Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(),
+					res.getBoolean(theme.launcher_bfb_visible_by_default))
 			}
 		}
 	}

--- a/app/src/main/res/layout/activity_home_customise.xml
+++ b/app/src/main/res/layout/activity_home_customise.xml
@@ -103,4 +103,28 @@
             android:id="@+id/spiCustomisePanelEdge"></Spinner>
 
     </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone"
+        android:id="@+id/llCustomiseMenuButton">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/option_menu_button"
+            style="@style/TextAppearance.AppCompat.Title" />
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/hint_menu_button" />
+        <CheckBox
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/option_menu_button_show"
+            android:id="@+id/cbCustomiseMenuButton" />
+
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="hint_panel_edge">To which screen edge the Panel should be attached.</string>
     <string name="option_launcher_edge">Launcher location</string>
     <string name="hint_launcher_edge">To which screen edge the Launcher should be attached.</string>
+    <string name="option_menu_button">Menu button</string>
+    <string name="hint_menu_button">Show the menu button in the Launcher. You can also open the Dash by swiping up from the screen edge.</string>
+    <string name="option_menu_button_show">Show the menu button</string>
     <string name="widget_picker_title">Add widget</string>
     <string name="widget_no_room">There is no room left on the home screen for this widget.</string>
     <string name="option_dashsearch_focus_on_open">Start search when Dash opened</string>

--- a/app/src/main/res/values/theme_budgie.xml
+++ b/app/src/main/res/values/theme_budgie.xml
@@ -37,9 +37,11 @@
     <drawable name="theme_budgie_launcher_bfb_image">@drawable/theme_budgie_res_launcher_bfb</drawable>
     <drawable name="theme_budgie_launcher_bfb_image_vertical">@drawable/theme_budgie_res_launcher_bfb</drawable>
     <bool name="theme_budgie_launcher_bfb_hide_while_dragging">false</bool>
-    <integer name="theme_budgie_launcher_preferences_location">@integer/position_right</integer>
+    <bool name="theme_budgie_launcher_bfb_user_toggleable">false</bool>
+    <bool name="theme_budgie_launcher_bfb_visible_by_default">true</bool>
+    <integer name="theme_budgie_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_budgie_launcher_preferences_image">@drawable/theme_budgie_res_launcher_preferences</drawable>
-    <integer name="theme_budgie_launcher_preferences_location_when_panel_hidden">@integer/position_right</integer>
+    <integer name="theme_budgie_launcher_preferences_location_when_panel_hidden">@integer/position_none</integer>
     <drawable name="theme_budgie_launcher_trash_image">@drawable/launcher_trash</drawable>
     <bool name="theme_budgie_launcher_applauncher_backgroundcolour_dynamic">false</bool>
     <color name="theme_budgie_launcher_applauncher_backgroundcolour">@android:color/transparent</color>

--- a/app/src/main/res/values/theme_cinnamon.xml
+++ b/app/src/main/res/values/theme_cinnamon.xml
@@ -33,9 +33,11 @@
     <drawable name="theme_cinnamon_launcher_bfb_image">@drawable/theme_cinnamon_res_launcher_bfb</drawable>
     <drawable name="theme_cinnamon_launcher_bfb_image_vertical">@drawable/theme_cinnamon_res_launcher_bfb</drawable>
     <bool name="theme_cinnamon_launcher_bfb_hide_while_dragging">false</bool>
-    <integer name="theme_cinnamon_launcher_preferences_location">@integer/position_right</integer>
+    <bool name="theme_cinnamon_launcher_bfb_user_toggleable">false</bool>
+    <bool name="theme_cinnamon_launcher_bfb_visible_by_default">true</bool>
+    <integer name="theme_cinnamon_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_cinnamon_launcher_preferences_image">@drawable/theme_cinnamon_res_launcher_preferences</drawable>
-    <integer name="theme_cinnamon_launcher_preferences_location_when_panel_hidden">@integer/position_right</integer>
+    <integer name="theme_cinnamon_launcher_preferences_location_when_panel_hidden">@integer/position_none</integer>
     <drawable name="theme_cinnamon_launcher_trash_image">@drawable/launcher_trash</drawable>
     <bool name="theme_cinnamon_launcher_applauncher_backgroundcolour_dynamic">false</bool>
     <color name="theme_cinnamon_launcher_applauncher_backgroundcolour">@android:color/transparent</color>

--- a/app/src/main/res/values/theme_cosmic.xml
+++ b/app/src/main/res/values/theme_cosmic.xml
@@ -33,9 +33,11 @@
     <drawable name="theme_cosmic_launcher_bfb_image">@drawable/theme_cosmic_res_launcher_bfb</drawable>
     <drawable name="theme_cosmic_launcher_bfb_image_vertical">@drawable/theme_cosmic_res_launcher_bfb</drawable>
     <bool name="theme_cosmic_launcher_bfb_hide_while_dragging">false</bool>
-    <integer name="theme_cosmic_launcher_preferences_location">@integer/position_right</integer>
+    <bool name="theme_cosmic_launcher_bfb_user_toggleable">true</bool>
+    <bool name="theme_cosmic_launcher_bfb_visible_by_default">true</bool>
+    <integer name="theme_cosmic_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_cosmic_launcher_preferences_image">@drawable/theme_cosmic_res_launcher_preferences</drawable>
-    <integer name="theme_cosmic_launcher_preferences_location_when_panel_hidden">@integer/position_right</integer>
+    <integer name="theme_cosmic_launcher_preferences_location_when_panel_hidden">@integer/position_none</integer>
     <drawable name="theme_cosmic_launcher_trash_image">@drawable/launcher_trash</drawable>
     <bool name="theme_cosmic_launcher_applauncher_backgroundcolour_dynamic">false</bool>
     <color name="theme_cosmic_launcher_applauncher_backgroundcolour">@android:color/transparent</color>

--- a/app/src/main/res/values/theme_default.xml
+++ b/app/src/main/res/values/theme_default.xml
@@ -32,9 +32,11 @@
     <drawable name="theme_default_launcher_bfb_image">@drawable/launcher_bfb</drawable>
     <drawable name="theme_default_launcher_bfb_image_vertical">@drawable/launcher_bfb</drawable>
     <bool name="theme_default_launcher_bfb_hide_while_dragging">false</bool>
-    <integer name="theme_default_launcher_preferences_location">@integer/position_bottom</integer>
+    <bool name="theme_default_launcher_bfb_user_toggleable">false</bool>
+    <bool name="theme_default_launcher_bfb_visible_by_default">true</bool>
+    <integer name="theme_default_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_default_launcher_preferences_image">@drawable/launcher_preferences</drawable>
-    <integer name="theme_default_launcher_preferences_location_when_panel_hidden">@integer/position_bottom</integer>
+    <integer name="theme_default_launcher_preferences_location_when_panel_hidden">@integer/position_none</integer>
     <drawable name="theme_default_launcher_trash_image">@drawable/launcher_trash</drawable>
     <bool name="theme_default_launcher_applauncher_backgroundcolour_dynamic">true</bool>
     <color name="theme_default_launcher_applauncher_backgroundcolour">@android:color/transparent</color>

--- a/app/src/main/res/values/theme_elementary.xml
+++ b/app/src/main/res/values/theme_elementary.xml
@@ -33,6 +33,8 @@
     <drawable name="theme_elementary_launcher_bfb_image">@drawable/theme_elementary_res_launcher_bfb</drawable>
     <drawable name="theme_elementary_launcher_bfb_image_vertical">@drawable/theme_elementary_res_launcher_bfb</drawable>
     <bool name="theme_elementary_launcher_bfb_hide_while_dragging">false</bool>
+    <bool name="theme_elementary_launcher_bfb_user_toggleable">true</bool>
+    <bool name="theme_elementary_launcher_bfb_visible_by_default">false</bool>
     <integer name="theme_elementary_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_elementary_launcher_preferences_image">@drawable/theme_elementary_res_launcher_preferences</drawable>
     <integer name="theme_elementary_launcher_preferences_location_when_panel_hidden">@integer/position_right</integer>

--- a/app/src/main/res/values/theme_gnome.xml
+++ b/app/src/main/res/values/theme_gnome.xml
@@ -32,9 +32,11 @@
     <drawable name="theme_gnome_launcher_bfb_image">@drawable/theme_gnome_res_launcher_bfb</drawable>
     <drawable name="theme_gnome_launcher_bfb_image_vertical">@drawable/theme_gnome_res_launcher_bfb</drawable>
     <bool name="theme_gnome_launcher_bfb_hide_while_dragging">true</bool>
+    <bool name="theme_gnome_launcher_bfb_user_toggleable">false</bool>
+    <bool name="theme_gnome_launcher_bfb_visible_by_default">true</bool>
     <integer name="theme_gnome_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_gnome_launcher_preferences_image">@drawable/launcher_preferences</drawable>
-    <integer name="theme_gnome_launcher_preferences_location_when_panel_hidden">@integer/position_bottom</integer>
+    <integer name="theme_gnome_launcher_preferences_location_when_panel_hidden">@integer/position_none</integer>
     <drawable name="theme_gnome_launcher_trash_image">@drawable/launcher_trash</drawable>
     <bool name="theme_gnome_launcher_applauncher_backgroundcolour_dynamic">false</bool>
     <color name="theme_gnome_launcher_applauncher_backgroundcolour">@android:color/transparent</color>
@@ -51,6 +53,7 @@
     <integer name="theme_gnome_panel_location">@integer/position_top</integer>
     <array name="theme_gnome_panel_location_supported">
         <item>@integer/position_top</item>
+        <item>@integer/position_none</item>
     </array>
     <dimen name="theme_gnome_panel_height">28dp</dimen>
     <drawable name="theme_gnome_panel_background">@drawable/theme_gnome_res_panel_background</drawable>

--- a/app/src/main/res/values/theme_mate.xml
+++ b/app/src/main/res/values/theme_mate.xml
@@ -33,9 +33,11 @@
     <drawable name="theme_mate_launcher_bfb_image">@drawable/theme_mate_res_launcher_bfb</drawable>
     <drawable name="theme_mate_launcher_bfb_image_vertical">@drawable/theme_mate_res_launcher_bfb_vertical</drawable>
     <bool name="theme_mate_launcher_bfb_hide_while_dragging">false</bool>
-    <integer name="theme_mate_launcher_preferences_location">@integer/position_right</integer>
+    <bool name="theme_mate_launcher_bfb_user_toggleable">false</bool>
+    <bool name="theme_mate_launcher_bfb_visible_by_default">true</bool>
+    <integer name="theme_mate_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_mate_launcher_preferences_image">@drawable/theme_mate_res_launcher_preferences</drawable>
-    <integer name="theme_mate_launcher_preferences_location_when_panel_hidden">@integer/position_right</integer>
+    <integer name="theme_mate_launcher_preferences_location_when_panel_hidden">@integer/position_none</integer>
     <drawable name="theme_mate_launcher_trash_image">@drawable/launcher_trash</drawable>
     <bool name="theme_mate_launcher_applauncher_backgroundcolour_dynamic">false</bool>
     <color name="theme_mate_launcher_applauncher_backgroundcolour">@android:color/transparent</color>

--- a/app/src/main/res/values/theme_plasma.xml
+++ b/app/src/main/res/values/theme_plasma.xml
@@ -33,9 +33,11 @@
     <drawable name="theme_plasma_launcher_bfb_image">@drawable/theme_plasma_res_launcher_bfb</drawable>
     <drawable name="theme_plasma_launcher_bfb_image_vertical">@drawable/theme_plasma_res_launcher_bfb</drawable>
     <bool name="theme_plasma_launcher_bfb_hide_while_dragging">false</bool>
-    <integer name="theme_plasma_launcher_preferences_location">@integer/position_right</integer>
+    <bool name="theme_plasma_launcher_bfb_user_toggleable">false</bool>
+    <bool name="theme_plasma_launcher_bfb_visible_by_default">true</bool>
+    <integer name="theme_plasma_launcher_preferences_location">@integer/position_none</integer>
     <drawable name="theme_plasma_launcher_preferences_image">@drawable/theme_plasma_res_launcher_preferences</drawable>
-    <integer name="theme_plasma_launcher_preferences_location_when_panel_hidden">@integer/position_right</integer>
+    <integer name="theme_plasma_launcher_preferences_location_when_panel_hidden">@integer/position_none</integer>
     <drawable name="theme_plasma_launcher_trash_image">@drawable/launcher_trash</drawable>
     <bool name="theme_plasma_launcher_applauncher_backgroundcolour_dynamic">false</bool>
     <color name="theme_plasma_launcher_applauncher_backgroundcolour">@android:color/transparent</color>

--- a/app/src/test/java/be/robinj/distrohopper/home/LauncherBarBinderTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/LauncherBarBinderTest.kt
@@ -151,8 +151,8 @@ class LauncherBarBinderTest {
 			binder.stoppedDraggingPinnedApp()
 
 			assertEquals(View.GONE, activity.findViewById<View>(R.id.lalTrash).visibility)
-			// The default theme places the preferences launcher at the bottom.
-			assertEquals(View.VISIBLE,
+			// The default theme no longer shows a preferences launcher.
+			assertEquals(View.GONE,
 				activity.findViewById<View>(R.id.lalPreferences).visibility)
 			assertEquals(View.VISIBLE, activity.findViewById<View>(R.id.lalBfb).visibility)
 			assertEquals(1.0F, pinnedContainer(activity).alpha, 0.001F)

--- a/app/src/test/java/be/robinj/distrohopper/home/ThemeApplierTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/ThemeApplierTest.kt
@@ -33,7 +33,9 @@ class ThemeApplierTest {
 					activity.findViewById<TextView>(R.id.tvPanelBfb).visibility)
 				assertEquals(View.VISIBLE,
 					activity.findViewById<LinearLayout>(R.id.llDashRibbon).visibility)
-				assertEquals(View.VISIBLE,
+				// The launcher preferences icon was removed: settings are reached
+				// via the cog in the dash.
+				assertEquals(View.GONE,
 					activity.findViewById<View>(R.id.lalPreferences).visibility)
 
 				val llLauncher = activity.findViewById<LinearLayout>(R.id.llLauncher)
@@ -74,14 +76,15 @@ class ThemeApplierTest {
 		}
 	}
 
-	@Test fun cinnamonThemeHidesPanelAndRibbonButShowsPreferences() {
+	@Test fun cinnamonThemeHidesPanelRibbonAndPreferences() {
 		launch("cinnamon").use { scenario ->
 			scenario.onActivity { activity ->
 				assertEquals(View.GONE,
 					activity.findViewById<TextView>(R.id.tvPanelBfb).visibility)
 				assertEquals(View.GONE,
 					activity.findViewById<LinearLayout>(R.id.llDashRibbon).visibility)
-				assertEquals(View.VISIBLE,
+				// The launcher preferences icon was removed.
+				assertEquals(View.GONE,
 					activity.findViewById<View>(R.id.lalPreferences).visibility)
 				assertEquals(View.VISIBLE,
 					activity.findViewById<View>(R.id.llBfbSpinnerWrapper).visibility)
@@ -92,7 +95,7 @@ class ThemeApplierTest {
 		}
 	}
 
-	@Test fun elementaryThemeShowsPanelBfbAndHidesPreferences() {
+	@Test fun elementaryThemeShowsPanelBfbAndHidesPreferencesAndMenuButton() {
 		launch("elementary").use { scenario ->
 			scenario.onActivity { activity ->
 				assertEquals(View.VISIBLE,
@@ -101,6 +104,33 @@ class ThemeApplierTest {
 					activity.findViewById<LinearLayout>(R.id.llDashRibbon).visibility)
 				assertEquals(View.GONE,
 					activity.findViewById<View>(R.id.lalPreferences).visibility)
+				// The menu button defaults to hidden on Pantheon.
+				assertEquals(View.GONE,
+					activity.findViewById<View>(R.id.llBfbSpinnerWrapper).visibility)
+			}
+		}
+	}
+
+	@Test fun cosmicThemeShowsMenuButtonByDefault() {
+		launch("cosmic").use { scenario ->
+			scenario.onActivity { activity ->
+				assertEquals(View.GONE,
+					activity.findViewById<View>(R.id.lalPreferences).visibility)
+				// The menu button defaults to visible on COSMIC.
+				assertEquals(View.VISIBLE,
+					activity.findViewById<View>(R.id.llBfbSpinnerWrapper).visibility)
+			}
+		}
+	}
+
+	@Test fun menuButtonPreferenceHidesItOnAToggleableTheme() {
+		ActivityTestSupport.launchHome(configurePrefs = {
+			it.putString(Preference.THEME.getName(), "cosmic")
+			it.putBoolean(Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(), false)
+		}).use { scenario ->
+			scenario.onActivity { activity ->
+				assertEquals(View.GONE,
+					activity.findViewById<View>(R.id.llBfbSpinnerWrapper).visibility)
 			}
 		}
 	}

--- a/app/src/test/java/be/robinj/distrohopper/theme/ThemeTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/theme/ThemeTest.kt
@@ -58,6 +58,36 @@ class ThemeTest {
             theme.lalPreferences_getLocation(context.resources, prefs))
     }
 
+    @Test fun gnomePanelCanBeHidden() {
+        // The GNOME panel offers Top or Hidden in customise mode.
+        val supported = context.resources.getIntArray(Gnome().panel_location_supported)
+        assertTrue(supported.contains(Location.TOP.n))
+        assertTrue(supported.contains(Location.NONE.n))
+    }
+
+    @Test fun menuButtonDefaultsPerToggleableTheme() {
+        val prefs = Preferences.getSharedPreferences(context)
+        // Pantheon hides the menu button by default; COSMIC shows it.
+        assertFalse(Elementary().launcherBfbVisible(context.resources, prefs))
+        assertTrue(Cosmic().launcherBfbVisible(context.resources, prefs))
+    }
+
+    @Test fun menuButtonPreferenceOverridesTheDefault() {
+        val prefs = Preferences.getSharedPreferences(context)
+        prefs.edit().putBoolean(Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(), true).commit()
+        assertTrue(Elementary().launcherBfbVisible(context.resources, prefs))
+
+        prefs.edit().putBoolean(Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(), false).commit()
+        assertFalse(Cosmic().launcherBfbVisible(context.resources, prefs))
+    }
+
+    @Test fun menuButtonPreferenceIgnoredOnNonToggleableThemes() {
+        val prefs = Preferences.getSharedPreferences(context)
+        // The Unity launcher always shows its menu button regardless of the pref.
+        prefs.edit().putBoolean(Preference.LAUNCHER_MENU_BUTTON_VISIBLE.getName(), false).commit()
+        assertTrue(Default().launcherBfbVisible(context.resources, prefs))
+    }
+
     @Test fun panelLessThemeStatusBarFollowsLauncherEdge() {
         val theme = Budgie(); val prefs = Preferences.getSharedPreferences(context)
         // No panel: the status bar is opaque only when the launcher is at the top.


### PR DESCRIPTION
The swipe-up-to-open-dash gesture plus the always-present settings cog in
the dash make the per-theme launcher preferences icon redundant, so remove
it from every theme (drawables kept). Also add per-theme customise options:

- GNOME: the panel can now be hidden (Top or Hide).
- Pantheon & COSMIC: a "menu button" (BFB) show/hide toggle in customise
  mode, defaulting to hidden on Pantheon and visible on COSMIC.

The menu-button visibility is an opt-in Theme capability
(launcher_bfb_user_toggleable / launcher_bfb_visible_by_default, resolved by
Theme.launcherBfbVisible) and is reset to the theme default on theme switch.
The launcher_preferences_location_when_panel_hidden fallback is now also
none everywhere it mattered, since the dash is always reachable.