### PR TITLE
Exit widget edit mode when returning to home screen

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -516,10 +516,18 @@ public class HomeActivity extends AppCompatActivity
 		}
 
 		// Pressing home (or the home navigation gesture) while the launcher is
-		// already running lands here; close the dash if it's open and return to
-		// the first desktop //
+		// already running lands here; exit widget edit mode, close the dash if
+		// it's open and return to the first desktop. Exiting edit mode matters
+		// because swipe gestures are suppressed while a widget is being edited:
+		// without this the user could land back on the first desktop still in
+		// edit mode and be unable to swipe away. //
 		if (Intent.ACTION_MAIN.equals(intent.getAction())
 				&& intent.hasCategory(Intent.CATEGORY_HOME)) {
+			if (this.viewFinder != null) {
+				this.viewFinder.<WidgetsPager>get(R.id.vgWidgets).exitEditMode();
+				this.updateBackCallback();
+			}
+
 			if (this.dash != null && this.dash.isOpen()) {
 				this.closeDash();
 			}


### PR DESCRIPTION
## Summary
Fixed an issue where users could become stuck in widget edit mode when pressing the home button or using the home navigation gesture while editing a widget. This prevented swipe gestures from working on the home screen.

## Key Changes
- Added logic to exit widget edit mode when the home action is triggered (Intent.ACTION_MAIN with Intent.CATEGORY_HOME)
- Call `exitEditMode()` on the WidgetsPager and update the back callback to properly clean up edit mode state
- Updated code comments to document the rationale for exiting edit mode before handling other home screen actions

## Implementation Details
The fix ensures that when a user presses home while in widget edit mode, the edit mode is exited first before closing the dash or returning to the first desktop. This is necessary because swipe gestures are suppressed during widget editing, and without this fix, users could end up on the home screen still in edit mode with no way to navigate away.

https://claude.ai/code/session_01Xu6MUhTvpDFK947SGeHhEH