### PR TITLE
Apply selected font to dash/lens labels and dialog titles

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/ExceptionHandler.java
+++ b/app/src/main/java/be/robinj/distrohopper/ExceptionHandler.java
@@ -9,6 +9,7 @@ import org.acra.ACRA;
 
 import be.robinj.distrohopper.dev.Log;
 import be.robinj.distrohopper.desktop.FrostedGlass;
+import be.robinj.distrohopper.preferences.FontPreference;
 
 /**
  * Created by robin on 8/22/14.
@@ -69,8 +70,13 @@ public class ExceptionHandler {
 			dlg.setNeutralButton (android.R.string.ok, null);
 
 			final AlertDialog dialog = dlg.create ();
-			// Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
-			dialog.setOnShowListener (d -> FrostedGlass.INSTANCE.applyDialogFallback (dialog.getWindow ()));
+			dialog.setOnShowListener (d -> {
+				// Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
+				FrostedGlass.INSTANCE.applyDialogFallback (dialog.getWindow ());
+				// Dialog chrome inflates through the dialog window's own inflater,
+				// which doesn't carry the activity's font factory. //
+				FontPreference.INSTANCE.applyTo (dialog);
+			});
 			dialog.show ();
 		}
 		catch (Exception ex2)

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/GridAdapter.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/GridAdapter.java
@@ -31,7 +31,7 @@ public class GridAdapter extends ArrayAdapter<App> {
 		AppLauncher appLauncher = (this.getItem (position)).getDashAppLauncher ();
 
 		if (view == null)
-			view = LayoutInflater.from (this.getContext ()).inflate (R.layout.widget_dash_applauncher, parent, false);
+			view = LayoutInflater.from (parent.getContext ()).inflate (R.layout.widget_dash_applauncher, parent, false);
 
 		TextView tvLabel = (TextView) view.findViewById (R.id.tvLabel);
 		ImageView imgIcon = (ImageView) view.findViewById (R.id.imgIcon);

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/CollectionGridAdapter.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/CollectionGridAdapter.java
@@ -35,7 +35,7 @@ public class CollectionGridAdapter extends ArrayAdapter<LensSearchResultCollecti
 		boolean show = true;
 
 		if (view == null)
-			view = LayoutInflater.from (this.getContext ()).inflate (R.layout.widget_dash_lens_result_collection, parent, false);
+			view = LayoutInflater.from (parent.getContext ()).inflate (R.layout.widget_dash_lens_result_collection, parent, false);
 
 		TextView tvLabel = (TextView) view.findViewById (R.id.tvLabel);
 		GridView gvResults = (GridView) view.findViewById (R.id.gvResults);

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/GridAdapter.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/GridAdapter.java
@@ -31,7 +31,7 @@ public class GridAdapter extends ArrayAdapter<LensSearchResult> {
 		LensSearchResult result = this.getItem (position);
 
 		if (view == null)
-			view = LayoutInflater.from (this.getContext ()).inflate (R.layout.widget_dash_lens_result, parent, false);
+			view = LayoutInflater.from (parent.getContext ()).inflate (R.layout.widget_dash_lens_result, parent, false);
 
 		TextView tvLabel = (TextView) view.findViewById (R.id.tvLabel);
 		ImageView imgIcon = (ImageView) view.findViewById (R.id.imgIcon);

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/Lens.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/Lens.kt
@@ -10,6 +10,7 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import be.robinj.distrohopper.R
 import be.robinj.distrohopper.desktop.FrostedGlass
+import be.robinj.distrohopper.preferences.FontPreference
 import java.io.BufferedInputStream
 import java.io.BufferedReader
 import java.io.ByteArrayOutputStream
@@ -103,8 +104,13 @@ abstract class Lens(protected val context: Context) {
         dlg.setNeutralButton(android.R.string.ok, null)
 
         val dialog = dlg.create()
-        // Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
-        dialog.setOnShowListener { dialog.window?.let(FrostedGlass::applyDialogFallback) }
+        dialog.setOnShowListener {
+            // Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
+            dialog.window?.let(FrostedGlass::applyDialogFallback)
+            // Dialog chrome inflates through the dialog window's own inflater,
+            // which doesn't carry the activity's font factory. //
+            FontPreference.applyTo(dialog)
+        }
         dialog.show()
     }
 

--- a/app/src/main/java/be/robinj/distrohopper/preferences/FontPreference.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/FontPreference.kt
@@ -1,8 +1,12 @@
 package be.robinj.distrohopper.preferences
 
 import android.app.Activity
+import android.app.Dialog
 import android.content.Context
 import android.graphics.Typeface
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
@@ -62,5 +66,30 @@ object FontPreference {
 			inflater,
 			FontInflaterFactory(activity.delegate, typeface),
 		)
+	}
+
+	/**
+	 * Applies the chosen font to an already-shown [dialog]. A dialog inflates its
+	 * title (and chrome) through the dialog window's own LayoutInflater, which
+	 * doesn't carry the activity's [FontInflaterFactory], so we sweep the decor
+	 * view and force the typeface onto every TextView. No-op for System.
+	 *
+	 * Attach via [Dialog.setOnShowListener] so the views exist when this runs.
+	 */
+	fun applyTo(dialog: Dialog) {
+		val typeface = this.typeface(dialog.context) ?: return
+		val root = dialog.window?.decorView ?: return
+
+		this.applyTypeface(root, typeface)
+	}
+
+	private fun applyTypeface(view: View, typeface: Typeface) {
+		when (view) {
+			is ViewGroup -> for (i in 0 until view.childCount) {
+				this.applyTypeface(view.getChildAt(i), typeface)
+			}
+			// Keep each view's own style (bold/italic) while swapping the family.
+			is TextView -> view.setTypeface(typeface, view.typeface?.style ?: Typeface.NORMAL)
+		}
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetPickerDialog.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetPickerDialog.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AlertDialog
 import java.text.Collator
 import be.robinj.distrohopper.R
 import be.robinj.distrohopper.desktop.FrostedGlass
+import be.robinj.distrohopper.preferences.FontPreference
 
 /**
  * Lists the installed app widget providers, grouped by application.
@@ -51,8 +52,14 @@ class WidgetPickerDialog(
 			}
 		}
 
-		// Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
-		dialog.setOnShowListener { dialog.window?.let(FrostedGlass::applyDialogFallback) }
+		dialog.setOnShowListener {
+			// Keep the surface legible where cross-window blur isn't available (e.g. Samsung). //
+			dialog.window?.let(FrostedGlass::applyDialogFallback)
+			// The title inflates through the dialog window's own inflater, which
+			// doesn't carry the activity's font factory; apply the chosen font
+			// once the dialog's views exist. //
+			FontPreference.applyTo(dialog)
+		}
 
 		dialog.show()
 	}

--- a/app/src/test/java/be/robinj/distrohopper/FontPreferenceTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/FontPreferenceTest.kt
@@ -1,8 +1,10 @@
 package be.robinj.distrohopper
 
+import android.app.Dialog
 import android.content.Context
 import android.graphics.Typeface
 import android.os.Bundle
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ApplicationProvider
@@ -72,6 +74,36 @@ class FontPreferenceTest {
 		val activity = Robolectric.buildActivity(FontTestActivity::class.java).create().get()
 
 		FontPreference.applyTo(activity) // must not throw
+	}
+
+	/** The Dialog overload sweeps the decor view, reaching nested TextViews
+	 *  (e.g. the title) that the inflater factory never touches. */
+	@Test fun applyToDialogAppliesFontToNestedTextViews() {
+		this.setFont("ubuntu")
+		val activity = Robolectric.buildActivity(FontTestActivity::class.java).create().get()
+
+		val dialog = Dialog(activity)
+		val tvLabel = TextView(activity)
+		dialog.setContentView(LinearLayout(activity).apply { this.addView(tvLabel) })
+
+		FontPreference.applyTo(dialog)
+
+		assertEquals(FontPreference.typeface(activity), tvLabel.typeface)
+	}
+
+	/** The Dialog overload leaves text untouched when the system font is selected. */
+	@Test fun applyToDialogIsNoOpForSystem() {
+		this.setFont("system")
+		val activity = Robolectric.buildActivity(FontTestActivity::class.java).create().get()
+
+		val dialog = Dialog(activity)
+		val tvLabel = TextView(activity)
+		val before = tvLabel.typeface
+		dialog.setContentView(tvLabel)
+
+		FontPreference.applyTo(dialog)
+
+		assertEquals(before, tvLabel.typeface)
 	}
 }
 


### PR DESCRIPTION
Follow-up to the font picker: fixes the spots where the chosen font wasn't applying.

## What wasn't working
- **App labels in the dash**, and **labels/headers in Lens search results**
- **Dialog titles**

(The dev logs screen is intentionally left on the system font.)

## Why
The font is applied app-wide by a `LayoutInflater.Factory2` installed on each **activity's** inflater. Two paths bypassed it:

1. **Dash / Lens labels** — these adapters (`desktop/dash/GridAdapter`, `desktop/dash/lens/CollectionGridAdapter`, `desktop/dash/lens/GridAdapter`) inflated their rows with the **application context**, whose inflater has no factory. This is also why the dash *page title* (inflated via the activity context) already changed but the app *labels* didn't.
2. **Dialog titles** — the title is inflated through the **dialog window's own inflater**, which doesn't carry the activity factory, and `ModernDialogTitle` hardcodes `sans-serif-medium`, so the factory never touched it.

## Fix
1. Inflate adapter rows with **`parent.getContext()`** (the activity) instead of the application context — the idiomatic adapter pattern — so the factory applies. The nested Lens grid chains correctly off the same context.
2. Add **`FontPreference.applyTo(Dialog)`** that sweeps the dialog's decor view and forces the chosen typeface onto every `TextView` (title + chrome), preserving each view's bold/italic style. Hooked into each dialog's existing `onShow` listener (`WidgetPickerDialog`, `Lens`, `ExceptionHandler`). No-op for the system font.

## Known remaining gaps (out of scope)
- Framework-built **preference dialog** titles (e.g. the icon-pack `ListPreference`) still use the default font — would need a broader, context-wrapping approach.
- The floating **`LauncherService`** launcher uses a service context (unchanged).

## Verification
- `./gradlew :app:assembleDebug :app:testDebugUnitTest` — green.
- Added unit tests covering the `Dialog` sweep (applies the chosen font to nested TextViews; no-op for System).
- Manual: with a non-system font, the dash app labels, Lens result labels/headers, and the widget-picker dialog title all follow the selection; System stays stock.

https://claude.ai/code/session_01XQMzY9X3iZnmrvkr2QepAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQMzY9X3iZnmrvkr2QepAC)_