### PR TITLE
Handle Back press to close folder popups

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -237,8 +237,12 @@ public class HomeActivity extends AppCompatActivity
 						// just the folder — the dash it may have been opened from (or
 						// the widget edit mode behind it) stays as it was. //
 						if (FolderOverlay.dismissActive (HomeActivity.this))
-							;
-						else if (vgWidgets.hasEditModeChild ())
+						{
+							HomeActivity.this.updateBackCallback ();
+							return;
+						}
+
+						if (vgWidgets.hasEditModeChild ())
 							vgWidgets.exitEditMode ();
 						else if (HomeActivity.this.dash.isOpen ())
 							HomeActivity.this.closeDash ();

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -235,12 +235,11 @@ public class HomeActivity extends AppCompatActivity
 
 						// An open folder floats above everything else, so Back closes
 						// just the folder — the dash it may have been opened from (or
-						// the widget edit mode behind it) stays as it was. //
+						// the widget edit mode behind it) stays as it was. Dismissing
+						// it already re-synced the Back callback (FolderOverlay
+						// notifies on every show/dismiss), so nothing more to do. //
 						if (FolderOverlay.dismissActive (HomeActivity.this))
-						{
-							HomeActivity.this.updateBackCallback ();
 							return;
-						}
 
 						if (vgWidgets.hasEditModeChild ())
 							vgWidgets.exitEditMode ();

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -235,16 +235,19 @@ public class HomeActivity extends AppCompatActivity
 
 						// An open folder floats above everything else, so Back closes
 						// just the folder — the dash it may have been opened from (or
-						// the widget edit mode behind it) stays as it was. Dismissing
-						// it already re-synced the Back callback (FolderOverlay
-						// notifies on every show/dismiss), so nothing more to do. //
-						if (FolderOverlay.dismissActive (HomeActivity.this))
-							return;
-
-						if (vgWidgets.hasEditModeChild ())
+						// the widget edit mode behind it) stays as it was. //
+						if (FolderOverlay.isShowingIn (HomeActivity.this))
+						{
+							FolderOverlay.dismissActive (HomeActivity.this);
+						}
+						else if (vgWidgets.hasEditModeChild ())
+						{
 							vgWidgets.exitEditMode ();
+						}
 						else if (HomeActivity.this.dash.isOpen ())
+						{
 							HomeActivity.this.closeDash ();
+						}
 						// Default launcher, nothing open: swallow Back so the home screen
 						// stays put instead of the system replaying the home intent. //
 					}

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -61,6 +61,7 @@ import be.robinj.distrohopper.home.StartupLoader;
 import be.robinj.distrohopper.home.ThemeApplier;
 import be.robinj.distrohopper.home.WallpaperColourApplier;
 import be.robinj.distrohopper.dev.LogToaster;
+import be.robinj.distrohopper.folder.FolderOverlay;
 import be.robinj.distrohopper.onboarding.OnboardingActivity;
 import be.robinj.distrohopper.onboarding.OnboardingGate;
 import be.robinj.distrohopper.icons.IconConfig;
@@ -232,7 +233,12 @@ public class HomeActivity extends AppCompatActivity
 					{
 						final WidgetsPager vgWidgets = HomeActivity.this.viewFinder.get (R.id.vgWidgets);
 
-						if (vgWidgets.hasEditModeChild ())
+						// An open folder floats above everything else, so Back closes
+						// just the folder — the dash it may have been opened from (or
+						// the widget edit mode behind it) stays as it was. //
+						if (FolderOverlay.dismissActive (HomeActivity.this))
+							;
+						else if (vgWidgets.hasEditModeChild ())
 							vgWidgets.exitEditMode ();
 						else if (HomeActivity.this.dash.isOpen ())
 							HomeActivity.this.closeDash ();
@@ -541,13 +547,16 @@ public class HomeActivity extends AppCompatActivity
 		}
 
 		// Pressing home (or the home navigation gesture) while the launcher is
-		// already running lands here; exit widget edit mode, close the dash if
-		// it's open and return to the first desktop. Exiting edit mode matters
+		// already running lands here; close any open folder popup, exit widget
+		// edit mode, close the dash if it's open and return to the first
+		// desktop. Exiting edit mode matters
 		// because swipe gestures are suppressed while a widget is being edited:
 		// without this the user could land back on the first desktop still in
 		// edit mode and be unable to swipe away. //
 		if (Intent.ACTION_MAIN.equals(intent.getAction())
 				&& intent.hasCategory(Intent.CATEGORY_HOME)) {
+			FolderOverlay.dismissActive(this);
+
 			if (this.viewFinder != null) {
 				this.viewFinder.<WidgetsPager>get(R.id.vgWidgets).exitEditMode();
 				this.updateBackCallback();
@@ -598,11 +607,12 @@ public class HomeActivity extends AppCompatActivity
 
 	/**
 	 * Keeps the Back callback enabled exactly when the launcher needs to
-	 * intercept Back: while a widget is in edit mode, while the dash is open, or
-	 * whenever we are the default launcher (Back must never exit the home
-	 * screen). When DistroHopper runs as an ordinary app with nothing open the
-	 * callback is disabled, letting the system handle Back to leave the app.
-	 * Driven from onResume() and the dash-open state (see HomeStateBinder).
+	 * intercept Back: while a widget is in edit mode, while the dash is open,
+	 * while a folder popup is open, or whenever we are the default launcher
+	 * (Back must never exit the home screen). When DistroHopper runs as an
+	 * ordinary app with nothing open the callback is disabled, letting the
+	 * system handle Back to leave the app. Driven from onResume(), the
+	 * dash-open state (see HomeStateBinder) and FolderOverlay's show/dismiss.
 	 */
 	public void updateBackCallback ()
 	{
@@ -612,8 +622,9 @@ public class HomeActivity extends AppCompatActivity
 		final boolean editMode = this.viewFinder != null
 				&& this.viewFinder.<WidgetsPager>get (R.id.vgWidgets).hasEditModeChild ();
 		final boolean dashOpen = this.dash != null && this.dash.isOpen ();
+		final boolean folderOpen = FolderOverlay.isShowingIn (this);
 
-		this.backCallback.setEnabled (editMode || dashOpen || this.isDefaultLauncher ());
+		this.backCallback.setEnabled (editMode || dashOpen || folderOpen || this.isDefaultLauncher ());
 	}
 
 	/**
@@ -776,6 +787,8 @@ public class HomeActivity extends AppCompatActivity
 	@Override
 	public void onDestroy ()
 	{
+		FolderOverlay.clearFor (this);
+
 		if (this.dash != null)
 			this.getWindowManager ().removeCrossWindowBlurEnabledListener (this.dash.getCrossWindowBlurListener ());
 

--- a/app/src/main/java/be/robinj/distrohopper/folder/FolderOverlay.kt
+++ b/app/src/main/java/be/robinj/distrohopper/folder/FolderOverlay.kt
@@ -141,17 +141,12 @@ class FolderOverlay(private val activity: Activity) {
 		fun isShowingIn(activity: Activity): Boolean =
 			active?.let { it.activity === activity && it.isShowing } ?: false
 
-		/**
-		 * Dismisses the folder overlay open in [activity], if any. Returns whether
-		 * there was one — i.e. whether this press was consumed by a folder.
-		 */
+		/** Dismisses the folder overlay open in [activity], if any. */
 		@JvmStatic
-		fun dismissActive(activity: Activity): Boolean {
-			val open = isShowingIn(activity)
-			if (open) {
+		fun dismissActive(activity: Activity) {
+			if (isShowingIn(activity)) {
 				active?.dismiss()
 			}
-			return open
 		}
 
 		/** Drops the [active] reference so a destroyed [activity] is not retained. */

--- a/app/src/main/java/be/robinj/distrohopper/folder/FolderOverlay.kt
+++ b/app/src/main/java/be/robinj/distrohopper/folder/FolderOverlay.kt
@@ -87,8 +87,9 @@ class FolderOverlay(private val activity: Activity) {
 		val panel = this.panel
 		this.scrim = null
 		this.panel = null
-		if (active === this)
+		if (active === this) {
 			active = null
+		}
 		this.notifyStateChanged()
 
 		panel?.animate()?.scaleX(START_SCALE)?.scaleY(START_SCALE)?.alpha(0f)
@@ -147,16 +148,18 @@ class FolderOverlay(private val activity: Activity) {
 		@JvmStatic
 		fun dismissActive(activity: Activity): Boolean {
 			val open = isShowingIn(activity)
-			if (open)
+			if (open) {
 				active?.dismiss()
+			}
 			return open
 		}
 
 		/** Drops the [active] reference so a destroyed [activity] is not retained. */
 		@JvmStatic
 		fun clearFor(activity: Activity) {
-			if (active?.activity === activity)
+			if (active?.activity === activity) {
 				active = null
+			}
 		}
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/folder/FolderOverlay.kt
+++ b/app/src/main/java/be/robinj/distrohopper/folder/FolderOverlay.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.widget.FrameLayout
+import be.robinj.distrohopper.HomeActivity
 
 /**
  * Shared chrome for the three folder popovers (dash, launcher, desktop): a dim,
@@ -35,6 +36,8 @@ class FolderOverlay(private val activity: Activity) {
 	 * the panel calls [onOutsideTap] (typically dismiss).
 	 */
 	fun show(panel: View, width: Int, height: Int, anchor: View, onOutsideTap: () -> Unit) {
+		active?.takeIf { it !== this }?.dismiss()
+
 		val loc = anchorCentreInContent(anchor)
 		val margin = dp(8)
 		val left = (loc.first - width / 2)
@@ -69,6 +72,9 @@ class FolderOverlay(private val activity: Activity) {
 		panel.animate().scaleX(1f).scaleY(1f).alpha(1f)
 			.setDuration(DURATION).setInterpolator(DecelerateInterpolator()).start()
 		scrim.animate().alpha(1f).setDuration(DURATION).start()
+
+		active = this
+		this.notifyStateChanged()
 	}
 
 	/**
@@ -81,6 +87,9 @@ class FolderOverlay(private val activity: Activity) {
 		val panel = this.panel
 		this.scrim = null
 		this.panel = null
+		if (active === this)
+			active = null
+		this.notifyStateChanged()
 
 		panel?.animate()?.scaleX(START_SCALE)?.scaleY(START_SCALE)?.alpha(0f)
 			?.setDuration(DURATION)?.setInterpolator(AccelerateInterpolator())?.start()
@@ -108,10 +117,46 @@ class FolderOverlay(private val activity: Activity) {
 	private fun dp(value: Int): Int =
 		(value * this.activity.resources.displayMetrics.density).toInt()
 
+	/** Keeps HomeActivity's Back callback in sync with folder-open state. */
+	private fun notifyStateChanged() {
+		(this.activity as? HomeActivity)?.updateBackCallback()
+	}
+
 	companion object {
 		private const val BLUR_RADIUS = 5f
 		private const val START_SCALE = 0.7f
 		private const val DURATION = 160L
 		private val SCRIM_COLOR = Color.argb(140, 0, 0, 0)
+
+		// The currently open folder overlay, if any. Only one folder can be open
+		// at a time (the scrim covers the whole activity), and every popup type
+		// opens and dismisses through this class, so a single slot suffices. Lets
+		// HomeActivity close the folder on Back or Home without every click site
+		// having to retain the popup it created.
+		private var active: FolderOverlay? = null
+
+		/** Whether a folder overlay is currently open in [activity]. */
+		@JvmStatic
+		fun isShowingIn(activity: Activity): Boolean =
+			active?.let { it.activity === activity && it.isShowing } ?: false
+
+		/**
+		 * Dismisses the folder overlay open in [activity], if any. Returns whether
+		 * there was one — i.e. whether this press was consumed by a folder.
+		 */
+		@JvmStatic
+		fun dismissActive(activity: Activity): Boolean {
+			val open = isShowingIn(activity)
+			if (open)
+				active?.dismiss()
+			return open
+		}
+
+		/** Drops the [active] reference so a destroyed [activity] is not retained. */
+		@JvmStatic
+		fun clearFor(activity: Activity) {
+			if (active?.activity === activity)
+				active = null
+		}
 	}
 }

--- a/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
+++ b/app/src/test/java/be/robinj/distrohopper/ActivityTestSupport.kt
@@ -16,8 +16,15 @@ import android.widget.GridView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.viewpager2.widget.ViewPager2
+import be.robinj.distrohopper.desktop.dash.DashItem
+import be.robinj.distrohopper.desktop.dash.FolderPopup
+import be.robinj.distrohopper.desktop.launcher.LauncherDragPayload
+import be.robinj.distrohopper.desktop.launcher.LauncherItem
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
+import be.robinj.distrohopper.widgets.DesktopFolderLayout
+import be.robinj.distrohopper.widgets.DesktopFolderOverlay
+import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
@@ -191,6 +198,52 @@ internal object ActivityTestSupport {
     /** The dash apps grid of the pager's current page (after [layoutDashApps]). */
     fun dashGrid(activity: HomeActivity): GridView? =
         activity.findViewById(R.id.gvDashHomeApps)
+
+    /**
+     * Folds the first two dash apps into a dash folder and opens its popup,
+     * the way AppLauncherClickListener does when a dash folder icon is tapped.
+     */
+    fun openDashFolder(activity: HomeActivity) {
+        val layout = activity.appManager.dashLayout
+        val apps = layout.dashItems(null).filterIsInstance<DashItem.AppItem>()
+        layout.createFolder(apps[0].app, apps[1].app)
+        val folder = layout.dashItems(null).filterIsInstance<DashItem.FolderItem>().first()
+        FolderPopup(activity, folder.folder.id, folder.apps)
+            .showAt(activity.findViewById(R.id.llDash))
+    }
+
+    /**
+     * Pins the first two dash apps, groups them into a launcher-bar folder and
+     * opens its popup with the same arguments LauncherBarBinder's click site uses.
+     */
+    fun openLauncherFolder(activity: HomeActivity) {
+        val appManager = activity.appManager
+        val desktop = appManager.currentDesktop
+        val apps = appManager.dashLayout.dashItems(null).filterIsInstance<DashItem.AppItem>()
+        appManager.repository.pin(apps[0].app, desktop)
+        appManager.repository.pin(apps[1].app, desktop)
+        appManager.launcherLayout.createFolder(desktop, apps[0].app, apps[1].app)
+        val folder = appManager.launcherLayout.launcherItems(desktop)
+            .filterIsInstance<LauncherItem.LauncherFolder>().first()
+        FolderPopup(activity, folder.folder.id, folder.apps,
+            clipLabel = "launcherFolderMember",
+            memberPayload = { app -> LauncherDragPayload.FolderMemberDrag(folder.folder.id, app) })
+            .showAt(activity.findViewById(R.id.llDash))
+    }
+
+    /**
+     * Builds a two-app desktop folder layout and opens its overlay, the way
+     * DesktopFolderHost does when a desktop folder icon is tapped.
+     */
+    fun openDesktopFolder(activity: HomeActivity) {
+        val appMap = activity.appManager.repository.installedAppsMap()
+        val apps = appMap.values.toList()
+        val layout = DesktopFolderLayout(UUID.randomUUID().toString(), 0, 0, 0)
+            .withApp(apps[0].profileScopedKey)!!
+            .withApp(apps[1].profileScopedKey)!!
+        DesktopFolderOverlay(activity, layout, appMap)
+            .show(activity.findViewById(R.id.llDash))
+    }
 
     fun drainTasks() {
         // The background scheduler only exists under the LEGACY looper; animator-driven

--- a/app/src/test/java/be/robinj/distrohopper/HomeBackButtonTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/HomeBackButtonTest.kt
@@ -6,6 +6,9 @@ import android.content.IntentFilter
 import android.view.View
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.pressBack
+import be.robinj.distrohopper.desktop.dash.DashItem
+import be.robinj.distrohopper.desktop.dash.FolderPopup
+import be.robinj.distrohopper.folder.FolderOverlay
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -43,6 +46,15 @@ class HomeBackButtonTest {
     }
 
     private fun llDash(activity: HomeActivity) = activity.findViewById<View>(R.id.llDash)
+
+    /** Folds the first two dash apps into a folder and opens its popup. */
+    private fun openFolder(activity: HomeActivity) {
+        val layout = activity.appManager.dashLayout
+        val apps = layout.dashItems(null).filterIsInstance<DashItem.AppItem>()
+        layout.createFolder(apps[0].app, apps[1].app)
+        val folder = layout.dashItems(null).filterIsInstance<DashItem.FolderItem>().first()
+        FolderPopup(activity, folder.folder.id, folder.apps).showAt(this.llDash(activity))
+    }
 
     /*
      * Default launcher, nothing open: Back must be consumed (so the system does
@@ -92,6 +104,58 @@ class HomeBackButtonTest {
 
             activity.openDash()
             assertTrue(activity.onBackPressedDispatcher.hasEnabledCallbacks())
+        }
+    }
+
+    /*
+     * A folder floats above the dash, so Back must close just the folder and
+     * leave the dash open underneath; a second Back then closes the dash.
+     */
+    @Test fun backClosesAnOpenFolderButKeepsTheDashOpen() {
+        this.scenario.onActivity { activity ->
+            activity.openDash()
+            this.openFolder(activity)
+            assertTrue(FolderOverlay.isShowingIn(activity))
+        }
+
+        pressBack()
+        ActivityTestSupport.drainTasks() // let the close animation finish //
+
+        this.scenario.onActivity { activity ->
+            assertFalse(FolderOverlay.isShowingIn(activity))
+            assertEquals(View.VISIBLE, this.llDash(activity).visibility)
+            // The dash is still open, so Back must still be captured //
+            assertTrue(activity.onBackPressedDispatcher.hasEnabledCallbacks())
+        }
+
+        pressBack()
+        ActivityTestSupport.drainTasks()
+
+        this.scenario.onActivity { activity ->
+            assertEquals(View.GONE, this.llDash(activity).visibility)
+        }
+    }
+
+    /*
+     * Even when not the default launcher, an open folder must capture Back so
+     * it closes the folder instead of leaving the app.
+     */
+    @Test fun backCallbackEnablesWhileFolderOpenEvenWhenNotDefaultLauncher() {
+        this.scenario.onActivity { activity ->
+            activity.updateBackCallback()
+            assertFalse(activity.onBackPressedDispatcher.hasEnabledCallbacks())
+
+            this.openFolder(activity)
+            assertTrue(activity.onBackPressedDispatcher.hasEnabledCallbacks())
+        }
+
+        pressBack()
+        ActivityTestSupport.drainTasks()
+
+        this.scenario.onActivity { activity ->
+            assertFalse(FolderOverlay.isShowingIn(activity))
+            // Not the default launcher and nothing open: stop consuming Back //
+            assertFalse(activity.onBackPressedDispatcher.hasEnabledCallbacks())
         }
     }
 

--- a/app/src/test/java/be/robinj/distrohopper/HomeBackButtonTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/HomeBackButtonTest.kt
@@ -6,8 +6,6 @@ import android.content.IntentFilter
 import android.view.View
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.pressBack
-import be.robinj.distrohopper.desktop.dash.DashItem
-import be.robinj.distrohopper.desktop.dash.FolderPopup
 import be.robinj.distrohopper.folder.FolderOverlay
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -46,15 +44,6 @@ class HomeBackButtonTest {
     }
 
     private fun llDash(activity: HomeActivity) = activity.findViewById<View>(R.id.llDash)
-
-    /** Folds the first two dash apps into a folder and opens its popup. */
-    private fun openFolder(activity: HomeActivity) {
-        val layout = activity.appManager.dashLayout
-        val apps = layout.dashItems(null).filterIsInstance<DashItem.AppItem>()
-        layout.createFolder(apps[0].app, apps[1].app)
-        val folder = layout.dashItems(null).filterIsInstance<DashItem.FolderItem>().first()
-        FolderPopup(activity, folder.folder.id, folder.apps).showAt(this.llDash(activity))
-    }
 
     /*
      * Default launcher, nothing open: Back must be consumed (so the system does
@@ -114,7 +103,7 @@ class HomeBackButtonTest {
     @Test fun backClosesAnOpenFolderButKeepsTheDashOpen() {
         this.scenario.onActivity { activity ->
             activity.openDash()
-            this.openFolder(activity)
+            ActivityTestSupport.openDashFolder(activity)
             assertTrue(FolderOverlay.isShowingIn(activity))
         }
 
@@ -145,7 +134,7 @@ class HomeBackButtonTest {
             activity.updateBackCallback()
             assertFalse(activity.onBackPressedDispatcher.hasEnabledCallbacks())
 
-            this.openFolder(activity)
+            ActivityTestSupport.openDashFolder(activity)
             assertTrue(activity.onBackPressedDispatcher.hasEnabledCallbacks())
         }
 
@@ -156,6 +145,41 @@ class HomeBackButtonTest {
             assertFalse(FolderOverlay.isShowingIn(activity))
             // Not the default launcher and nothing open: stop consuming Back //
             assertFalse(activity.onBackPressedDispatcher.hasEnabledCallbacks())
+        }
+    }
+
+    /*
+     * The launcher-bar folder popover goes through the same shared overlay as
+     * the dash folder; Back must close it too (and capture Back while open).
+     */
+    @Test fun backClosesAnOpenLauncherFolder() {
+        this.scenario.onActivity { activity ->
+            ActivityTestSupport.openLauncherFolder(activity)
+            assertTrue(FolderOverlay.isShowingIn(activity))
+            assertTrue(activity.onBackPressedDispatcher.hasEnabledCallbacks())
+        }
+
+        pressBack()
+        ActivityTestSupport.drainTasks()
+
+        this.scenario.onActivity { activity ->
+            assertFalse(FolderOverlay.isShowingIn(activity))
+        }
+    }
+
+    /* Same for the desktop folder popover. */
+    @Test fun backClosesAnOpenDesktopFolder() {
+        this.scenario.onActivity { activity ->
+            ActivityTestSupport.openDesktopFolder(activity)
+            assertTrue(FolderOverlay.isShowingIn(activity))
+            assertTrue(activity.onBackPressedDispatcher.hasEnabledCallbacks())
+        }
+
+        pressBack()
+        ActivityTestSupport.drainTasks()
+
+        this.scenario.onActivity { activity ->
+            assertFalse(FolderOverlay.isShowingIn(activity))
         }
     }
 

--- a/app/src/test/java/be/robinj/distrohopper/HomeHomeButtonTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/HomeHomeButtonTest.kt
@@ -4,10 +4,15 @@ import android.app.Application
 import android.content.Intent
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.desktop.dash.DashItem
+import be.robinj.distrohopper.desktop.dash.FolderPopup
+import be.robinj.distrohopper.folder.FolderOverlay
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -62,6 +67,25 @@ class HomeHomeButtonTest {
         this.controller.newIntent(this.homeIntent())
         ActivityTestSupport.drainTasks() // let the close animation finish //
 
+        assertEquals(View.GONE, this.llDash().visibility)
+    }
+
+    /* Home dismisses a folder popup along with the dash it was opened from. */
+    @Test fun pressingHomeWhileFolderOpenClosesFolderAndDash() {
+        val activity = this.controller.get()
+        activity.openDash()
+
+        val layout = activity.appManager.dashLayout
+        val apps = layout.dashItems(null).filterIsInstance<DashItem.AppItem>()
+        layout.createFolder(apps[0].app, apps[1].app)
+        val folder = layout.dashItems(null).filterIsInstance<DashItem.FolderItem>().first()
+        FolderPopup(activity, folder.folder.id, folder.apps).showAt(this.llDash())
+        assertTrue(FolderOverlay.isShowingIn(activity))
+
+        this.controller.newIntent(this.homeIntent())
+        ActivityTestSupport.drainTasks() // let the close animations finish //
+
+        assertFalse(FolderOverlay.isShowingIn(activity))
         assertEquals(View.GONE, this.llDash().visibility)
     }
 

--- a/app/src/test/java/be/robinj/distrohopper/HomeHomeButtonTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/HomeHomeButtonTest.kt
@@ -4,8 +4,6 @@ import android.app.Application
 import android.content.Intent
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
-import be.robinj.distrohopper.desktop.dash.DashItem
-import be.robinj.distrohopper.desktop.dash.FolderPopup
 import be.robinj.distrohopper.folder.FolderOverlay
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
@@ -74,12 +72,7 @@ class HomeHomeButtonTest {
     @Test fun pressingHomeWhileFolderOpenClosesFolderAndDash() {
         val activity = this.controller.get()
         activity.openDash()
-
-        val layout = activity.appManager.dashLayout
-        val apps = layout.dashItems(null).filterIsInstance<DashItem.AppItem>()
-        layout.createFolder(apps[0].app, apps[1].app)
-        val folder = layout.dashItems(null).filterIsInstance<DashItem.FolderItem>().first()
-        FolderPopup(activity, folder.folder.id, folder.apps).showAt(this.llDash())
+        ActivityTestSupport.openDashFolder(activity)
         assertTrue(FolderOverlay.isShowingIn(activity))
 
         this.controller.newIntent(this.homeIntent())
@@ -87,6 +80,30 @@ class HomeHomeButtonTest {
 
         assertFalse(FolderOverlay.isShowingIn(activity))
         assertEquals(View.GONE, this.llDash().visibility)
+    }
+
+    /* Home also dismisses the launcher-bar folder popover. */
+    @Test fun pressingHomeWhileLauncherFolderOpenClosesIt() {
+        val activity = this.controller.get()
+        ActivityTestSupport.openLauncherFolder(activity)
+        assertTrue(FolderOverlay.isShowingIn(activity))
+
+        this.controller.newIntent(this.homeIntent())
+        ActivityTestSupport.drainTasks()
+
+        assertFalse(FolderOverlay.isShowingIn(activity))
+    }
+
+    /* Home also dismisses the desktop folder popover. */
+    @Test fun pressingHomeWhileDesktopFolderOpenClosesIt() {
+        val activity = this.controller.get()
+        ActivityTestSupport.openDesktopFolder(activity)
+        assertTrue(FolderOverlay.isShowingIn(activity))
+
+        this.controller.newIntent(this.homeIntent())
+        ActivityTestSupport.drainTasks()
+
+        assertFalse(FolderOverlay.isShowingIn(activity))
     }
 
     @Test fun pressingHomeWithDashClosedLeavesItClosed() {


### PR DESCRIPTION
## Summary
This change adds proper Back button handling for folder popups in the home activity. When a folder popup is open, pressing Back now closes just the folder while keeping the underlying UI (dash or widget edit mode) intact, rather than closing the entire activity.

## Key Changes

- **FolderOverlay state tracking**: Added a static `active` reference to track the currently open folder overlay, since only one can be open at a time due to the full-screen scrim. This allows HomeActivity to close folders without retaining references to popup creators.

- **FolderOverlay public API**: Added three new static methods:
  - `isShowingIn(activity)`: Check if a folder is open in a given activity
  - `dismissActive(activity)`: Close the active folder and return whether one was dismissed
  - `clearFor(activity)`: Clean up references when an activity is destroyed

- **Back button integration**: Modified `HomeActivity.handleOnBackPressed()` to check for open folders first, closing them before handling other Back actions (dash close, edit mode exit, etc.)

- **Home button integration**: Modified `HomeActivity.onNewIntent()` to dismiss any open folder when the Home button is pressed, ensuring the folder closes along with the dash.

- **Back callback state**: Updated `HomeActivity.updateBackCallback()` to enable the Back callback when a folder is open, even if the app isn't the default launcher. This ensures folders can be closed via Back in all contexts.

- **Lifecycle cleanup**: Added `FolderOverlay.clearFor()` call in `HomeActivity.onDestroy()` to prevent retaining destroyed activities.

## Notable Implementation Details

- The folder overlay automatically dismisses any previously open folder when showing a new one via `active?.takeIf { it !== this }?.dismiss()`
- State changes in FolderOverlay (show/dismiss) trigger `notifyStateChanged()` to keep HomeActivity's Back callback synchronized
- Tests verify that Back closes folders while preserving underlying UI state, and that the Back callback is properly enabled/disabled based on folder visibility

https://claude.ai/code/session_01Vtq2FPMmpX64gcuCAed9V1