### PR TITLE
Activate first dash result on Enter key

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -23,6 +23,7 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 import android.animation.LayoutTransition;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -870,6 +871,15 @@ public class HomeActivity extends AppCompatActivity
 			LinearLayout llLauncher = this.viewFinder.get(R.id.llLauncher);
 
 			etDashSearch.addTextChangedListener (new SearchTextWatcher (installedApps, this.lenses));
+			// Pressing Enter activates the first available result, as if it had been tapped.
+			// singleLine means this fires for both the soft-keyboard action and a hardware Enter //
+			etDashSearch.setOnEditorActionListener ((v, actionId, event) -> {
+				// Fire once on key-down only (hardware Enter also delivers an ACTION_UP) //
+				if (event != null && event.getAction () != KeyEvent.ACTION_DOWN)
+					return false;
+
+				return this.lenses.activateFirstResult ();
+			});
 			llLauncher.setOnDragListener (new LauncherDragListener (this.apps));
 
 			this.startLauncherService (false);

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LensManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LensManager.java
@@ -215,6 +215,32 @@ public class LensManager
 		this.searchLoader = searchLoader;
 	}
 
+	/**
+	 * Activates the first available search result as if it had been tapped,
+	 * forwarding to the owning lens's onClick. Skips error sections (null
+	 * results) and empty sections, so it lands on the first real result of the
+	 * first lens that has one. Returns whether a result was activated.
+	 *
+	 * Called from the UI thread (the search box's Enter handler); the results
+	 * list is only ever read/mutated on the main thread, so no extra
+	 * synchronization is needed.
+	 */
+	public boolean activateFirstResult ()
+	{
+		for (LensSearchResultCollection coll : this.results)
+		{
+			List<LensSearchResult> res = coll.getResults ();
+			if (res != null && ! res.isEmpty ())
+			{
+				LensSearchResult result = res.get (0);
+				coll.getLens ().onClick (result.getUrl (), result.getObj ());
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public void startSearch (String pattern)
 	{
 		if (this.searchLoader != null)

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LensManagerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LensManagerTest.kt
@@ -92,6 +92,64 @@ class LensManagerTest {
         LensManager(context, LinearLayout(context), null, null, null)
     }
 
+    @Test fun activateFirstResultForwardsUrlAndObjToTheLens() {
+        val manager = manager()
+        val lens = RecordingLens(context)
+        val obj = Any()
+        val result = LensSearchResult(context, "name", "https://example.com", null, obj)
+        setResults(manager, mutableListOf(LensSearchResultCollection(lens, mutableListOf(result))))
+
+        assertTrue(manager.activateFirstResult())
+        assertEquals("https://example.com", lens.clickedUrl)
+        assertSame(obj, lens.clickedObj)
+    }
+
+    @Test fun activateFirstResultReturnsFalseWhenThereAreNoResults() {
+        assertFalse(manager().activateFirstResult())
+    }
+
+    @Test fun activateFirstResultSkipsErrorAndEmptySectionsForTheFirstRealResult() {
+        val manager = manager()
+        val errorLens = RecordingLens(context)
+        val emptyLens = RecordingLens(context)
+        val hitLens = RecordingLens(context)
+        val result = LensSearchResult(context, "name", "https://hit.example", null, null)
+        setResults(manager, mutableListOf(
+            LensSearchResultCollection(errorLens, RuntimeException("boom")),
+            LensSearchResultCollection(emptyLens, mutableListOf()),
+            LensSearchResultCollection(hitLens, mutableListOf(result)),
+        ))
+
+        assertTrue(manager.activateFirstResult())
+        assertNull(errorLens.clickedUrl)
+        assertNull(emptyLens.clickedUrl)
+        assertEquals("https://hit.example", hitLens.clickedUrl)
+    }
+
+    private fun setResults(manager: LensManager, results: MutableList<LensSearchResultCollection>) {
+        val field = LensManager::class.java.getDeclaredField("results")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val backing = field.get(manager) as MutableList<LensSearchResultCollection>
+        backing.clear()
+        backing.addAll(results)
+    }
+
+    private class RecordingLens(context: Context) : Lens(context) {
+        var clickedUrl: String? = null
+        var clickedObj: Any? = null
+
+        override val type = LensType.LOCAL
+        override fun getName() = "Recording"
+        override fun getDescription() = "Records onClick for tests"
+        override suspend fun search(query: String, maxResults: Int, emitter: LensResultEmitter) {}
+
+        override fun onClick(url: String, obj: Any?) {
+            this.clickedUrl = url
+            this.clickedObj = obj
+        }
+    }
+
     @Test fun lensResultsViewIsResolvedFromTheLensesContainer() {
         val lensesContainer = LinearLayout(context)
         val lensResults = ListView(context).apply { id = R.id.lvDashHomeLensResults }


### PR DESCRIPTION
Pressing Enter in the dash search box now activates the first available
result as if it had been tapped, forwarding to the owning lens's onClick.

Adds LensManager.activateFirstResult(), which walks the results in display
order and triggers onClick on the first collection that has a real result
(skipping error and empty sections). HomeActivity wires it to the search
box via an OnEditorActionListener, which covers both the soft-keyboard
action and a hardware Enter key since the field is singleLine.

https://claude.ai/code/session_019qqwrSx3en4kc8P2joxuxd