### PR TITLE
Add automated release build and signing on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ master, 'claude/**' ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
 
@@ -42,3 +43,86 @@ jobs:
         with:
           name: unit-test-coverage
           path: app/build/reports/jacoco/jacocoTestReport/
+
+  # Build signed APK + AAB on version tags (v*), gated on the unit tests.
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # create/attach the GitHub Release on tags
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Require signing secret
+        env:
+          KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$KEYSTORE_B64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set — refusing to build a release without the keystore."
+            exit 1
+          fi
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_B64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
+
+      - name: Write key.properties
+        env:
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          # PKCS12 uses one password for both the store and the key entry.
+          {
+            echo "storeFile=$RUNNER_TEMP/upload-keystore.jks"
+            echo "storePassword=$STORE_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "keyPassword=$STORE_PASSWORD"
+          } > key.properties
+
+      - name: Create secret.properties
+        env:
+          ACRA_USERNAME: ${{ secrets.ACRA_USERNAME }}
+          ACRA_PASSWORD: ${{ secrets.ACRA_PASSWORD }}
+        run: |
+          echo "acra_username=${ACRA_USERNAME}" > secret.properties
+          echo "acra_password=${ACRA_PASSWORD}" >> secret.properties
+
+      - name: Build signed APK and AAB
+        run: ./gradlew assembleRelease bundleRelease
+
+      - name: Verify APK is release-signed
+        run: |
+          APKSIGNER=$(ls "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
+          "$APKSIGNER" verify --print-certs \
+            app/build/outputs/apk/release/app-release.apk
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: distrohopper-release-android
+          path: |
+            app/build/outputs/apk/release/app-release.apk
+            app/build/outputs/bundle/release/app-release.aab
+
+      - name: Attach to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            app/build/outputs/apk/release/app-release.apk
+            app/build/outputs/bundle/release/app-release.aab
+
+      - name: Clean up secrets
+        if: always()
+        run: rm -f key.properties "$RUNNER_TEMP/upload-keystore.jks"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 /captures
 .externalNativeBuild
 secret.properties
+key.properties
+*.jks
 app-release.apk
 /app/release/
 /app/build/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,12 @@ if (secretFile.exists()) {
     properties.load(new FileInputStream(secretFile))
 }
 
+def keystorePropertiesFile = rootProject.file("key.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace "be.robinj.distrohopper"
     compileSdk 36
@@ -26,8 +32,21 @@ android {
         buildConfigField "boolean", "ACRA_CONFIGURED", acraConfigured.toString()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
+        }
+    }
     buildTypes {
         release {
+            // Sign release builds only when a keystore is provided, so local
+            // and CI test builds without one still succeed.
+            signingConfig keystorePropertiesFile.exists() ? signingConfigs.release : null
             minifyEnabled false
             shrinkResources false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
## Summary
This PR adds a complete automated release pipeline that builds and signs APK and AAB artifacts when version tags (v*) are pushed, with the signed artifacts automatically attached to GitHub Releases.

## Key Changes
- **CI/CD Pipeline**: Added a new `release` job in the GitHub Actions workflow that:
  - Triggers only on version tags matching `v*`
  - Depends on successful unit tests before proceeding
  - Requires the `ANDROID_KEYSTORE_BASE64` secret to be set
  - Decodes the base64-encoded keystore and configures signing credentials
  - Builds signed APK and AAB artifacts
  - Verifies the APK signature before uploading
  - Automatically attaches artifacts to the GitHub Release
  - Cleans up sensitive files after completion

- **Gradle Configuration**: Updated `app/build.gradle` to:
  - Load keystore properties from `key.properties` file
  - Define a `release` signing configuration that uses the keystore when available
  - Apply signing to release builds only when the keystore file exists (allows local/CI test builds without signing to succeed)

- **Git Ignore**: Updated `.gitignore` to exclude:
  - `key.properties` (signing configuration)
  - `*.jks` (keystore files)

## Notable Implementation Details
- The release job is gated on unit tests passing via the `needs` directive
- Keystore validation happens early with a clear error message if the secret is missing
- The signing configuration is conditional—builds without a keystore still succeed, enabling flexibility for local development and non-release CI runs
- Sensitive files (keystore and key.properties) are explicitly cleaned up after the build completes
- APK signature verification is performed before uploading to ensure the build was properly signed

https://claude.ai/code/session_01PfgZTqXhdkDFaGyLVmUC9G