### PR TITLE
Add grid overlay visualization for widget drag and resize

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/home/LauncherBarBinder.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/LauncherBarBinder.kt
@@ -22,6 +22,7 @@ import be.robinj.distrohopper.desktop.launcher.AppLauncherDragListener
 import be.robinj.distrohopper.desktop.launcher.AppLauncherLongClickListener
 import be.robinj.distrohopper.desktop.launcher.PinnedAppsBar
 import be.robinj.distrohopper.desktop.launcher.RunningAppLauncher
+import be.robinj.distrohopper.widgets.WidgetsPager
 import be.robinj.distrohopper.theme.Location
 import be.robinj.distrohopper.theme.ProfileIndicatorStyle
 
@@ -463,6 +464,8 @@ class LauncherBarBinder(private val appManager: AppManager) {
 			activity.closeDash()
 
 			viewFinder.get<LinearLayout>(llLauncher, R.id.llLauncherPinnedApps).alpha = 0.9F
+
+			viewFinder.get<WidgetsPager>(R.id.vgWidgets).showGridOverlay()
 		}
 
 		@JvmStatic
@@ -482,6 +485,8 @@ class LauncherBarBinder(private val appManager: AppManager) {
 			lalTrash.visibility = View.GONE
 
 			viewFinder.get<LinearLayout>(llLauncher, R.id.llLauncherPinnedApps).alpha = 1.0F
+
+			viewFinder.get<WidgetsPager>(R.id.vgWidgets).hideGridOverlay()
 		}
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.java
@@ -24,7 +24,8 @@ public enum Preference {
 	DEFAULT_PINS_AUTO_INELIGIBLE("default_pins_auto_ineligible"),
 	DEV("dev"),
 	DEV_LOG_TOASTER("dev_log_toaster", null, DEV),
-	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false, DEV);
+	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false, DEV),
+	DEV_SHOW_GRID_ON_DRAG("dev_show_grid_on_drag", false, DEV);
 
 	private final String name;
 	private final Object defaultValue;

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetContainer.kt
@@ -152,6 +152,7 @@ class WidgetContainer internal constructor(
 					lp.previewTopPx = this.startTop
 					lp.previewWidthPx = this.startWidth
 					lp.previewHeightPx = this.startHeight
+					parent.showGridOverlay()
 				}
 
 				val cellW = parent.cellWidth
@@ -242,6 +243,7 @@ class WidgetContainer internal constructor(
 
 					lp.clearPreview()
 					parent.hideSnapLine()
+					parent.hideGridOverlay()
 					parent.requestLayout()
 				}
 

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer.java
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import be.robinj.distrohopper.R;
+import be.robinj.distrohopper.preferences.Preference;
+import be.robinj.distrohopper.preferences.Preferences;
 
 /**
  * The widget area of the home screen. Positions its children on an invisible
@@ -26,6 +28,12 @@ public class WidgetsContainer extends ViewGroup
 	private final Paint snapLinePaint = new Paint (Paint.ANTI_ALIAS_FLAG);
 	private final Paint moveTargetFillPaint = new Paint (Paint.ANTI_ALIAS_FLAG);
 	private final Paint moveTargetStrokePaint = new Paint (Paint.ANTI_ALIAS_FLAG);
+	private final Paint gridDotPaint = new Paint (Paint.ANTI_ALIAS_FLAG);
+	private final float gridDotRadius;
+
+	// When the developer option is on, dots are drawn at every grid intersection
+	// while a widget or app is being dragged or a widget is being resized //
+	private boolean gridOverlayVisible = false;
 
 	// While an edge is being dragged, the line shows where it will snap on release //
 	private boolean snapLineVisible = false;
@@ -52,6 +60,38 @@ public class WidgetsContainer extends ViewGroup
 		this.moveTargetStrokePaint.setStyle (Paint.Style.STROKE);
 		this.moveTargetStrokePaint.setStrokeWidth (TypedValue.applyDimension (
 				TypedValue.COMPLEX_UNIT_DIP, 2, context.getResources ().getDisplayMetrics ()));
+		this.gridDotPaint.setColor (Color.argb (190, 255, 255, 255));
+		this.gridDotPaint.setStyle (Paint.Style.FILL);
+		this.gridDotRadius = TypedValue.applyDimension (
+				TypedValue.COMPLEX_UNIT_DIP, 2.5f, context.getResources ().getDisplayMetrics ());
+	}
+
+	/**
+	 * Shows the grid-intersection dot overlay, if the developer option is enabled.
+	 * No-op otherwise, so callers can fire it unconditionally on every drag/resize.
+	 */
+	public void showGridOverlay ()
+	{
+		if (this.gridOverlayVisible || ! this.isGridOverlayEnabled ())
+			return;
+
+		this.gridOverlayVisible = true;
+		this.invalidate ();
+	}
+
+	public void hideGridOverlay ()
+	{
+		if (! this.gridOverlayVisible)
+			return;
+
+		this.gridOverlayVisible = false;
+		this.invalidate ();
+	}
+
+	private boolean isGridOverlayEnabled ()
+	{
+		return Preferences.getSharedPreferences (this.getContext ())
+				.getBoolean (Preference.DEV_SHOW_GRID_ON_DRAG.getName (), false);
 	}
 
 	public void showMoveTarget (final int col, final int row, final int colSpan, final int rowSpan,
@@ -121,6 +161,23 @@ public class WidgetsContainer extends ViewGroup
 	protected void dispatchDraw (final Canvas canvas)
 	{
 		super.dispatchDraw (canvas);
+
+		if (this.gridOverlayVisible)
+		{
+			final int cellWidth = this.getCellWidth ();
+			final int cellHeight = this.getCellHeight ();
+
+			for (int col = 0; col <= WidgetGrid.COLS; col++)
+			{
+				final float x = this.getPaddingLeft () + col * cellWidth;
+
+				for (int row = 0; row <= WidgetGrid.ROWS; row++)
+				{
+					final float y = this.getPaddingTop () + row * cellHeight;
+					canvas.drawCircle (x, y, this.gridDotRadius, this.gridDotPaint);
+				}
+			}
+		}
 
 		if (this.moveTargetVisible)
 		{

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer.java
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsContainer.java
@@ -88,6 +88,11 @@ public class WidgetsContainer extends ViewGroup
 		this.invalidate ();
 	}
 
+	boolean isGridOverlayVisible ()
+	{
+		return this.gridOverlayVisible;
+	}
+
 	private boolean isGridOverlayEnabled ()
 	{
 		return Preferences.getSharedPreferences (this.getContext ())

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsPager.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetsPager.kt
@@ -316,6 +316,19 @@ class WidgetsPager @JvmOverloads constructor(
 		}
 	}
 
+	/** Shows the grid-intersection overlay on every desktop (no-op unless the dev option is on). */
+	fun showGridOverlay() {
+		for (i in 0 until this.childCount) {
+			(this.getChildAt(i) as WidgetsContainer).showGridOverlay()
+		}
+	}
+
+	fun hideGridOverlay() {
+		for (i in 0 until this.childCount) {
+			(this.getChildAt(i) as WidgetsContainer).hideGridOverlay()
+		}
+	}
+
 	/**
 	 * Keeps each desktop clear of the launcher and the navigation bar; applied
 	 * as padding on every page (existing and future) rather than the pager

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
     <string name="hint_full_restart">Kill and relaunch the app to fully re-initialise it.</string>
     <string name="option_widget_resize_any">Allow unsupported widget dimensions</string>
     <string name="hint_widget_resize_any">Allow widgets to be resized beyond their supported size constraints.</string>
+    <string name="option_show_grid_on_drag">Show desktop grid while dragging</string>
+    <string name="hint_show_grid_on_drag">Show a dot at each grid intersection while dragging or resizing widgets and apps.</string>
     <string name="option_rerun_onboarding">Run setup wizard again</string>
     <string name="hint_rerun_onboarding">The first-run setup wizard will be shown the next time DistroHopper starts.</string>
     <string name="toast_rerun_onboarding">Setup wizard will run on next start</string>

--- a/app/src/main/res/xml/pref_dev.xml
+++ b/app/src/main/res/xml/pref_dev.xml
@@ -22,6 +22,13 @@
 		android:summary="@string/hint_widget_resize_any"
 		android:defaultValue="false" />
 
+	<SwitchPreferenceCompat
+		android:key="dev_show_grid_on_drag"
+		android:dependency="dev"
+		android:title="@string/option_show_grid_on_drag"
+		android:summary="@string/hint_show_grid_on_drag"
+		android:defaultValue="false" />
+
 	<Preference
 		android:key="dummy_rerun_onboarding"
 		android:dependency="dev"

--- a/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/DevPreferenceTest.kt
@@ -29,6 +29,7 @@ class DevPreferenceTest {
 			.putBoolean(Preference.DEV.getName(), true)
 			.putBoolean(Preference.DEV_LOG_TOASTER.getName(), true)
 			.putBoolean(Preference.DEV_WIDGET_RESIZE_ANY.getName(), true)
+			.putBoolean(Preference.DEV_SHOW_GRID_ON_DRAG.getName(), true)
 			.commit()
 	}
 
@@ -43,14 +44,18 @@ class DevPreferenceTest {
 					Preference.DEV_LOG_TOASTER.getName())!!
 				val widgetResize = fragment.findPreference<SwitchPreferenceCompat>(
 					Preference.DEV_WIDGET_RESIZE_ANY.getName())!!
+				val showGrid = fragment.findPreference<SwitchPreferenceCompat>(
+					Preference.DEV_SHOW_GRID_ON_DRAG.getName())!!
 
 				assertTrue(logToaster.isChecked)
 				assertTrue(widgetResize.isChecked)
+				assertTrue(showGrid.isChecked)
 
 				dev.performClick()
 
 				assertFalse(logToaster.isChecked)
 				assertFalse(widgetResize.isChecked)
+				assertFalse(showGrid.isChecked)
 			}
 		}
 
@@ -58,6 +63,7 @@ class DevPreferenceTest {
 		assertFalse(prefs.getBoolean(Preference.DEV.getName(), true))
 		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
 		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
+		assertFalse(prefs.contains(Preference.DEV_SHOW_GRID_ON_DRAG.getName()))
 	}
 
 	@Test fun openingPreferencesWithDeveloperModeOffClearsStaleDeveloperToggles() {
@@ -74,15 +80,19 @@ class DevPreferenceTest {
 					Preference.DEV_LOG_TOASTER.getName())!!
 				val widgetResize = fragment.findPreference<SwitchPreferenceCompat>(
 					Preference.DEV_WIDGET_RESIZE_ANY.getName())!!
+				val showGrid = fragment.findPreference<SwitchPreferenceCompat>(
+					Preference.DEV_SHOW_GRID_ON_DRAG.getName())!!
 
 				assertFalse(logToaster.isChecked)
 				assertFalse(widgetResize.isChecked)
+				assertFalse(showGrid.isChecked)
 			}
 		}
 
 		val prefs = Preferences.getSharedPreferences(this.application)
 		assertFalse(prefs.contains(Preference.DEV_LOG_TOASTER.getName()))
 		assertFalse(prefs.contains(Preference.DEV_WIDGET_RESIZE_ANY.getName()))
+		assertFalse(prefs.contains(Preference.DEV_SHOW_GRID_ON_DRAG.getName()))
 	}
 
 	@Test fun clickingClearCacheClearsLabelIconAndExpirationCaches() {

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetContainerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetContainerTest.kt
@@ -32,6 +32,7 @@ class WidgetContainerTest {
 			Preferences.getSharedPreferences(activity)
 				.edit()
 				.remove(Preference.DEV_WIDGET_RESIZE_ANY.getName())
+				.remove(Preference.DEV_SHOW_GRID_ON_DRAG.getName())
 				.commit()
 		}
 		scenario.close()
@@ -260,6 +261,54 @@ class WidgetContainerTest {
 
 			// Clamped to gridRight - startLeft = 800 - 200
 			assertEquals(6 * CELL, lp(container).previewWidthPx)
+		}
+	}
+
+	@Test fun resizingShowsTheGridOverlayWhenTheDevOptionIsOnAndHidesItOnRelease() {
+		scenario.onActivity { activity ->
+			Preferences.getSharedPreferences(activity)
+				.edit()
+				.putBoolean(Preference.DEV_SHOW_GRID_ON_DRAG.getName(), true)
+				.commit()
+			val fixture = widgetAt22(activity)
+			val container = fixture.container
+
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_DOWN, 400F, 300F)
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_MOVE, 400F + CELL, 300F)
+			assertTrue(fixture.grid.isGridOverlayVisible)
+
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_UP, 400F + CELL, 300F)
+			assertFalse(fixture.grid.isGridOverlayVisible)
+		}
+	}
+
+	@Test fun cancellingAResizeAlsoHidesTheGridOverlay() {
+		scenario.onActivity { activity ->
+			Preferences.getSharedPreferences(activity)
+				.edit()
+				.putBoolean(Preference.DEV_SHOW_GRID_ON_DRAG.getName(), true)
+				.commit()
+			val fixture = widgetAt22(activity)
+			val container = fixture.container
+
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_DOWN, 400F, 300F)
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_MOVE, 400F + CELL, 300F)
+			assertTrue(fixture.grid.isGridOverlayVisible)
+
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_CANCEL, 400F + CELL, 300F)
+			assertFalse(fixture.grid.isGridOverlayVisible)
+		}
+	}
+
+	@Test fun resizingDoesNotShowTheGridOverlayWhenTheDevOptionIsOff() {
+		scenario.onActivity { activity ->
+			val fixture = widgetAt22(activity)
+			val container = fixture.container
+
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_DOWN, 400F, 300F)
+			touch(container, R.id.llEdgeRight, MotionEvent.ACTION_MOVE, 400F + CELL, 300F)
+
+			assertFalse(fixture.grid.isGridOverlayVisible)
 		}
 	}
 

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetsContainerGridOverlayTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetsContainerGridOverlayTest.kt
@@ -1,0 +1,138 @@
+package be.robinj.distrohopper.widgets
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.R
+import be.robinj.distrohopper.home.LauncherBarBinder
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.Preferences
+import be.robinj.distrohopper.widgets.WidgetTestSupport.CELL
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class WidgetsContainerGridOverlayTest {
+	private lateinit var scenario: ActivityScenario<HomeActivity>
+
+	@Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
+	@After fun tearDown() {
+		scenario.onActivity { activity ->
+			Preferences.getSharedPreferences(activity)
+				.edit()
+				.remove(Preference.DEV_SHOW_GRID_ON_DRAG.getName())
+				.commit()
+		}
+		scenario.close()
+	}
+
+	/** A Canvas that only records the dots drawn by the grid overlay. */
+	private class RecordingCanvas : Canvas() {
+		val circles = mutableListOf<Pair<Float, Float>>()
+
+		override fun drawCircle(cx: Float, cy: Float, radius: Float, paint: Paint) {
+			this.circles.add(cx to cy)
+		}
+	}
+
+	private fun enableOption(activity: HomeActivity) {
+		Preferences.getSharedPreferences(activity)
+			.edit()
+			.putBoolean(Preference.DEV_SHOW_GRID_ON_DRAG.getName(), true)
+			.commit()
+	}
+
+	@Test fun showGridOverlayIsANoOpWhenTheDevOptionIsOff() {
+		scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			WidgetTestSupport.layoutGrid(grid)
+
+			grid.showGridOverlay()
+
+			assertFalse(grid.isGridOverlayVisible)
+		}
+	}
+
+	@Test fun showAndHideToggleTheOverlayWhenTheDevOptionIsOn() {
+		scenario.onActivity { activity ->
+			enableOption(activity)
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			WidgetTestSupport.layoutGrid(grid)
+
+			grid.showGridOverlay()
+			assertTrue(grid.isGridOverlayVisible)
+
+			grid.hideGridOverlay()
+			assertFalse(grid.isGridOverlayVisible)
+		}
+	}
+
+	@Test fun visibleOverlayDrawsADotAtEveryGridIntersection() {
+		scenario.onActivity { activity ->
+			enableOption(activity)
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			WidgetTestSupport.layoutGrid(grid)
+			grid.showGridOverlay()
+
+			val canvas = RecordingCanvas()
+			grid.draw(canvas)
+
+			// One dot at every corner of the COLS x ROWS grid //
+			assertEquals(
+				(WidgetGrid.COLS + 1) * (WidgetGrid.ROWS + 1),
+				canvas.circles.size)
+			// The four extreme corners of the 800x800 grid (100px cells) //
+			assertTrue(canvas.circles.contains(0F to 0F))
+			assertTrue(canvas.circles.contains((WidgetGrid.COLS * CELL).toFloat() to 0F))
+			assertTrue(canvas.circles.contains(0F to (WidgetGrid.ROWS * CELL).toFloat()))
+			assertTrue(canvas.circles.contains(
+				(WidgetGrid.COLS * CELL).toFloat() to (WidgetGrid.ROWS * CELL).toFloat()))
+		}
+	}
+
+	@Test fun hiddenOverlayDrawsNoDots() {
+		scenario.onActivity { activity ->
+			enableOption(activity)
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			WidgetTestSupport.layoutGrid(grid)
+
+			val canvas = RecordingCanvas()
+			grid.draw(canvas)
+
+			assertTrue(canvas.circles.isEmpty())
+		}
+	}
+
+	@Test fun startingADragShowsTheOverlayAndStoppingHidesItWhenTheDevOptionIsOn() {
+		scenario.onActivity { activity ->
+			enableOption(activity)
+			val page = activity.findViewById<WidgetsPager>(R.id.vgWidgets).pageAt(0)
+
+			LauncherBarBinder.startedDragging(activity)
+			assertTrue(page.isGridOverlayVisible)
+
+			LauncherBarBinder.stoppedDragging(activity)
+			assertFalse(page.isGridOverlayVisible)
+		}
+	}
+
+	@Test fun startingADragDoesNotShowTheOverlayWhenTheDevOptionIsOff() {
+		scenario.onActivity { activity ->
+			val page = activity.findViewById<WidgetsPager>(R.id.vgWidgets).pageAt(0)
+
+			LauncherBarBinder.startedDragging(activity)
+
+			assertFalse(page.isGridOverlayVisible)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Adds a developer option to display a grid overlay showing widget cell intersections during drag and resize operations. This helps developers visualize the underlying grid system when interacting with widgets.

## Key Changes
- **New Developer Option**: Added `DEV_SHOW_GRID_ON_DRAG` preference to enable/disable grid overlay visualization
- **Grid Overlay Implementation**: 
  - Added `showGridOverlay()` and `hideGridOverlay()` methods to `WidgetsContainer` to control overlay visibility
  - Grid overlay draws white semi-transparent dots at every grid intersection point when enabled
  - Overlay is automatically shown when dragging widgets/apps and hidden when the drag completes
- **Widget Resize Integration**: Grid overlay is also shown during widget edge resize operations
- **WidgetsPager Integration**: Added methods to show/hide grid overlay across all desktop pages
- **LauncherBarBinder Integration**: Automatically triggers grid overlay display when drag operations start/stop
- **UI Preferences**: Added new preference UI option in developer settings with title and hint text
- **Comprehensive Tests**: Added `WidgetsContainerGridOverlayTest` with 6 test cases covering:
  - Option toggle behavior
  - Grid dot rendering at correct positions
  - Drag/resize integration
  - Option disabled behavior

## Implementation Details
- Grid dots are rendered as 2.5dp circles with 190/255 alpha white color for visibility without obstruction
- The overlay respects container padding when calculating dot positions
- Grid overlay is a no-op when the developer option is disabled, allowing callers to trigger it unconditionally
- Both `ACTION_UP` and `ACTION_CANCEL` motion events properly hide the overlay during resize operations

https://claude.ai/code/session_016YRiscTr492BnSwQPG2xyu