### PR TITLE
Add comprehensive test coverage for dash UI and theme components

### DIFF
--- a/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
+++ b/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
@@ -143,7 +143,8 @@ internal object ActivityTestSupport {
         configurePrefs: (SharedPreferences.Editor) -> Unit = {},
     ): ActivityScenario<HomeActivity> {
         val application = ApplicationProvider.getApplicationContext<Application>()
-        listOf(Preferences.PREFERENCES, Preferences.PINNED_APPS, Preferences.LENSES).forEach {
+        listOf(Preferences.PREFERENCES, Preferences.PINNED_APPS, Preferences.LENSES,
+            Preferences.DASH_LAYOUT).forEach {
             application.getSharedPreferences(it, 0).edit().clear().commit()
         }
         // Fresh prefs would otherwise redirect HomeActivity to the first-run wizard //

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/DashGridDragListenerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/DashGridDragListenerTest.kt
@@ -1,0 +1,256 @@
+package be.robinj.distrohopper.desktop.dash
+
+import android.content.Context
+import android.view.DragEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.BaseAdapter
+import android.widget.GridView
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.App
+import be.robinj.distrohopper.DashLayoutRepository
+import be.robinj.distrohopper.DragEvents
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.preferences.Preferences
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * The dash grid's drag listener: the folder-create-on-dwell, drop-into-folder,
+ * custom-order reposition and folder-member-extraction state machine. The folder
+ * model itself is covered by [be.robinj.distrohopper.DashLayoutRepositoryTest];
+ * this verifies the listener glue drives it correctly from DragEvents.
+ *
+ * The grid is a [FixedGrid] whose `pointToPosition` is pinned to a known cell so
+ * the coordinate-driven branches are deterministic without Robolectric layout.
+ */
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class DashGridDragListenerTest {
+    private lateinit var scenario: ActivityScenario<HomeActivity>
+
+    @Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
+    @After fun tearDown() { scenario.close() }
+
+    /** A grid whose adapter serves a known item list and whose hit-test is fixed. */
+    private class FixedGrid(
+        context: Context,
+        private val items: List<DashItem>,
+        private val pos: Int,
+    ) : GridView(context) {
+        init {
+            adapter = object : BaseAdapter() {
+                override fun getCount() = items.size
+                override fun getItem(position: Int): Any = items[position]
+                override fun getItemId(position: Int) = position.toLong()
+                override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View =
+                    convertView ?: View(context)
+            }
+        }
+
+        override fun pointToPosition(x: Int, y: Int): Int = this.pos
+    }
+
+    private fun appItems(layout: DashLayoutRepository): List<DashItem.AppItem> =
+        layout.dashItems(null).filterIsInstance<DashItem.AppItem>()
+
+    private fun app(layout: DashLayoutRepository, label: String): App =
+        this.appItems(layout).first { it.app.label == label }.app
+
+    private fun labels(layout: DashLayoutRepository): List<String> =
+        layout.dashItems(null).map {
+            when (it) {
+                is DashItem.AppItem -> it.app.label
+                is DashItem.FolderItem -> "[folder]"
+            }
+        }
+
+    private fun setCustomOrder(activity: HomeActivity) =
+        Preferences.getSharedPreferences(activity).edit().putString("app_sort_order", "custom").commit()
+
+    private fun drainDelayed() = ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+    // --- ACTION_DRAG_STARTED: which drags this listener claims ---
+
+    @Test fun dragStartedClaimsLooseAppAndFolderPayloadDrags() {
+        scenario.onActivity { activity ->
+            val listener = DashGridDragListener(activity, activity.appManager, null)
+            val grid = FixedGrid(activity, emptyList(), AdapterView.INVALID_POSITION)
+            val anApp = this.app(activity.appManager.dashLayout, "Alpha")
+
+            assertTrue("a loose app drag is claimed",
+                listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DRAG_STARTED, localState = anApp)))
+            assertTrue("a folder drag is claimed", listener.onDrag(grid,
+                DragEvents.obtain(DragEvent.ACTION_DRAG_STARTED, localState = DashDragPayload.FolderDrag("f"))))
+            assertTrue("a folder-member drag is claimed", listener.onDrag(grid,
+                DragEvents.obtain(DragEvent.ACTION_DRAG_STARTED, localState = DashDragPayload.FolderMemberDrag("f", anApp))))
+        }
+    }
+
+    @Test fun dragStartedIgnoresForeignDrags() {
+        scenario.onActivity { activity ->
+            val listener = DashGridDragListener(activity, activity.appManager, null)
+            val grid = FixedGrid(activity, emptyList(), AdapterView.INVALID_POSITION)
+
+            assertFalse("no local state (e.g. a widget drag) is left to other listeners",
+                listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DRAG_STARTED, localState = null)))
+            assertFalse("a non-dash payload is not claimed",
+                listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DRAG_STARTED, localState = "widget")))
+        }
+    }
+
+    // --- Folder create / add ---
+
+    @Test fun dwellingOverAnotherAppAndDroppingCreatesAFolder() {
+        scenario.onActivity { activity ->
+            val appManager = activity.appManager
+            val layout = appManager.dashLayout
+            val items = layout.dashItems(null)
+            val alpha = this.app(layout, "Alpha")
+            val betaIndex = items.indexOfFirst { it is DashItem.AppItem && it.app.label == "Beta" }
+            val grid = FixedGrid(activity, items, betaIndex)
+            val listener = DashGridDragListener(activity, appManager, null)
+
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DRAG_LOCATION, 10f, 10f, alpha))
+            this.drainDelayed() // fire the dwell timer that arms the fold
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DROP, 10f, 10f, alpha))
+
+            val folders = layout.dashItems(null).filterIsInstance<DashItem.FolderItem>()
+            assertEquals(1, folders.size)
+            assertEquals(setOf("Alpha", "Beta"), folders[0].apps.map { it.label }.toSet())
+        }
+    }
+
+    @Test fun droppingOnAFolderAfterDwellAddsTheAppToIt() {
+        scenario.onActivity { activity ->
+            val appManager = activity.appManager
+            val layout = appManager.dashLayout
+            layout.createFolder(this.app(layout, "Alpha"), this.app(layout, "Beta"))
+            val gamma = this.app(layout, "Gamma")
+            val items = layout.dashItems(null)
+            val folderIndex = items.indexOfFirst { it is DashItem.FolderItem }
+            val grid = FixedGrid(activity, items, folderIndex)
+            val listener = DashGridDragListener(activity, appManager, null)
+
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DRAG_LOCATION, 10f, 10f, gamma))
+            this.drainDelayed()
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DROP, 10f, 10f, gamma))
+
+            val folder = layout.dashItems(null).filterIsInstance<DashItem.FolderItem>().single()
+            assertTrue(folder.apps.map { it.label }.containsAll(listOf("Alpha", "Beta", "Gamma")))
+        }
+    }
+
+    // --- Reorder (custom order only) ---
+
+    @Test fun droppingALooseAppReordersItInCustomOrder() {
+        scenario.onActivity { activity ->
+            val appManager = activity.appManager
+            val layout = appManager.dashLayout
+            this.setCustomOrder(activity)
+            val settings = this.app(layout, "Settings")
+            val grid = FixedGrid(activity, layout.dashItems(null), 0) // drop at the front
+            val listener = DashGridDragListener(activity, appManager, null)
+
+            // No dwell, so this is a reorder rather than a fold.
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DROP, 10f, 10f, settings))
+
+            assertEquals("Settings", (layout.dashItems(null).first() as DashItem.AppItem).app.label)
+        }
+    }
+
+    @Test fun droppingALooseAppDoesNotReorderWhenNotInCustomOrder() {
+        scenario.onActivity { activity ->
+            val appManager = activity.appManager
+            val layout = appManager.dashLayout // default alphabetical order
+            val before = this.labels(layout)
+            val zeta = this.app(layout, "Zeta")
+            val grid = FixedGrid(activity, layout.dashItems(null), 0)
+            val listener = DashGridDragListener(activity, appManager, null)
+
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DROP, 10f, 10f, zeta))
+
+            assertEquals(before, this.labels(layout))
+        }
+    }
+
+    // --- Folder members ---
+
+    @Test fun droppingAFolderMemberOnTheDashExtractsIt() {
+        scenario.onActivity { activity ->
+            val appManager = activity.appManager
+            val layout = appManager.dashLayout
+            val alpha = this.app(layout, "Alpha")
+            val folderId = layout.createFolder(alpha, this.app(layout, "Beta"))!!
+            // Drop onto empty space (no cell under the pointer): a plain extraction.
+            val grid = FixedGrid(activity, layout.dashItems(null), AdapterView.INVALID_POSITION)
+            val listener = DashGridDragListener(activity, appManager, null)
+
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DROP,
+                localState = DashDragPayload.FolderMemberDrag(folderId, alpha)))
+
+            // Removing a member down to one dissolves the folder: both apps loose.
+            assertTrue(layout.dashItems(null).none { it is DashItem.FolderItem })
+            assertTrue(this.appItems(layout).map { it.app.label }.containsAll(listOf("Alpha", "Beta")))
+        }
+    }
+
+    // --- Whole-folder reposition ---
+
+    @Test fun droppingAFolderRepositionsItInCustomOrder() {
+        scenario.onActivity { activity ->
+            val appManager = activity.appManager
+            val layout = appManager.dashLayout
+            this.setCustomOrder(activity)
+            val folderId = layout.createFolder(this.app(layout, "Alpha"), this.app(layout, "Beta"))!!
+            val items = layout.dashItems(null)
+            val targetPos = items.size - 1 // send the folder to the end
+            val grid = FixedGrid(activity, items, targetPos)
+            val listener = DashGridDragListener(activity, appManager, null)
+
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DROP,
+                localState = DashDragPayload.FolderDrag(folderId)))
+
+            assertEquals(targetPos, layout.dashItems(null).indexOfFirst { it is DashItem.FolderItem })
+        }
+    }
+
+    @Test fun droppingAFolderDoesNotRepositionWhenNotInCustomOrder() {
+        scenario.onActivity { activity ->
+            val appManager = activity.appManager
+            val layout = appManager.dashLayout // alphabetical: folder sorts first
+            val folderId = layout.createFolder(this.app(layout, "Alpha"), this.app(layout, "Beta"))!!
+            val before = layout.dashItems(null).indexOfFirst { it is DashItem.FolderItem }
+            val grid = FixedGrid(activity, layout.dashItems(null), layout.dashItems(null).size - 1)
+            val listener = DashGridDragListener(activity, appManager, null)
+
+            listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DROP,
+                localState = DashDragPayload.FolderDrag(folderId)))
+
+            assertEquals(before, layout.dashItems(null).indexOfFirst { it is DashItem.FolderItem })
+        }
+    }
+
+    // --- ACTION_DRAG_ENDED housekeeping ---
+
+    @Test fun dragEndedClearsHoverAndNotifiesWithoutThrowing() {
+        scenario.onActivity { activity ->
+            ActivityTestSupport.layoutDashApps(activity)
+            val grid = ActivityTestSupport.dashGrid(activity) ?: return@onActivity
+            val listener = DashGridDragListener(activity, activity.appManager, null)
+
+            assertTrue(listener.onDrag(grid, DragEvents.obtain(DragEvent.ACTION_DRAG_ENDED)))
+            ActivityTestSupport.drainTasks() // runs the posted stoppedDragging()
+        }
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/SearchTextWatcherTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/SearchTextWatcherTest.kt
@@ -1,0 +1,98 @@
+package be.robinj.distrohopper.desktop.dash
+
+import android.content.Context
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.desktop.dash.lens.LensManager
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowAlertDialog
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * The dash search box's text watcher: each keystroke forwards the current text
+ * to the lens manager, and any failure is caught and surfaced through
+ * [be.robinj.distrohopper.ExceptionHandler] rather than crashing typing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class SearchTextWatcherTest {
+    private lateinit var scenario: ActivityScenario<HomeActivity>
+
+    @Before fun setUp() {
+        ShadowAlertDialog.reset()
+        scenario = ActivityTestSupport.launchHome()
+    }
+
+    @After fun tearDown() { scenario.close() }
+
+    private class RecordingLensManager(context: Context) : LensManager(context, null, null, null, null) {
+        var lastQuery: String? = null
+        var calls = 0
+        override fun startSearch(pattern: String?) { this.calls++; this.lastQuery = pattern }
+    }
+
+    private class ThrowingLensManager(context: Context) : LensManager(context, null, null, null, null) {
+        override fun startSearch(pattern: String?) { throw RuntimeException("boom") }
+    }
+
+    @Test fun onTextChangedForwardsTypedTextToStartSearch() {
+        scenario.onActivity { activity ->
+            val lenses = RecordingLensManager(activity)
+            val watcher = SearchTextWatcher(activity.appManager, lenses)
+
+            watcher.onTextChanged("fire", 0, 0, 4)
+
+            assertEquals("fire", lenses.lastQuery)
+            assertEquals(1, lenses.calls)
+        }
+    }
+
+    @Test fun emptyTextIsStillForwarded() {
+        scenario.onActivity { activity ->
+            val lenses = RecordingLensManager(activity)
+            val watcher = SearchTextWatcher(activity.appManager, lenses)
+
+            // The watcher does not pre-filter; clearing the box must reach the
+            // lens manager so it can drop the previous results.
+            watcher.onTextChanged("", 0, 4, 0)
+
+            assertEquals("", lenses.lastQuery)
+            assertEquals(1, lenses.calls)
+        }
+    }
+
+    @Test fun beforeAndAfterTextChangedDoNotSearch() {
+        scenario.onActivity { activity ->
+            val lenses = RecordingLensManager(activity)
+            val watcher = SearchTextWatcher(activity.appManager, lenses)
+
+            watcher.beforeTextChanged("fire", 0, 0, 4)
+            watcher.afterTextChanged(android.text.SpannableStringBuilder("fire"))
+
+            assertEquals(0, lenses.calls)
+        }
+    }
+
+    @Test fun exceptionInStartSearchIsCaughtAndSurfaced() {
+        scenario.onActivity { activity ->
+            val watcher = SearchTextWatcher(activity.appManager, ThrowingLensManager(activity))
+
+            // Must not propagate — typing keeps working even if a lens blows up.
+            watcher.onTextChanged("x", 0, 0, 1)
+
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+            assertNotNull(
+                "the failure should be surfaced to the user via ExceptionHandler",
+                ShadowAlertDialog.getLatestAlertDialog(),
+            )
+        }
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/AppStoreLensTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/AppStoreLensTest.kt
@@ -1,0 +1,46 @@
+package be.robinj.distrohopper.desktop.dash.lens
+
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageInfo
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+
+/**
+ * Covers the [AppStoreLens.isInstalled] helper shared by every app-store lens
+ * (Google Play, F-Droid, …); the concrete lenses use it to hide apps the user
+ * already has, but the helper itself was only exercised indirectly.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AppStoreLensTest {
+    private lateinit var application: Application
+
+    @Before fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+    }
+
+    /** Minimal concrete store lens exposing the protected install check. */
+    private class ProbeStore(context: Context) : AppStoreLens(context) {
+        fun probe(packageName: String) = isInstalled(packageName)
+        override fun getName() = "ProbeStore"
+        override fun getDescription() = "Test store lens"
+        override suspend fun search(query: String, maxResults: Int, emitter: LensResultEmitter) {}
+    }
+
+    @Test fun reportsInstalledPackageAsInstalled() {
+        val packageInfo = PackageInfo().apply { packageName = "com.example.installed" }
+        Shadows.shadowOf(application.packageManager).installPackage(packageInfo)
+
+        assertTrue(ProbeStore(application).probe("com.example.installed"))
+    }
+
+    @Test fun reportsAbsentPackageAsNotInstalled() {
+        assertFalse(ProbeStore(application).probe("com.example.absent"))
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/profile/GnomeProfilePillIndicatorTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/profile/GnomeProfilePillIndicatorTest.kt
@@ -1,0 +1,85 @@
+package be.robinj.distrohopper.desktop.dash.profile
+
+import android.content.Context
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The GNOME pill profile indicator: a [ProfilePillView] shown only while the
+ * dash is open and more than one profile exists, with the pager driving the
+ * pill's (fractional) position.
+ */
+@RunWith(RobolectricTestRunner::class)
+class GnomeProfilePillIndicatorTest {
+    private lateinit var context: Context
+
+    @Before fun setUp() { context = ApplicationProvider.getApplicationContext() }
+
+    private fun pill(container: FrameLayout) = container.getChildAt(0) as ProfilePillView
+
+    @Test fun bindSetsPillCountAndSelectedPosition() {
+        val container = FrameLayout(context)
+        GnomeProfilePillIndicator(context, container) {}.bind(listOf(null, null), selected = 1)
+
+        assertEquals(2, pill(container).count)
+        assertEquals(1f, pill(container).position, 0.001f)
+    }
+
+    @Test fun visibleOnlyWithMultipleProfilesAndDashOpen() {
+        val container = FrameLayout(context)
+        val indicator = GnomeProfilePillIndicator(context, container) {}
+
+        // Single profile, dash open → hidden.
+        indicator.bind(listOf(null), selected = 0)
+        indicator.onDashOpenChanged(true)
+        assertEquals(View.GONE, container.visibility)
+
+        // Multiple profiles, dash open → shown.
+        indicator.bind(listOf(null, null), selected = 0)
+        assertEquals(View.VISIBLE, container.visibility)
+
+        // Dash closes → hidden again.
+        indicator.onDashOpenChanged(false)
+        assertEquals(View.GONE, container.visibility)
+    }
+
+    @Test fun scrollAndSelectDriveThePillPosition() {
+        val container = FrameLayout(context)
+        val indicator = GnomeProfilePillIndicator(context, container) {}
+        indicator.bind(listOf(null, null, null), selected = 0)
+
+        indicator.onPageScrolled(1, 0.25f)
+        assertEquals(1.25f, pill(container).position, 0.001f)
+
+        indicator.onPageSelected(2)
+        assertEquals(2f, pill(container).position, 0.001f)
+    }
+
+    @Test fun tappingASlotForwardsTheIndex() {
+        val container = FrameLayout(context)
+        var selected = -1
+        val indicator = GnomeProfilePillIndicator(context, container) { selected = it }
+        indicator.bind(listOf(null, null), selected = 0)
+
+        pill(container).onSlotClick?.invoke(1)
+
+        assertEquals(1, selected)
+    }
+
+    @Test fun clearHidesTheIndicator() {
+        val container = FrameLayout(context)
+        val indicator = GnomeProfilePillIndicator(context, container) {}
+        indicator.bind(listOf(null, null), selected = 0)
+        indicator.onDashOpenChanged(true)
+        assertEquals(View.VISIBLE, container.visibility)
+
+        indicator.clear()
+        assertEquals(View.GONE, container.visibility)
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/profile/ProfilePillViewTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/profile/ProfilePillViewTest.kt
@@ -1,0 +1,89 @@
+package be.robinj.distrohopper.desktop.dash.profile
+
+import android.content.Context
+import android.view.MotionEvent
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The GNOME pill's geometry: its measured width is constant as the current shape
+ * elongates (so neighbours slide rather than the row reflowing), and a tap
+ * resolves to the slot under it. The drawing itself is left untested (pixels).
+ */
+@RunWith(RobolectricTestRunner::class)
+class ProfilePillViewTest {
+    private lateinit var context: Context
+
+    @Before fun setUp() { context = ApplicationProvider.getApplicationContext() }
+
+    private val unspecified = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+
+    private fun measured(pill: ProfilePillView): Int {
+        pill.measure(this.unspecified, this.unspecified)
+        return pill.measuredWidth
+    }
+
+    private fun laidOut(count: Int): ProfilePillView {
+        val pill = ProfilePillView(context).apply { this.count = count }
+        pill.measure(this.unspecified, this.unspecified)
+        pill.layout(0, 0, pill.measuredWidth, pill.measuredHeight)
+        return pill
+    }
+
+    private fun tapAt(pill: ProfilePillView, x: Float) {
+        val up = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_UP, x, 0f, 0)
+        try { pill.onTouchEvent(up) } finally { up.recycle() }
+    }
+
+    @Test fun measuredWidthIsConstantAsTheCurrentShapeMoves() {
+        val pill = ProfilePillView(context).apply { count = 3 }
+
+        pill.position = 0f
+        val atStart = this.measured(pill)
+        pill.position = 1.5f
+        val midSwipe = this.measured(pill)
+
+        assertTrue(atStart > 0)
+        assertEquals(atStart, midSwipe)
+    }
+
+    @Test fun zeroCountMeasuresToZeroWidth() {
+        assertEquals(0, this.measured(ProfilePillView(context).apply { count = 0 }))
+    }
+
+    @Test fun tapNearTheStartSelectsTheFirstSlot() {
+        val pill = this.laidOut(count = 3)
+        var selected = -1
+        pill.onSlotClick = { selected = it }
+
+        this.tapAt(pill, 1f)
+
+        assertEquals(0, selected)
+    }
+
+    @Test fun tapNearTheEndSelectsTheLastSlot() {
+        val pill = this.laidOut(count = 3)
+        var selected = -1
+        pill.onSlotClick = { selected = it }
+
+        this.tapAt(pill, pill.width - 1f)
+
+        assertEquals(2, selected)
+    }
+
+    @Test fun tapPastTheLastIndicatorFallsThroughToIt() {
+        val pill = this.laidOut(count = 3)
+        var selected = -1
+        pill.onSlotClick = { selected = it }
+
+        this.tapAt(pill, pill.width + 500f)
+
+        assertEquals(2, selected)
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/profile/UnityRibbonIndicatorTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/profile/UnityRibbonIndicatorTest.kt
@@ -1,0 +1,112 @@
+package be.robinj.distrohopper.desktop.dash.profile
+
+import android.content.Context
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The Unity ribbon profile indicator: one glyph per profile with the current
+ * one highlighted, the highlight interpolating as the dash pager is swiped. Two
+ * personal-style handles (`listOf(null, null)`) exercise the multi-glyph
+ * highlight maths without depending on a headless system profile badge.
+ */
+@RunWith(RobolectricTestRunner::class)
+class UnityRibbonIndicatorTest {
+    private lateinit var context: Context
+
+    @Before fun setUp() { context = ApplicationProvider.getApplicationContext() }
+
+    private fun indicator(container: LinearLayout, onSelect: (Int) -> Unit = {}) =
+        UnityRibbonIndicator(context, container, R.drawable.ic_profile, onSelect)
+
+    private fun iconAt(container: LinearLayout, i: Int) = container.getChildAt(i) as ImageView
+
+    @Test fun bindCreatesOneGlyphPerProfileAndShowsTheContainer() {
+        val container = LinearLayout(context)
+        indicator(container).bind(listOf(null, null, null), selected = 0)
+
+        assertEquals(3, container.childCount)
+        assertEquals(View.VISIBLE, container.visibility)
+    }
+
+    // The glyph's own (View) alpha is the exact, reliable signal — the backing
+    // ColorDrawable's getAlpha() returns the base colour's alpha modulated by the
+    // set value, so the backing is only asserted relatively (full vs transparent).
+
+    @Test fun selectedGlyphIsFullyHighlightedAndOthersDimmed() {
+        val container = LinearLayout(context)
+        indicator(container).bind(listOf(null, null), selected = 0)
+
+        // i=0 selected: highlight 1 → full glyph + visible backing.
+        assertEquals(1f, iconAt(container, 0).alpha, 0.001f)
+        assertTrue(iconAt(container, 0).background.alpha > 0)
+        // i=1 inactive: highlight 0 → INACTIVE_ALPHA glyph + transparent backing.
+        assertEquals(0.55f, iconAt(container, 1).alpha, 0.001f)
+        assertEquals(0, iconAt(container, 1).background.alpha)
+    }
+
+    @Test fun pageScrollInterpolatesHighlightBetweenNeighbours() {
+        val container = LinearLayout(context)
+        val indicator = indicator(container)
+        indicator.bind(listOf(null, null), selected = 0)
+
+        indicator.onPageScrolled(0, 0.5f)
+
+        // Both glyphs sit halfway: glyph alpha 0.55 + 0.45*0.5 == 0.775, and their
+        // backings fade equally.
+        assertEquals(0.775f, iconAt(container, 0).alpha, 0.001f)
+        assertEquals(0.775f, iconAt(container, 1).alpha, 0.001f)
+        assertEquals(iconAt(container, 0).background.alpha, iconAt(container, 1).background.alpha)
+    }
+
+    @Test fun pageSelectedSnapsHighlightToThatPage() {
+        val container = LinearLayout(context)
+        val indicator = indicator(container)
+        indicator.bind(listOf(null, null), selected = 0)
+
+        indicator.onPageSelected(1)
+
+        assertEquals(1f, iconAt(container, 1).alpha, 0.001f)
+        assertTrue(iconAt(container, 1).background.alpha > 0)
+        assertEquals(0.55f, iconAt(container, 0).alpha, 0.001f)
+        assertEquals(0, iconAt(container, 0).background.alpha)
+    }
+
+    @Test fun tappingAGlyphInvokesOnSelectWithItsIndex() {
+        val container = LinearLayout(context)
+        var selected = -1
+        indicator(container) { selected = it }.bind(listOf(null, null), selected = 0)
+
+        iconAt(container, 1).performClick()
+
+        assertEquals(1, selected)
+    }
+
+    @Test fun bindHidesTheRibbonHomeButtonAndClearRestoresIt() {
+        // The home button is found via the container's parent, so wrap them together.
+        val parent = FrameLayout(context)
+        val container = LinearLayout(context)
+        val homeButton = View(context).apply { id = R.id.ibDashLensHome }
+        parent.addView(container)
+        parent.addView(homeButton)
+
+        val indicator = indicator(container)
+        indicator.bind(listOf(null, null), selected = 0)
+        assertEquals("the personal glyph replaces the ribbon home button", View.GONE, homeButton.visibility)
+
+        indicator.clear()
+        assertEquals(View.VISIBLE, homeButton.visibility)
+        assertEquals(View.GONE, container.visibility)
+        assertEquals(0, container.childCount)
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/launcher/DashEdgeDragListenerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/launcher/DashEdgeDragListenerTest.kt
@@ -1,0 +1,121 @@
+package be.robinj.distrohopper.desktop.launcher
+
+import android.view.DragEvent
+import android.view.View
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.DragEvents
+import be.robinj.distrohopper.HomeActivity
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * The chrome listener that feeds the cross-surface drag's open/close-the-dash
+ * controller. The controller's own state machine is covered by
+ * [DashCrossSurfaceControllerTest]; this verifies the DragEvent→controller
+ * mapping — which action registers/clears a hover target, and that ENDED counts
+ * as an exit — against the real controller wired into a launched [HomeActivity],
+ * plus one end-to-end close.
+ */
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class DashEdgeDragListenerTest {
+    private lateinit var scenario: ActivityScenario<HomeActivity>
+
+    // A BFB is an open-target; the launcher/panel are close-targets. The ids only
+    // need to be distinct so the controller can track the two as separate sets.
+    private val bfbId = 4001
+    private val panelId = 4002
+
+    @Before fun setUp() { scenario = ActivityTestSupport.launchHome() }
+    @After fun tearDown() { scenario.close() }
+
+    /** The controller tracks hovered view ids in two private sets, keyed by [open]. */
+    private fun targets(controller: DashCrossSurfaceController, open: Boolean): Set<Int> {
+        val field = DashCrossSurfaceController::class.java
+            .getDeclaredField(if (open) "openTargets" else "closeTargets")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return (field.get(controller) as Set<Int>).toSet()
+    }
+
+    @Test fun dragStartedReturnsTrueToClaimTheView() {
+        scenario.onActivity { activity ->
+            val view = View(activity)
+            assertTrue(DashEdgeDragListener(activity, open = true)
+                .onDrag(view, DragEvents.obtain(DragEvent.ACTION_DRAG_STARTED)))
+            assertTrue(DashEdgeDragListener(activity, open = false)
+                .onDrag(view, DragEvents.obtain(DragEvent.ACTION_DRAG_STARTED)))
+        }
+    }
+
+    @Test fun enteringRegistersTheViewAsTheRightKindOfTarget() {
+        scenario.onActivity { activity ->
+            val controller = activity.dashCrossSurface
+            val bfb = View(activity).apply { id = bfbId }
+            val panel = View(activity).apply { id = panelId }
+
+            DashEdgeDragListener(activity, open = true)
+                .onDrag(bfb, DragEvents.obtain(DragEvent.ACTION_DRAG_ENTERED))
+            DashEdgeDragListener(activity, open = false)
+                .onDrag(panel, DragEvents.obtain(DragEvent.ACTION_DRAG_ENTERED))
+
+            assertTrue("BFB hover is an open-target", bfbId in targets(controller, open = true))
+            assertTrue("panel hover is a close-target", panelId in targets(controller, open = false))
+            assertFalse("a BFB is never a close-target", bfbId in targets(controller, open = false))
+            controller.reset() // cancel the pending debounced apply before teardown
+        }
+    }
+
+    @Test fun exitedRemovesTheTargetFromTheController() {
+        scenario.onActivity { activity ->
+            val controller = activity.dashCrossSurface
+            val bfb = View(activity).apply { id = bfbId }
+            val listener = DashEdgeDragListener(activity, open = true)
+
+            listener.onDrag(bfb, DragEvents.obtain(DragEvent.ACTION_DRAG_ENTERED))
+            assertTrue(bfbId in targets(controller, open = true))
+
+            listener.onDrag(bfb, DragEvents.obtain(DragEvent.ACTION_DRAG_EXITED))
+            assertFalse(bfbId in targets(controller, open = true))
+            controller.reset()
+        }
+    }
+
+    @Test fun dragEndedAlsoReportsExitToTheController() {
+        scenario.onActivity { activity ->
+            val controller = activity.dashCrossSurface
+            val bfb = View(activity).apply { id = bfbId }
+            val listener = DashEdgeDragListener(activity, open = true)
+
+            listener.onDrag(bfb, DragEvents.obtain(DragEvent.ACTION_DRAG_ENTERED))
+            // ENDED maps to the same exit as EXITED, so the target is dropped.
+            listener.onDrag(bfb, DragEvents.obtain(DragEvent.ACTION_DRAG_ENDED))
+
+            assertFalse(bfbId in targets(controller, open = true))
+            controller.reset()
+        }
+    }
+
+    @Test fun enteringACloseTargetWhileOpenClosesTheDash() {
+        scenario.onActivity { activity ->
+            activity.openDash()
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+            assertTrue(activity.dashIsOpen())
+            val panel = View(activity).apply { id = panelId }
+
+            DashEdgeDragListener(activity, open = false)
+                .onDrag(panel, DragEvents.obtain(DragEvent.ACTION_DRAG_ENTERED))
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+            assertFalse(activity.dashIsOpen())
+        }
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/theme/ProfileIndicatorStyleTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/theme/ProfileIndicatorStyleTest.kt
@@ -1,0 +1,28 @@
+package be.robinj.distrohopper.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * The integer a theme stores in `profile_indicator` is mapped to this enum by
+ * [ProfileIndicatorStyle.of]; these lock that mapping so a theme can rely on the
+ * values documented in profile_indicator.xml.
+ */
+class ProfileIndicatorStyleTest {
+    @Test fun numbersMapToEnumValues() {
+        ProfileIndicatorStyle.entries.forEach { assertEquals(it, ProfileIndicatorStyle.of(it.n)) }
+    }
+
+    @Test fun ofUsesOrdinalIndexing() {
+        assertEquals(ProfileIndicatorStyle.NONE, ProfileIndicatorStyle.of(0))
+        assertEquals(ProfileIndicatorStyle.UNITY_RIBBON, ProfileIndicatorStyle.of(1))
+        assertEquals(ProfileIndicatorStyle.GNOME_PANEL, ProfileIndicatorStyle.of(2))
+    }
+
+    @Test fun ofRejectsOutOfRangeValues() {
+        // of(n) is values()[n] with no validation, so an unknown integer throws —
+        // documented here so a theme shipping a bad value fails loudly, not silently.
+        assertThrows(ArrayIndexOutOfBoundsException::class.java) { ProfileIndicatorStyle.of(3) }
+    }
+}

--- a/app/src/test/java/be/robinj/distrohopper/theme/ThemeTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/theme/ThemeTest.kt
@@ -163,4 +163,51 @@ class ThemeTest {
             arr.recycle()
         }
     }
+
+    // --- Registry-wide coverage ---
+    // The behavioural tests above hardcode a handful of themes; Plasma and MATE
+    // were never instantiated by any test, so a theme shipping an out-of-range
+    // enum integer or an unresolvable resource array could reach users unnoticed.
+    // These drive every theme the picker can create straight from ThemeRegistry,
+    // so any future theme is covered automatically.
+
+    @Test fun everyRegisteredThemeNameMatchesItsRegistryKey() {
+        ThemeRegistry.themes.keys.forEach { key ->
+            assertEquals(key, ThemeRegistry.create(key).getName())
+        }
+    }
+
+    @Test fun registryIncludesPlasmaAndMate() {
+        assertTrue(ThemeRegistry.themes.keys.containsAll(listOf("plasma", "mate")))
+        assertEquals("plasma", Plasma().getName())
+        assertEquals("mate", Mate().getName())
+    }
+
+    @Test fun everyRegisteredThemeResolvesKeyResources() {
+        val prefs = Preferences.getSharedPreferences(context)
+        ThemeRegistry.themes.forEach { (key, factory) ->
+            val theme = factory()
+            // Enum-backed integer resources must map into range (catches a theme
+            // shipping an out-of-range dash_animation / profile_indicator value).
+            DashAnimation.of(context.resources.getInteger(theme.dash_animation))
+            ProfileIndicatorStyle.of(context.resources.getInteger(theme.profile_indicator))
+            // The position arrays behind the customise-mode dropdowns must resolve
+            // (panel-less themes legitimately have an empty panel array).
+            context.resources.getIntArray(theme.launcher_bfb_location_supported)
+            context.resources.getIntArray(theme.panel_location_supported)
+            // The resolved getters each read several integer/bool/array resources;
+            // none may throw for any registered theme.
+            theme.launcherBfbToggleable(context.resources)
+            theme.launcherBfbVisible(context.resources, prefs)
+            theme.lalPreferences_getLocation(context.resources, prefs)
+        }
+    }
+
+    @Test fun themeDisplayNameMayDifferFromItsLowercaseName() {
+        // The human-facing `name` field is intentionally distinct from getName()
+        // (the lowercase class name used as the registry key); lock both so a
+        // future "tidy-up" that conflates them is a deliberate, visible change.
+        assertEquals("plasma", Plasma().getName()); assertEquals("Plasma", Plasma().name)
+        assertEquals("mate", Mate().getName()); assertEquals("MATE", Mate().name)
+    }
 }


### PR DESCRIPTION
This PR adds extensive test coverage for several key UI components and theme functionality that were previously untested or only indirectly exercised.

## Summary
Introduces 8 new test classes covering drag-and-drop interactions, profile indicators, search functionality, app store lens helpers, and theme registry validation. These tests ensure critical user-facing features work correctly and prevent regressions in future changes.

## Key Changes

**Drag & Drop Tests:**
- `DashGridDragListenerTest`: Comprehensive coverage of the dash grid's drag listener state machine, including folder creation on dwell, dropping apps into folders, custom order reordering, and folder member extraction
- `DashEdgeDragListenerTest`: Tests for the cross-surface drag controller that manages dash open/close behavior when dragging over screen edges

**Profile Indicator Tests:**
- `UnityRibbonIndicatorTest`: Tests the Unity ribbon profile indicator's glyph highlighting and interpolation during pager scrolling
- `GnomeProfilePillIndicatorTest`: Tests the GNOME pill-style profile indicator's visibility, positioning, and interaction
- `ProfilePillViewTest`: Tests the underlying pill view's geometry (constant measured width during animation) and tap-to-select behavior

**Search & Lens Tests:**
- `SearchTextWatcherTest`: Tests the dash search box's text watcher, including keystroke forwarding to lens manager and exception handling
- `AppStoreLensTest`: Tests the `isInstalled` helper method shared by all app store lenses

**Theme Registry Tests:**
- Extended `ThemeTest` with registry-wide coverage that instantiates every registered theme (including previously untested Plasma and MATE) and validates that all resource references resolve correctly

## Notable Implementation Details

- Uses `FixedGrid` test helper to make coordinate-driven drag tests deterministic without relying on Robolectric layout
- Employs reflection to access private controller state for verification in drag listener tests
- Tests exception handling in search to ensure typing continues even if a lens fails
- Validates enum-backed integer resources and array resolution across all themes to catch shipping errors early

https://claude.ai/code/session_011TPUAUreeXAmXPeW3s9hgg