### PR TITLE
Configurable home-screen gestures (Gestures preferences section)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,13 +183,21 @@ etc/                                        — design assets (SVG/XCF sources, 
     tracking an openness fraction (blur/panel/overlay follow the same
     fraction) and settles open or closed when the finger lifts.
   - `HomeGestureController` — the home screen's swipe gestures on empty
-    desktop space: swiping up pulls in the dash tracking the finger (with
+    desktop space. Swipe-up and swipe-down are each configurable
+    (`home/GestureAction`, persisted via `GESTURE_SWIPE_UP`/
+    `GESTURE_SWIPE_DOWN`, edited in the Gestures preferences section): open
+    the dash, open the dash and focus search, open the notification tray, or
+    do nothing. Opening the dash tracks the finger in either direction (with
     the theme's own open animation scrubbed by the swipe — see
-    `DashAnimator`), and swiping sideways pans between the widget desktops
+    `DashAnimator`); swiping sideways pans between the widget desktops
     (`widgets/WidgetsPager`). It is also `SwipeToCloseLayout`'s delegate for
-    swiping the open dash closed. (Swiping down once pulled down the system
-    notification shade, but the only API for that is blocklisted to
-    non-system apps on modern Android, so it was dropped.)
+    swiping the open dash closed. The notification-tray action can't be
+    finger-tracked (the only API for it is an `AccessibilityService`'s global
+    action — see `accessibility/NotificationAccessibilityService`, since the
+    `StatusBarManager` route is blocklisted for non-system apps), so its
+    commit is decided on release; it is offered only once that service is
+    enabled, and a no-lockout rule (`GestureAction.reconcileOther`) keeps at
+    least one of the two gestures opening the dash.
     Touch routing gotcha: the widget pager is clickable (tap = exit widget
     edit mode), so empty-desktop touches are consumed by it and never reach
     `Activity#onTouchEvent` — HomeActivity therefore feeds the pager's

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -144,6 +144,16 @@
 				android:value="be.robinj.distrohopper.preferences.PreferencesActivity" />
 		</activity>
 		<activity
+			android:name="be.robinj.distrohopper.accessibility.AccessibilityGestureSetupActivity"
+			android:label="@string/title_activity_gesture_setup"
+			android:parentActivityName="be.robinj.distrohopper.preferences.PreferencesActivity"
+			android:theme="@style/OnboardingTheme"
+			android:exported="false">
+			<meta-data
+				android:name="android.support.PARENT_ACTIVITY"
+				android:value="be.robinj.distrohopper.preferences.PreferencesActivity" />
+		</activity>
+		<activity
 			android:name="be.robinj.distrohopper.dev.DevLogsActivity"
 			android:label="@string/title_activity_dev_logs"
 			android:parentActivityName="be.robinj.distrohopper.preferences.PreferencesActivity"

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -48,6 +48,7 @@ import be.robinj.distrohopper.dev.Log;
 import be.robinj.distrohopper.home.CustomiseModeUi;
 import be.robinj.distrohopper.home.DashController;
 import be.robinj.distrohopper.home.Desktops;
+import be.robinj.distrohopper.home.GestureAction;
 import be.robinj.distrohopper.home.HomeGestureController;
 import be.robinj.distrohopper.home.HomeStateBinder;
 import be.robinj.distrohopper.home.HomeViewModel;
@@ -196,7 +197,10 @@ public class HomeActivity extends AppCompatActivity
 			HomeStateBinder.bind (this, this.viewModel, this.dash, this.themeApplier);
 			this.gestures = new HomeGestureController (this, this.viewFinder, this.dash,
 					this.viewModel, () -> container.getCustomiseMode ().getValue (),
-					() -> prefs.getBoolean (Preference.GESTURE_NOTIFICATION_TRAY.getName (), false),
+					() -> GestureAction.fromValue (
+						prefs.getString (Preference.GESTURE_SWIPE_UP.getName (), "open_dash")),
+					() -> GestureAction.fromValue (
+						prefs.getString (Preference.GESTURE_SWIPE_DOWN.getName (), "none")),
 					() -> { this.promptEnableNotificationAccessibility (); return kotlin.Unit.INSTANCE; });
 			((SwipeToCloseLayout) this.llDash).setDelegate (this.gestures);
 
@@ -580,10 +584,9 @@ public class HomeActivity extends AppCompatActivity
 	}
 
 	/**
-	 * Swipe-down-for-notifications fired, but the accessibility service that
-	 * performs the action isn't enabled yet. Brisk nudge: drop the user onto the
-	 * system accessibility settings so they can turn DistroHopper on. (Toast text
-	 * is kept inline rather than in strings.xml while this is experimental.)
+	 * A gesture mapped to the notification tray fired, but the accessibility
+	 * service that performs the action isn't connected yet. Brisk nudge: drop the
+	 * user onto the system accessibility settings so they can turn DistroHopper on.
 	 */
 	private void promptEnableNotificationAccessibility ()
 	{

--- a/app/src/main/java/be/robinj/distrohopper/accessibility/AccessibilityGestureSetupActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/accessibility/AccessibilityGestureSetupActivity.kt
@@ -1,0 +1,56 @@
+package be.robinj.distrohopper.accessibility
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.Toast
+import android.widget.ViewFlipper
+import androidx.appcompat.app.AppCompatActivity
+import be.robinj.distrohopper.ExceptionHandler
+import be.robinj.distrohopper.R
+
+/**
+ * A small, onboarding-styled wizard that explains why the notification-tray
+ * gesture needs an accessibility service (and that the service does nothing
+ * else), then guides the user to turn it on. Auto-finishes once the service is
+ * enabled. Launched from the Gestures preferences when the service is off.
+ */
+class AccessibilityGestureSetupActivity : AppCompatActivity() {
+	private lateinit var flipper: ViewFlipper
+
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+		this.setContentView(R.layout.activity_accessibility_gesture_setup)
+		this.flipper = this.findViewById(R.id.vfGestureSetup)
+
+		this.findViewById<Button>(R.id.btnGestureSetupCancel).setOnClickListener { this.finish() }
+		this.findViewById<Button>(R.id.btnGestureSetupProceed).setOnClickListener {
+			this.flipper.displayedChild = STEP_GUIDE
+			this.openAccessibilitySettings()
+		}
+		this.findViewById<Button>(R.id.btnGestureSetupOpenSettings).setOnClickListener {
+			this.openAccessibilitySettings()
+		}
+	}
+
+	override fun onResume() {
+		super.onResume()
+
+		// Returning with the service granted is the success exit. //
+		if (NotificationAccessibilityService.isEnabled(this)) {
+			Toast.makeText(this, R.string.toast_gesture_setup_enabled, Toast.LENGTH_SHORT).show()
+			this.finish()
+		}
+	}
+
+	private fun openAccessibilitySettings() {
+		try {
+			this.startActivity(NotificationAccessibilityService.accessibilitySettingsIntent())
+		} catch (ex: Exception) {
+			ExceptionHandler(ex).show(this)
+		}
+	}
+
+	companion object {
+		private const val STEP_GUIDE = 1
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/accessibility/AccessibilityGestureSetupActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/accessibility/AccessibilityGestureSetupActivity.kt
@@ -23,9 +23,10 @@ class AccessibilityGestureSetupActivity : AppCompatActivity() {
 		this.flipper = this.findViewById(R.id.vfGestureSetup)
 
 		this.findViewById<Button>(R.id.btnGestureSetupCancel).setOnClickListener { this.finish() }
+		// Proceed only advances to the guide page; the user reads it and opens
+		// settings from there (launching settings here would bury the guide). //
 		this.findViewById<Button>(R.id.btnGestureSetupProceed).setOnClickListener {
 			this.flipper.displayedChild = STEP_GUIDE
-			this.openAccessibilitySettings()
 		}
 		this.findViewById<Button>(R.id.btnGestureSetupOpenSettings).setOnClickListener {
 			this.openAccessibilitySettings()

--- a/app/src/main/java/be/robinj/distrohopper/accessibility/NotificationAccessibilityService.kt
+++ b/app/src/main/java/be/robinj/distrohopper/accessibility/NotificationAccessibilityService.kt
@@ -1,7 +1,13 @@
 package be.robinj.distrohopper.accessibility
 
 import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
 import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityManager
 
 /**
  * The only public route left for a non-system launcher to open the notification
@@ -11,8 +17,8 @@ import android.view.accessibility.AccessibilityEvent
  * home screen reaches the running instance through the [instance] singleton (a
  * different process component can't bind to it directly for this).
  *
- * Experimental and opt-in: gated behind the GESTURE_NOTIFICATION_TRAY developer
- * setting and the user manually granting the service in system settings.
+ * Opt-in: a swipe gesture only maps to it once the user has granted the service
+ * in system settings (see [isEnabled]).
  */
 class NotificationAccessibilityService : AccessibilityService() {
 	override fun onServiceConnected() {
@@ -43,5 +49,41 @@ class NotificationAccessibilityService : AccessibilityService() {
 
 		val isConnected: Boolean
 			get() = instance != null
+
+		private fun component(context: Context): ComponentName =
+			ComponentName(context, NotificationAccessibilityService::class.java)
+
+		/**
+		 * Whether the user has granted this service in system accessibility
+		 * settings — distinct from [isConnected], which only reflects a live bind.
+		 */
+		@JvmStatic
+		fun isEnabled(context: Context): Boolean {
+			val component = component(context)
+			val manager =
+				context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+			val running = manager?.getEnabledAccessibilityServiceList(
+				AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+			if (running != null && running.any { it.id == component.flattenToString() }) {
+				return true
+			}
+
+			// Fallback: parse the secure setting directly (the manager list can lag
+			// a just-granted service). //
+			val enabled = Settings.Secure.getString(
+				context.contentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+				?: return false
+			val flat = component.flattenToString()
+			return enabled.split(':').any { it.equals(flat, ignoreCase = true) }
+		}
+
+		/**
+		 * Opens the system accessibility settings list (reliable across OEMs); the
+		 * user enables DistroHopper's service from there.
+		 */
+		@JvmStatic
+		fun accessibilitySettingsIntent(): Intent =
+			Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+				.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/DashController.kt
@@ -117,13 +117,14 @@ class DashController(
 		}
 	}
 
-	fun open() {
+	@JvmOverloads
+	fun open(forceSearchFocus: Boolean = false) {
 		if (this.isOpen) {
 			return
 		}
 
 		this.animator.open(this.blurRadiusPx())
-		this.applyOpenedChrome()
+		this.applyOpenedChrome(forceSearchFocus)
 
 		this.isOpen = true
 	}
@@ -175,14 +176,14 @@ class DashController(
 	 * Ends a finger-tracked open: [commit] settles the dash fully open and
 	 * applies the opened chrome, otherwise it settles back closed.
 	 */
-	fun swipeOpenEnd(commit: Boolean) {
+	fun swipeOpenEnd(commit: Boolean, forceSearchFocus: Boolean = false) {
 		if (this.isOpen || ! this.animator.swipeInProgress) {
 			return
 		}
 
 		if (commit) {
 			this.animator.swipeSettle(open = true)
-			this.applyOpenedChrome()
+			this.applyOpenedChrome(forceSearchFocus)
 			this.isOpen = true
 		} else {
 			this.animator.swipeSettle(open = false) { this.teardownDashViews() }
@@ -208,10 +209,10 @@ class DashController(
 		this.activity.resources.getDimensionPixelSize(this.theme.dash_blur_radius)
 
 	/** The non-dash side of opening: the panel's close button, backgrounds and search focus. */
-	private fun applyOpenedChrome() {
+	private fun applyOpenedChrome(forceSearchFocus: Boolean = false) {
 		val llPanel = this.viewFinder.get<LinearLayout>(R.id.llPanel)
 
-		if (this.prefs.getBoolean(Preference.DASH_SEARCH_FOCUS_ON_OPEN, false)) {
+		if (forceSearchFocus || this.prefs.getBoolean(Preference.DASH_SEARCH_FOCUS_ON_OPEN, false)) {
 			val llDashContent = this.viewFinder.get<LinearLayout>(R.id.llDashContent)
 			val etDashSearch = this.viewFinder.get<EditText>(R.id.etDashSearch)
 			// Defer until the dash view is laid out/visible so the focus and

--- a/app/src/main/java/be/robinj/distrohopper/home/GestureAction.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/GestureAction.kt
@@ -1,0 +1,40 @@
+package be.robinj.distrohopper.home
+
+/**
+ * What a home-screen swipe-up or swipe-down gesture does. The [value] is the
+ * string persisted in SharedPreferences (and used as the ListPreference entry
+ * value), kept stable across releases.
+ *
+ * Only [OPEN_DASH] and [OPEN_DASH_SEARCH] open the dash; [reconcileOther] uses
+ * that to enforce the no-lockout rule — at least one of the two gestures must
+ * keep the dash reachable.
+ */
+enum class GestureAction(val value: String) {
+	/** Do nothing (the swipe is inert). */
+	NONE("none"),
+	/** Open the dash. */
+	OPEN_DASH("open_dash"),
+	/** Open the dash and focus the search field, raising the keyboard. */
+	OPEN_DASH_SEARCH("open_dash_search"),
+	/** Open the system notification tray (needs the accessibility service). */
+	NOTIFICATIONS("notifications_tray");
+
+	val opensDash: Boolean
+		get() = this == OPEN_DASH || this == OPEN_DASH_SEARCH
+
+	companion object {
+		@JvmStatic
+		fun fromValue(value: String?): GestureAction =
+			entries.firstOrNull { it.value == value } ?: NONE
+
+		/**
+		 * No-lockout reconciliation: given that one gesture was just set to
+		 * [changed], returns the value the OTHER gesture must take so the dash
+		 * stays reachable, or null when no change is needed. (At least one of the
+		 * two gestures must open the dash.)
+		 */
+		@JvmStatic
+		fun reconcileOther(changed: GestureAction, other: GestureAction): GestureAction? =
+			if (! changed.opensDash && ! other.opensDash) OPEN_DASH else null
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/home/HomeGestureController.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/HomeGestureController.kt
@@ -16,16 +16,18 @@ import kotlin.math.abs
  * The home screen's swipe gestures. On empty desktop space (the widget
  * pager's OnTouchListener feeds in its touches, and HomeActivity those no
  * view claimed; the panel and launcher are excluded by hit-testing):
- *  - swiping up slides the dash in, tracking the finger with the theme's
- *    own open animation — DashController and DashAnimator do the visual
- *    work — committing or cancelling when it lifts;
- *  - swiping down opens the system notification tray, but only when the
- *    experimental [notificationGestureEnabled] developer setting is on. The
- *    only public API for that is an accessibility service's global action, so
- *    the shade can't be finger-tracked: the commit decision (same fling /
- *    distance thresholds as the dash open) is made on release. If the service
- *    isn't actually connected, [promptEnableAccessibility] nudges the user to
- *    enable it instead;
+ *  - swiping up or down runs the user-configured [GestureAction] for that
+ *    direction ([swipeUpAction] / [swipeDownAction]):
+ *     - opening the dash slides it in tracking the finger with the theme's own
+ *       open animation (DashController and DashAnimator do the visual work),
+ *       either direction, committing or cancelling when it lifts; the search
+ *       variant additionally focuses the dash search field;
+ *     - opening the notification tray goes through the accessibility service's
+ *       global action, which can't be finger-tracked, so the commit decision
+ *       (same fling / distance thresholds as the dash open) is made on release;
+ *       if the service isn't connected, [promptEnableAccessibility] nudges the
+ *       user to enable it;
+ *     - "do nothing" leaves the swipe inert;
  *  - swiping sideways pans between the widget desktops (WidgetsPager does
  *    the same for swipes that start on a widget).
  * As SwipeToCloseLayout's delegate it likewise tracks the open dash being
@@ -41,7 +43,8 @@ class HomeGestureController(
 	private val dash: DashController,
 	private val viewModel: HomeViewModel,
 	private val customiseMode: () -> Boolean,
-	private val notificationGestureEnabled: () -> Boolean = { false },
+	private val swipeUpAction: () -> GestureAction = { GestureAction.OPEN_DASH },
+	private val swipeDownAction: () -> GestureAction = { GestureAction.NONE },
 	private val serviceConnected: () -> Boolean = { NotificationAccessibilityService.isConnected },
 	private val onOpenNotifications: () -> Unit =
 		{ NotificationAccessibilityService.instance?.openNotifications() },
@@ -49,7 +52,7 @@ class HomeGestureController(
 ) : SwipeToCloseLayout.Delegate {
 	/**
 	 * Production constructor (Java call site): the service-touching callbacks use
-	 * their real implementations; only the two app-supplied behaviours are passed.
+	 * their real implementations; only the app-supplied behaviours are passed.
 	 */
 	constructor(
 		activity: Activity,
@@ -57,14 +60,15 @@ class HomeGestureController(
 		dash: DashController,
 		viewModel: HomeViewModel,
 		customiseMode: () -> Boolean,
-		notificationGestureEnabled: () -> Boolean,
+		swipeUpAction: () -> GestureAction,
+		swipeDownAction: () -> GestureAction,
 		promptEnableAccessibility: () -> Unit,
-	) : this(activity, viewFinder, dash, viewModel, customiseMode, notificationGestureEnabled,
+	) : this(activity, viewFinder, dash, viewModel, customiseMode, swipeUpAction, swipeDownAction,
 		{ NotificationAccessibilityService.isConnected },
 		{ NotificationAccessibilityService.instance?.openNotifications() },
 		promptEnableAccessibility)
 
-	private enum class State { IDLE, PENDING, TRACKING_OPEN, TRACKING_PAGES, TRACKING_NOTIFICATIONS, INSTANT_OPEN, DONE }
+	private enum class State { IDLE, PENDING, TRACKING_OPEN, TRACKING_PAGES, TRACKING_ACTION, INSTANT_OPEN, DONE }
 
 	private val touchSlop = ViewConfiguration.get(activity).scaledTouchSlop
 	private val flingVelocityPx =
@@ -74,6 +78,10 @@ class HomeGestureController(
 	private var downX = 0F
 	private var downY = 0F
 	private var startOpenness = 0F
+	/** Whether the in-flight vertical gesture travels downward (only one is ever live). */
+	private var swipeDownward = false
+	/** Whether the in-flight dash open should force the search field to focus. */
+	private var forceSearch = false
 	private var velocityTracker: VelocityTracker? = null
 
 	private var closeTracking = false
@@ -116,10 +124,10 @@ class HomeGestureController(
 				when (this.state) {
 					State.PENDING -> this.maybeStart(ev)
 					State.TRACKING_OPEN -> this.dash.swipeUpdate(this.startOpenness
-						+ (this.downY - ev.y) / this.dash.swipeDistancePx)
+						+ this.openTravel(ev) / this.dash.swipeDistancePx)
 					State.TRACKING_PAGES -> this.pager.panBy(this.downX - ev.x)
-					State.INSTANT_OPEN -> if (this.downY - ev.y > this.touchSlop * 4F) {
-						this.dash.open()
+					State.INSTANT_OPEN -> if (this.openTravel(ev) > this.touchSlop * 4F) {
+						this.dash.open(this.forceSearch)
 						this.viewModel.openDash()
 						this.state = State.DONE
 					}
@@ -132,27 +140,24 @@ class HomeGestureController(
 
 				when (this.state) {
 					State.TRACKING_OPEN -> {
-						val velocityY = this.currentVelocity { it.yVelocity }
-						val commit = if (abs(velocityY) > this.flingVelocityPx) {
-							velocityY < 0F // Flung in the opening (upward) direction //
+						val commit = if (this.flung()) {
+							this.flungOpen() // Flung in the opening direction //
 						} else {
 							this.dash.swipeOpenness > COMMIT_FRACTION
 						}
 
-						this.dash.swipeOpenEnd(commit)
+						this.dash.swipeOpenEnd(commit, this.forceSearch)
 						if (commit) {
 							this.viewModel.openDash()
 						}
 					}
 					State.TRACKING_PAGES ->
 						this.pager.panSettle(this.currentVelocity { it.xVelocity })
-					State.TRACKING_NOTIFICATIONS -> {
-						val velocityY = this.currentVelocity { it.yVelocity }
-						val distance = ev.y - this.downY
-						val commit = if (abs(velocityY) > this.flingVelocityPx) {
-							velocityY > 0F // Flung in the opening (downward) direction //
+					State.TRACKING_ACTION -> {
+						val commit = if (this.flung()) {
+							this.flungOpen() // Flung in the gesture's direction //
 						} else {
-							distance > this.dash.swipeDistancePx * COMMIT_FRACTION
+							this.openTravel(ev) > this.dash.swipeDistancePx * COMMIT_FRACTION
 						}
 
 						if (commit) {
@@ -199,25 +204,41 @@ class HomeGestureController(
 			return // Not (yet) locked to either axis //
 		}
 
-		if (dy >= 0F) {
-			// Downwards opens the notification tray, if the experimental gesture
-			// is enabled. There is nothing to finger-track (the shade isn't ours);
-			// the commit decision is made on release. //
-			if (this.notificationGestureEnabled()) {
-				this.state = State.TRACKING_NOTIFICATIONS
+		this.swipeDownward = dy >= 0F
+		val action = if (this.swipeDownward) this.swipeDownAction() else this.swipeUpAction()
+		this.forceSearch = action == GestureAction.OPEN_DASH_SEARCH
+
+		when (action) {
+			GestureAction.NONE -> return // Inert: leave the swipe unconsumed //
+			GestureAction.OPEN_DASH, GestureAction.OPEN_DASH_SEARCH ->
+				if (this.dash.swipeOpenBegin()) { // Pull in the dash, tracking the finger //
+					this.state = State.TRACKING_OPEN
+					this.startOpenness = this.dash.swipeOpenness
+					this.downY = ev.y // Track from where the swipe was recognised //
+				} else { // Battery saver: nothing to track; open at the trigger distance //
+					this.state = State.INSTANT_OPEN
+				}
+			GestureAction.NOTIFICATIONS -> {
+				// The notification shade isn't ours to finger-track; the commit
+				// decision is made on release. //
+				this.state = State.TRACKING_ACTION
 				this.downY = ev.y // Track from where the swipe was recognised //
 			}
-
-			return
 		}
+	}
 
-		if (this.dash.swipeOpenBegin()) { // Upwards: pull in the dash //
-			this.state = State.TRACKING_OPEN
-			this.startOpenness = this.dash.swipeOpenness
-			this.downY = ev.y // Track from where the swipe was recognised //
-		} else { // Battery saver: nothing to track; open at the trigger distance //
-			this.state = State.INSTANT_OPEN
-		}
+	/** How far the finger has travelled in the gesture's opening direction. */
+	private fun openTravel(ev: MotionEvent): Float =
+		if (this.swipeDownward) ev.y - this.downY else this.downY - ev.y
+
+	/** Whether the lift was a fling (fast enough for direction alone to decide). */
+	private fun flung(): Boolean =
+		abs(this.currentVelocity { it.yVelocity }) > this.flingVelocityPx
+
+	/** Whether a fling went in the gesture's opening direction. */
+	private fun flungOpen(): Boolean {
+		val velocityY = this.currentVelocity { it.yVelocity }
+		return if (this.swipeDownward) velocityY > 0F else velocityY < 0F
 	}
 
 	private fun openNotifications() {

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
@@ -68,8 +68,10 @@ enum class Preference(
 	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false, DEV),
 	/** Dev: show a dot at every grid intersection while dragging or resizing. */
 	DEV_SHOW_GRID_ON_DRAG("dev_show_grid_on_drag", false, DEV),
-	/** Dev: experimental swipe-down gesture that opens the notification shade. */
-	GESTURE_NOTIFICATION_TRAY("gesture_notification_tray", false, DEV);
+	/** What the home-screen swipe-up gesture does (a GestureAction value). */
+	GESTURE_SWIPE_UP("gesture_swipe_up", "open_dash"),
+	/** What the home-screen swipe-down gesture does (a GestureAction value). */
+	GESTURE_SWIPE_DOWN("gesture_swipe_down", "none");
 
 	fun getName(): String = this.key
 

--- a/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/PreferencesActivity.java
@@ -38,6 +38,9 @@ import be.robinj.distrohopper.ContributeActivity;
 import be.robinj.distrohopper.DependencyContainer;
 import be.robinj.distrohopper.ExceptionHandler;
 import be.robinj.distrohopper.HomeRole;
+import be.robinj.distrohopper.accessibility.AccessibilityGestureSetupActivity;
+import be.robinj.distrohopper.accessibility.NotificationAccessibilityService;
+import be.robinj.distrohopper.home.GestureAction;
 import be.robinj.distrohopper.IconPackHelper;
 import be.robinj.distrohopper.InsetsHelper;
 import be.robinj.distrohopper.R;
@@ -144,6 +147,7 @@ public class PreferencesActivity extends AppCompatActivity
 
 			this.addCategory (R.string.pref_header_appearance, R.xml.pref_appearance);
 			this.addCategory (R.string.pref_header_functionality, R.xml.pref_functionality);
+			this.addCategory (R.string.pref_header_gestures, R.xml.pref_gestures);
 			this.addCategory (R.string.pref_header_advanced, R.xml.pref_advanced);
 			this.devCategory = this.addCategory (R.string.pref_header_dev, R.xml.pref_dev);
 
@@ -151,7 +155,7 @@ public class PreferencesActivity extends AppCompatActivity
 			this.initCrashReportsPreference ();
 			this.initLauncherPinModePreference ();
 			this.initDevPreference ();
-			this.initNotificationGesturePreference ();
+			this.initGesturePreferences ();
 
 			this.findPreference ("dummy_wallpaper").setOnPreferenceClickListener (
 				new Preference.OnPreferenceClickListener ()
@@ -303,6 +307,10 @@ public class PreferencesActivity extends AppCompatActivity
 			{
 				setDefaultLauncher.setVisible (! HomeRole.isHeld (this.requireContext ()));
 			}
+
+			// Re-evaluate the notification-tray option in case the user just
+			// enabled (or disabled) the accessibility service. //
+			this.applyGesturePreferences ();
 		}
 
 		// The icon-pack and app-sort-order pickers are framework-created ListPreference
@@ -372,38 +380,103 @@ public class PreferencesActivity extends AppCompatActivity
 			});
 		}
 
-		// Experimental swipe-down-for-notifications gesture. It needs the
-		// accessibility service the user has to grant by hand, so switching it on
-		// drops them straight onto the system accessibility settings. No guided
-		// flow — this is a developer-only experiment for now. //
-		private void initNotificationGesturePreference ()
+		// The swipe-up / swipe-down gesture dropdowns. The notification-tray
+		// option is only offered once the accessibility service is enabled, and a
+		// no-lockout rule keeps at least one gesture opening the dash. Re-run on
+		// resume because the user may return from the enable wizard / system
+		// settings with the service now on. //
+		private void initGesturePreferences ()
 		{
-			final SwitchPreferenceCompat pref = this.findPreference (
-				be.robinj.distrohopper.preferences.Preference.GESTURE_NOTIFICATION_TRAY.getName ());
-			if (pref == null)
+			this.applyGesturePreferences ();
+		}
+
+		private void applyGesturePreferences ()
+		{
+			final ListPreference up = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.GESTURE_SWIPE_UP.getName ());
+			final ListPreference down = this.findPreference (
+				be.robinj.distrohopper.preferences.Preference.GESTURE_SWIPE_DOWN.getName ());
+			if (up == null || down == null)
 				return;
 
-			pref.setOnPreferenceChangeListener ((preference, newValue) ->
-			{
-				if (Boolean.TRUE.equals (newValue))
-				{
-					try
-					{
-						// Toast kept inline (not in strings.xml) while experimental. //
-						Toast.makeText (this.requireContext (),
-							"Enable DistroHopper in the list to use the notification gesture",
-							Toast.LENGTH_LONG).show ();
-						this.startActivity (
-							new Intent (android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS));
-					}
-					catch (Exception ex)
-					{
-						new ExceptionHandler (ex).show (this.requireActivity ());
-					}
-				}
+			final boolean serviceEnabled =
+				NotificationAccessibilityService.isEnabled (this.requireContext ());
 
+			this.populateGestureList (up, serviceEnabled);
+			this.populateGestureList (down, serviceEnabled);
+
+			// A stored notifications choice can't work with the service off: fall
+			// back to opening the dash. //
+			if (! serviceEnabled)
+			{
+				resetIfNotifications (up);
+				resetIfNotifications (down);
+			}
+
+			up.setSummaryProvider (ListPreference.SimpleSummaryProvider.getInstance ());
+			down.setSummaryProvider (ListPreference.SimpleSummaryProvider.getInstance ());
+
+			up.setOnPreferenceChangeListener ((preference, newValue) ->
+			{
+				reconcileSiblingGesture (down, String.valueOf (newValue));
 				return true;
 			});
+			down.setOnPreferenceChangeListener ((preference, newValue) ->
+			{
+				reconcileSiblingGesture (up, String.valueOf (newValue));
+				return true;
+			});
+
+			final Preference enableRow = this.findPreference ("dummy_enable_notification_gestures");
+			if (enableRow != null)
+			{
+				enableRow.setVisible (! serviceEnabled);
+				enableRow.setOnPreferenceClickListener (preference ->
+				{
+					this.startActivity (new Intent (this.requireContext (),
+						AccessibilityGestureSetupActivity.class));
+					return true;
+				});
+			}
+		}
+
+		private void populateGestureList (final ListPreference pref, final boolean withNotifications)
+		{
+			final List<CharSequence> entries = new ArrayList<> ();
+			final List<CharSequence> values = new ArrayList<> ();
+
+			entries.add (this.getString (R.string.gesture_action_none));
+			values.add (GestureAction.NONE.getValue ());
+			entries.add (this.getString (R.string.gesture_action_open_dash));
+			values.add (GestureAction.OPEN_DASH.getValue ());
+			entries.add (this.getString (R.string.gesture_action_open_dash_search));
+			values.add (GestureAction.OPEN_DASH_SEARCH.getValue ());
+			if (withNotifications)
+			{
+				entries.add (this.getString (R.string.gesture_action_notifications_tray));
+				values.add (GestureAction.NOTIFICATIONS.getValue ());
+			}
+
+			pref.setEntries (entries.toArray (new CharSequence[0]));
+			pref.setEntryValues (values.toArray (new CharSequence[0]));
+		}
+
+		private static void resetIfNotifications (final ListPreference pref)
+		{
+			if (GestureAction.fromValue (pref.getValue ()) == GestureAction.NOTIFICATIONS)
+				pref.setValue (GestureAction.OPEN_DASH.getValue ());
+		}
+
+		// Enforce the no-lockout rule: once one gesture is set to [changedValue],
+		// nudge the other back to "open dash" if neither would open the dash.
+		// Package-private + static so it can be unit-tested without the Activity. //
+		static void reconcileSiblingGesture (final ListPreference other, final String changedValue)
+		{
+			final GestureAction fix = GestureAction.reconcileOther (
+				GestureAction.fromValue (changedValue),
+				GestureAction.fromValue (other.getValue ()));
+			if (fix != null)
+				other.setValue (fix.getValue ());
 		}
 
 		// Only surface the developer options section while developer mode is on;

--- a/app/src/main/res/layout/activity_accessibility_gesture_setup.xml
+++ b/app/src/main/res/layout/activity_accessibility_gesture_setup.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Full-screen over the wallpaper, like onboarding; the scrim keeps the copy
+     legible. Two steps swapped with a ViewFlipper. -->
+<FrameLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:background="@drawable/onboarding_scrim">
+
+	<ViewFlipper
+		android:id="@+id/vfGestureSetup"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent">
+
+		<!-- Step 1: explanation + cancel / proceed -->
+		<FrameLayout
+			android:layout_width="match_parent"
+			android:layout_height="match_parent">
+
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_gravity="center"
+				android:gravity="center_horizontal"
+				android:orientation="vertical"
+				android:padding="32dp">
+
+				<TextView
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:gravity="center"
+					android:text="@string/gesture_setup_explain_title"
+					android:textColor="@android:color/white"
+					android:textSize="28sp"
+					android:textStyle="bold" />
+
+				<TextView
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="16dp"
+					android:gravity="center"
+					android:lineSpacingExtra="4dp"
+					android:text="@string/gesture_setup_explain_body"
+					android:textColor="@color/transparent30"
+					android:textSize="16sp" />
+
+				<LinearLayout
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="32dp"
+					android:gravity="center"
+					android:orientation="horizontal">
+
+					<Button
+						android:id="@+id/btnGestureSetupCancel"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:layout_marginEnd="12dp"
+						android:background="@android:color/transparent"
+						android:stateListAnimator="@null"
+						android:text="@string/gesture_setup_cancel"
+						android:textColor="@android:color/white" />
+
+					<Button
+						android:id="@+id/btnGestureSetupProceed"
+						android:layout_width="wrap_content"
+						android:layout_height="wrap_content"
+						android:background="@drawable/onboarding_button_primary"
+						android:minWidth="160dp"
+						android:paddingStart="32dp"
+						android:paddingEnd="32dp"
+						android:stateListAnimator="@null"
+						android:text="@string/gesture_setup_proceed"
+						android:textColor="@android:color/white" />
+				</LinearLayout>
+			</LinearLayout>
+		</FrameLayout>
+
+		<!-- Step 2: guide to the system toggle -->
+		<FrameLayout
+			android:layout_width="match_parent"
+			android:layout_height="match_parent">
+
+			<LinearLayout
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_gravity="center"
+				android:gravity="center_horizontal"
+				android:orientation="vertical"
+				android:padding="32dp">
+
+				<TextView
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:gravity="center"
+					android:text="@string/gesture_setup_guide_title"
+					android:textColor="@android:color/white"
+					android:textSize="28sp"
+					android:textStyle="bold" />
+
+				<TextView
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="16dp"
+					android:gravity="center"
+					android:lineSpacingExtra="4dp"
+					android:text="@string/gesture_setup_guide_body"
+					android:textColor="@color/transparent30"
+					android:textSize="16sp" />
+
+				<Button
+					android:id="@+id/btnGestureSetupOpenSettings"
+					android:layout_width="wrap_content"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="32dp"
+					android:background="@drawable/onboarding_button_primary"
+					android:minWidth="160dp"
+					android:paddingStart="32dp"
+					android:paddingEnd="32dp"
+					android:stateListAnimator="@null"
+					android:text="@string/gesture_setup_open_settings"
+					android:textColor="@android:color/white" />
+			</LinearLayout>
+		</FrameLayout>
+	</ViewFlipper>
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="pref_header_advanced">Advanced</string>
     <string name="pref_header_dev">Developer options</string>
     <string name="pref_header_functionality">Functionality</string>
+    <string name="pref_header_gestures">Gestures</string>
     <string name="pref_header_appearance">Appearance</string>
     <string name="option_launchericon_size">Pinned icon size</string>
     <string name="hint_launchericon_size">How large icons for pinned apps should be. The slider goes from 48dip to 120dip, with the default (right in the middle) being 84dip.</string>
@@ -115,9 +116,30 @@
     <string name="hint_widget_resize_any">Allow widgets to be resized beyond their supported size constraints.</string>
     <string name="option_show_grid_on_drag">Show desktop grid while dragging</string>
     <string name="hint_show_grid_on_drag">Show a dot at each grid intersection while dragging or resizing widgets and apps.</string>
-    <string name="option_gesture_notification_tray">Swipe down for notifications</string>
-    <string name="hint_gesture_notification_tray">Experimental: swipe down on the home screen to open the notification tray. Requires DistroHopper\'s accessibility service to be enabled.</string>
     <string name="accessibility_service_notification_tray_description">Lets DistroHopper open the notification tray when you swipe down on the home screen. Only used to perform that one action; no screen content is read.</string>
+
+    <!-- Gestures preferences -->
+    <string name="option_gesture_swipe_sides">Swipe left or right</string>
+    <string name="hint_gesture_swipe_sides">Switches between desktops. This can\'t be changed.</string>
+    <string name="option_gesture_swipe_up">Swipe up</string>
+    <string name="option_gesture_swipe_down">Swipe down</string>
+    <string name="gesture_action_none">Do nothing</string>
+    <string name="gesture_action_open_dash">Open dash</string>
+    <string name="gesture_action_open_dash_search">Open dash and start search</string>
+    <string name="gesture_action_notifications_tray">Open notifications tray</string>
+    <string name="option_enable_notification_gestures">Enable open notifications tray gestures</string>
+    <string name="hint_enable_notification_gestures">A system accessibility service needs to be enabled in order for this to work.</string>
+
+    <!-- Accessibility gesture setup wizard -->
+    <string name="title_activity_gesture_setup">Notification gestures</string>
+    <string name="gesture_setup_explain_title">Open the notification tray</string>
+    <string name="gesture_setup_explain_body">To open the notification tray from a swipe, DistroHopper needs you to turn on its accessibility service.\n\nThis service is only ever used to open the notification tray. It does not read screen content, collect any data, or perform any other action.</string>
+    <string name="gesture_setup_guide_title">Turn on the service</string>
+    <string name="gesture_setup_guide_body">Find DistroHopper in the accessibility settings list and switch it on, then come back here.</string>
+    <string name="gesture_setup_cancel">Cancel</string>
+    <string name="gesture_setup_proceed">I understand, proceed</string>
+    <string name="gesture_setup_open_settings">Open accessibility settings</string>
+    <string name="toast_gesture_setup_enabled">Notification tray gestures enabled</string>
     <string name="option_rerun_onboarding">Run setup wizard again</string>
     <string name="hint_rerun_onboarding">The first-run setup wizard will be shown the next time DistroHopper starts.</string>
     <string name="toast_rerun_onboarding">Setup wizard will run on next start</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,7 @@
 
     <!-- Gestures preferences -->
     <string name="option_gesture_swipe_sides">Swipe left or right</string>
-    <string name="hint_gesture_swipe_sides">Switches between desktops. This can\'t be changed.</string>
+    <string name="hint_gesture_swipe_sides">Switches between desktops.</string>
     <string name="option_gesture_swipe_up">Swipe up</string>
     <string name="option_gesture_swipe_down">Swipe down</string>
     <string name="gesture_action_none">Do nothing</string>
@@ -133,7 +133,7 @@
     <!-- Accessibility gesture setup wizard -->
     <string name="title_activity_gesture_setup">Notification gestures</string>
     <string name="gesture_setup_explain_title">Open the notification tray</string>
-    <string name="gesture_setup_explain_body">To open the notification tray from a swipe, DistroHopper needs you to turn on its accessibility service.\n\nThis service is only ever used to open the notification tray. It does not read screen content, collect any data, or perform any other action.</string>
+    <string name="gesture_setup_explain_body">Android doesn\'t give ordinary apps any way to open the notification tray — for a home screen like DistroHopper, the only mechanism available is an accessibility service.\n\nThat\'s why DistroHopper\'s accessibility service needs to be enabled. It is used for nothing but opening the notification tray: it does not read what\'s on your screen, collect any data, or perform any other action.</string>
     <string name="gesture_setup_guide_title">Turn on the service</string>
     <string name="gesture_setup_guide_body">Find DistroHopper in the accessibility settings list and switch it on, then come back here.</string>
     <string name="gesture_setup_cancel">Cancel</string>

--- a/app/src/main/res/xml/pref_dev.xml
+++ b/app/src/main/res/xml/pref_dev.xml
@@ -29,13 +29,6 @@
 		android:summary="@string/hint_show_grid_on_drag"
 		android:defaultValue="false" />
 
-	<SwitchPreferenceCompat
-		android:key="gesture_notification_tray"
-		android:dependency="dev"
-		android:title="@string/option_gesture_notification_tray"
-		android:summary="@string/hint_gesture_notification_tray"
-		android:defaultValue="false" />
-
 	<Preference
 		android:key="dummy_rerun_onboarding"
 		android:dependency="dev"

--- a/app/src/main/res/xml/pref_gestures.xml
+++ b/app/src/main/res/xml/pref_gestures.xml
@@ -1,0 +1,34 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+	<!-- Not configurable: a non-selectable hint that surfaces the fixed
+	     swipe-left/right behaviour. -->
+	<Preference
+		android:enabled="false"
+		android:selectable="false"
+		android:persistent="false"
+		android:title="@string/option_gesture_swipe_sides"
+		android:summary="@string/hint_gesture_swipe_sides" />
+
+	<!-- Entries/values are populated in code so the notification-tray option can
+	     be hidden while the accessibility service is off. -->
+	<ListPreference
+		android:key="gesture_swipe_up"
+		android:title="@string/option_gesture_swipe_up"
+		android:dialogTitle="@string/option_gesture_swipe_up"
+		android:defaultValue="open_dash" />
+
+	<ListPreference
+		android:key="gesture_swipe_down"
+		android:title="@string/option_gesture_swipe_down"
+		android:dialogTitle="@string/option_gesture_swipe_down"
+		android:defaultValue="none" />
+
+	<!-- Shown only while the accessibility service is disabled; launches the
+	     enable wizard. -->
+	<Preference
+		android:key="dummy_enable_notification_gestures"
+		android:persistent="false"
+		android:title="@string/option_enable_notification_gestures"
+		android:summary="@string/hint_enable_notification_gestures" />
+
+</PreferenceScreen>

--- a/app/src/test/java/be/robinj/distrohopper/home/GestureActionTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/GestureActionTest.kt
@@ -1,0 +1,74 @@
+package be.robinj.distrohopper.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The gesture-action model and, crucially, the no-lockout reconciliation rule
+ * that keeps at least one of swipe-up/down opening the dash.
+ */
+class GestureActionTest {
+	@Test fun fromValueMapsEveryKnownValue() {
+		assertEquals(GestureAction.NONE, GestureAction.fromValue("none"))
+		assertEquals(GestureAction.OPEN_DASH, GestureAction.fromValue("open_dash"))
+		assertEquals(GestureAction.OPEN_DASH_SEARCH, GestureAction.fromValue("open_dash_search"))
+		assertEquals(GestureAction.NOTIFICATIONS, GestureAction.fromValue("notifications_tray"))
+	}
+
+	@Test fun fromValueDefaultsToNoneForNullOrUnknown() {
+		assertEquals(GestureAction.NONE, GestureAction.fromValue(null))
+		assertEquals(GestureAction.NONE, GestureAction.fromValue(""))
+		assertEquals(GestureAction.NONE, GestureAction.fromValue("nonsense"))
+	}
+
+	@Test fun valueRoundTrips() {
+		for (action in GestureAction.entries) {
+			assertEquals(action, GestureAction.fromValue(action.value))
+		}
+	}
+
+	@Test fun onlyDashActionsOpenTheDash() {
+		assertTrue(GestureAction.OPEN_DASH.opensDash)
+		assertTrue(GestureAction.OPEN_DASH_SEARCH.opensDash)
+		assertFalse(GestureAction.NONE.opensDash)
+		assertFalse(GestureAction.NOTIFICATIONS.opensDash)
+	}
+
+	/**
+	 * The full 4×4 matrix: reconcileOther forces the sibling to OPEN_DASH exactly
+	 * when both gestures would otherwise be non-dash (NONE/NOTIFICATIONS), and
+	 * leaves any pairing alone where one already opens the dash.
+	 */
+	@Test fun reconcileOtherForcesOpenDashOnlyWhenBothAreNonDash() {
+		for (changed in GestureAction.entries) {
+			for (other in GestureAction.entries) {
+				val result = GestureAction.reconcileOther(changed, other)
+				if (! changed.opensDash && ! other.opensDash) {
+					assertEquals("$changed + $other should reconcile to OPEN_DASH",
+						GestureAction.OPEN_DASH, result)
+				} else {
+					assertNull("$changed + $other should need no change", result)
+				}
+			}
+		}
+	}
+
+	@Test fun reconcileOtherMatchesTheSpecExample() {
+		// Set swipe-up to notifications while swipe-down is the default (none):
+		// swipe-down must flip to open dash. //
+		assertEquals(GestureAction.OPEN_DASH,
+			GestureAction.reconcileOther(GestureAction.NOTIFICATIONS, GestureAction.NONE))
+	}
+
+	@Test fun reconcileOtherPreservesADeliberateValidPairing() {
+		// up = open dash + search, down = notifications: dash is still reachable,
+		// so neither gets forced. //
+		assertNull(GestureAction.reconcileOther(
+			GestureAction.NOTIFICATIONS, GestureAction.OPEN_DASH_SEARCH))
+		assertNull(GestureAction.reconcileOther(
+			GestureAction.OPEN_DASH_SEARCH, GestureAction.NOTIFICATIONS))
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/home/HomeGestureControllerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/HomeGestureControllerTest.kt
@@ -73,15 +73,16 @@ class HomeGestureControllerTest {
 			}
 		}
 
-		/* A controller wired up for the experimental notification-tray gesture. */
-		fun notificationGestures(
-			enabled: Boolean = true,
+		/* A controller wired up with explicit per-direction actions. */
+		fun gesturesWith(
+			up: GestureAction = GestureAction.OPEN_DASH,
+			down: GestureAction = GestureAction.NONE,
 			serviceConnected: Boolean = true,
 			onOpen: () -> Unit = {},
 			onPrompt: () -> Unit = {},
 		): HomeGestureController =
 			HomeGestureController(this.activity, this.activity.viewFinder, this.dash,
-				this.viewModel, { false }, { enabled }, { serviceConnected }, onOpen, onPrompt)
+				this.viewModel, { false }, { up }, { down }, { serviceConnected }, onOpen, onPrompt)
 	}
 
 	private fun onHarness(block: (Harness) -> Unit) {
@@ -89,7 +90,7 @@ class HomeGestureControllerTest {
 	}
 
 	@Test fun swipingDownOnEmptySpaceDoesNothing() = this.onHarness { h ->
-		// The notification-tray gesture is off by default; a downward swipe is inert //
+		// Swipe-down defaults to "do nothing"; a downward swipe is inert //
 		h.touch(MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY - 200F, 0)
 		val consumedMove = h.touch(MotionEvent.ACTION_MOVE, h.emptyX, h.emptyY - 100F, 50)
 		val consumedUp = h.touch(MotionEvent.ACTION_UP, h.emptyX, h.emptyY - 100F, 100)
@@ -102,7 +103,8 @@ class HomeGestureControllerTest {
 	@Test fun swipingDownWithTheGestureEnabledOpensNotifications() = this.onHarness { h ->
 		var opened = 0
 		var prompted = 0
-		val g = h.notificationGestures(onOpen = { opened++ }, onPrompt = { prompted++ })
+		val g = h.gesturesWith(down = GestureAction.NOTIFICATIONS,
+			onOpen = { opened++ }, onPrompt = { prompted++ })
 		val distance = h.dash.swipeDistancePx
 
 		h.touch(g, MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY, 0)
@@ -121,7 +123,7 @@ class HomeGestureControllerTest {
 
 	@Test fun aFastFlickDownOpensNotificationsOnVelocityAlone() = this.onHarness { h ->
 		var opened = 0
-		val g = h.notificationGestures(onOpen = { opened++ })
+		val g = h.gesturesWith(down = GestureAction.NOTIFICATIONS, onOpen = { opened++ })
 		val distance = h.dash.swipeDistancePx
 
 		h.touch(g, MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY, 0)
@@ -136,7 +138,7 @@ class HomeGestureControllerTest {
 
 	@Test fun aShortSlowSwipeDownDoesNotOpenNotifications() = this.onHarness { h ->
 		var opened = 0
-		val g = h.notificationGestures(onOpen = { opened++ })
+		val g = h.gesturesWith(down = GestureAction.NOTIFICATIONS, onOpen = { opened++ })
 
 		h.touch(g, MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY, 0)
 		h.touch(g, MotionEvent.ACTION_MOVE, h.emptyX, h.emptyY + h.slop * 3F, 200)
@@ -149,7 +151,7 @@ class HomeGestureControllerTest {
 	@Test fun swipingDownWithoutTheServiceConnectedPromptsToEnableIt() = this.onHarness { h ->
 		var opened = 0
 		var prompted = 0
-		val g = h.notificationGestures(
+		val g = h.gesturesWith(down = GestureAction.NOTIFICATIONS,
 			serviceConnected = false, onOpen = { opened++ }, onPrompt = { prompted++ })
 		val distance = h.dash.swipeDistancePx
 
@@ -163,11 +165,12 @@ class HomeGestureControllerTest {
 		assertEquals(1, prompted) // Nudged towards the accessibility settings instead //
 	}
 
-	@Test fun aDisabledNotificationGestureLeavesTheDownSwipeInert() = this.onHarness { h ->
+	@Test fun aDoNothingDownGestureLeavesTheDownSwipeInert() = this.onHarness { h ->
 		var opened = 0
 		var prompted = 0
-		val g = h.notificationGestures(
-			enabled = false, onOpen = { opened++ }, onPrompt = { prompted++ })
+		// down = NONE (the default): the swipe is inert and not consumed //
+		val g = h.gesturesWith(down = GestureAction.NONE,
+			onOpen = { opened++ }, onPrompt = { prompted++ })
 		val distance = h.dash.swipeDistancePx
 
 		h.touch(g, MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY, 0)
@@ -178,10 +181,40 @@ class HomeGestureControllerTest {
 		assertEquals(0, opened)
 		assertEquals(0, prompted)
 		assertFalse(consumedUp)
+		assertFalse(h.dash.isOpen)
 	}
 
-	@Test fun enablingTheNotificationGestureLeavesSwipeUpForTheDashWorking() = this.onHarness { h ->
-		val g = h.notificationGestures()
+	@Test fun aNotificationsDownGestureLeavesSwipeUpForTheDashWorking() = this.onHarness { h ->
+		val g = h.gesturesWith(down = GestureAction.NOTIFICATIONS)
+		val distance = h.dash.swipeDistancePx
+
+		h.touch(g, MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY, 0)
+		h.touch(g, MotionEvent.ACTION_MOVE, h.emptyX, h.emptyY - h.slop * 3F, 50)
+		h.touch(g, MotionEvent.ACTION_MOVE, h.emptyX, h.emptyY - h.slop * 3F - distance * 0.6F, 250)
+		h.touch(g, MotionEvent.ACTION_UP, h.emptyX, h.emptyY - h.slop * 3F - distance * 0.6F, 300)
+		ActivityTestSupport.drainTasks()
+
+		assertTrue(h.dash.isOpen)
+	}
+
+	@Test fun swipingDownToOpenDashFingerTracksAndCommits() = this.onHarness { h ->
+		val g = h.gesturesWith(down = GestureAction.OPEN_DASH)
+		val distance = h.dash.swipeDistancePx
+
+		h.touch(g, MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY, 0)
+		h.touch(g, MotionEvent.ACTION_MOVE, h.emptyX, h.emptyY + h.slop * 3F, 50)
+		// Mid-flight: the dash tracks the downward finger //
+		h.touch(g, MotionEvent.ACTION_MOVE, h.emptyX, h.emptyY + h.slop * 3F + distance * 0.3F, 250)
+		assertTrue(h.dash.swipeOpenness > 0F && h.dash.swipeOpenness < 1F)
+		h.touch(g, MotionEvent.ACTION_MOVE, h.emptyX, h.emptyY + h.slop * 3F + distance * 0.6F, 450)
+		h.touch(g, MotionEvent.ACTION_UP, h.emptyX, h.emptyY + h.slop * 3F + distance * 0.6F, 500)
+		ActivityTestSupport.drainTasks()
+
+		assertTrue(h.dash.isOpen)
+	}
+
+	@Test fun swipingUpToOpenDashAndSearchOpensTheDash() = this.onHarness { h ->
+		val g = h.gesturesWith(up = GestureAction.OPEN_DASH_SEARCH)
 		val distance = h.dash.swipeDistancePx
 
 		h.touch(g, MotionEvent.ACTION_DOWN, h.emptyX, h.emptyY, 0)

--- a/app/src/test/java/be/robinj/distrohopper/preferences/GesturePreferencesTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/GesturePreferencesTest.kt
@@ -1,0 +1,49 @@
+package be.robinj.distrohopper.preferences
+
+import android.content.Context
+import androidx.preference.ListPreference
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The preferences-side plumbing of the no-lockout rule: changing one gesture's
+ * ListPreference flips the sibling to "open dash" when it would otherwise leave
+ * the dash unreachable. (The decision itself is GestureActionTest's job.)
+ */
+@RunWith(RobolectricTestRunner::class)
+class GesturePreferencesTest {
+	private val context: Context = ApplicationProvider.getApplicationContext()
+
+	private fun gestureList(value: String): ListPreference {
+		val pref = ListPreference(this.context)
+		pref.entryValues = arrayOf("none", "open_dash", "open_dash_search", "notifications_tray")
+		pref.entries = pref.entryValues
+		pref.value = value
+		return pref
+	}
+
+	@Test fun settingUpToNotificationsFlipsADoNothingDownToOpenDash() {
+		val down = this.gestureList("none")
+		PreferencesActivity.PreferencesFragment.reconcileSiblingGesture(down, "notifications_tray")
+		assertEquals("open_dash", down.value)
+	}
+
+	@Test fun settingDownToNotificationsFlipsANotificationsUpToOpenDash() {
+		val up = this.gestureList("notifications_tray")
+		PreferencesActivity.PreferencesFragment.reconcileSiblingGesture(up, "notifications_tray")
+		assertEquals("open_dash", up.value)
+	}
+
+	@Test fun aSiblingThatAlreadyOpensTheDashIsLeftAlone() {
+		val openDash = this.gestureList("open_dash")
+		PreferencesActivity.PreferencesFragment.reconcileSiblingGesture(openDash, "notifications_tray")
+		assertEquals("open_dash", openDash.value)
+
+		val searchDash = this.gestureList("open_dash_search")
+		PreferencesActivity.PreferencesFragment.reconcileSiblingGesture(searchDash, "none")
+		assertEquals("open_dash_search", searchDash.value)
+	}
+}


### PR DESCRIPTION
Turns the experimental swipe-down-for-notifications gesture (#66) into a proper, user-configurable feature.

## What's new

A new **Gestures** section in Preferences:

- **Swipe left/right** — switch desktops. Not configurable; shown as a non-selectable hint row so the behaviour is discoverable.
- **Swipe up** / **Swipe down** — each a dropdown:
  - **Do nothing** (swipe-down default)
  - **Open dash** (swipe-up default)
  - **Open dash and start search** — forces the search field to focus + raises the keyboard on open, regardless of the existing "Start search when Dash opened" toggle.
  - **Open notifications tray** — only listed once the accessibility service is enabled.

### No-lockout rule
At least one gesture must keep the dash reachable. Only *Open dash* / *Open dash + search* open the dash; *Do nothing* and *Open notifications tray* don't. Setting one gesture to a non-dash action while the other is already non-dash auto-flips the other back to **Open dash**. The decision lives in `GestureAction.reconcileOther` and is enforced in the ListPreference change listeners.

### Notification tray gating + enable wizard
The notification action is gated on the accessibility service actually being enabled (`NotificationAccessibilityService.isEnabled`, via `AccessibilityManager` / `Settings.Secure`). While it's off, a row at the bottom of the section ("Enable open notifications tray gestures") launches a small onboarding-styled wizard:
1. Explains *why* the service is needed and that it's **only ever** used to open the tray — reads no screen content, collects no data, does nothing else. Buttons: **Cancel** / **I understand, proceed**.
2. Guides the user to the accessibility settings; auto-finishes once the service is enabled.

### Other behaviour
- Dash opening is now **finger-tracked in both directions** (a downward swipe set to Open dash drives the open animation with the sign flipped).
- Replaces the dev-only `gesture_notification_tray` toggle (no migration — it was experimental).

## Testing
- `GestureActionTest` — value parsing/`opensDash` and the full 4×4 `reconcileOther` matrix (forces Open dash iff both sides are non-dash), plus the spec example and the "don't disturb a valid pairing" case.
- `GesturePreferencesTest` — drives the real preference reconcile wiring on `ListPreference`s in both directions.
- `HomeGestureControllerTest` — updated for the new per-direction action model; covers both-direction dash opens, the search variant, notifications commit/fling/prompt-fallback, and the inert do-nothing swipe.

`./gradlew :app:assembleDebug :app:testDebugUnitTest` — build green; all gesture suites pass (the only failures locally are pre-existing widget/desktop-drag tests that also fail on `master` in this headless environment, untouched by this change).

https://claude.ai/code/session_01LaFhwsrm6Rf8ek2J9cKs99

---
_Generated by [Claude Code](https://claude.ai/code/session_01LaFhwsrm6Rf8ek2J9cKs99)_