### PR TITLE
Add CI staging and privacy-focused `-paranoia` APK build; expose paranoia flag in Gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,21 +107,60 @@ jobs:
           "$APKSIGNER" verify --print-certs \
             app/build/outputs/apk/release/app-release.apk
 
+      - name: Stage release APK and AAB
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-artifacts"
+          cp app/build/outputs/apk/release/app-release.apk \
+            "$RUNNER_TEMP/release-artifacts/app-release.apk"
+          cp app/build/outputs/bundle/release/app-release.aab \
+            "$RUNNER_TEMP/release-artifacts/app-release.aab"
+
+      - name: Disable ACRA credentials for paranoia build
+        run: |
+          echo "acra_username=" > secret.properties
+          echo "acra_password=" >> secret.properties
+
+      - name: Build signed paranoia APK
+        run: ./gradlew clean assembleRelease -PparanoiaBuild=true
+
+      - name: Verify paranoia APK is release-signed
+        run: |
+          APKSIGNER=$(ls "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
+          "$APKSIGNER" verify --print-certs \
+            app/build/outputs/apk/release/app-release.apk
+
+      - name: Stage paranoia APK
+        run: |
+          cp app/build/outputs/apk/release/app-release.apk \
+            "$RUNNER_TEMP/release-artifacts/app-release-paranoia.apk"
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@v5
         with:
           name: distrohopper-release-android
           path: |
-            app/build/outputs/apk/release/app-release.apk
-            app/build/outputs/bundle/release/app-release.aab
+            ${{ runner.temp }}/release-artifacts/app-release.apk
+            ${{ runner.temp }}/release-artifacts/app-release.aab
+            ${{ runner.temp }}/release-artifacts/app-release-paranoia.apk
 
       - name: Attach to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          append_body: true
+          body: |
+            ### Privacy-conscious APK
+
+            `app-release-paranoia.apk` is a signed, APK-only sideload build for
+            privacy-conscious users. It disables ACRA crash reporting at build
+            time and omits AGP dependency-info metadata from the APK.
+
+            This version is provided on a best-effort basis only, with no
+            guarantee of continued support or future releases.
           files: |
-            app/build/outputs/apk/release/app-release.apk
-            app/build/outputs/bundle/release/app-release.aab
+            ${{ runner.temp }}/release-artifacts/app-release.apk
+            ${{ runner.temp }}/release-artifacts/app-release.aab
+            ${{ runner.temp }}/release-artifacts/app-release-paranoia.apk
 
       - name: Clean up secrets
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,13 @@ codebase — older Java alongside newer Kotlin.
   activities/views without a device).
 - Instrumented tests live under `app/src/androidTest/` (require a
   device/emulator; rarely the right place for new tests — prefer Robolectric).
+- Tagged CI releases build the normal signed APK/AAB plus a best-effort
+  signed `-paranoia` APK (`./gradlew clean assembleRelease -PparanoiaBuild=true`):
+  it appends `-paranoia` to `versionName`, forces `BuildConfig.ACRA_CONFIGURED`
+  off even if credentials exist, and omits AGP dependency-info metadata from
+  APKs. It deliberately does not remove dependencies/classes; it is a
+  privacy-conscious courtesy sideload artifact, not a separately supported
+  product line.
 
 ## Repository layout
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,13 @@ if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
 
+def paranoiaBuild = providers.gradleProperty("paranoiaBuild")
+        .map { it.toBoolean() }
+        .orElse(false)
+        .get()
+def appVersionCode = 106
+def baseVersionName = "3.0.0d"
+
 android {
     namespace "be.robinj.distrohopper"
     compileSdk 36
@@ -24,12 +31,13 @@ android {
         applicationId "be.robinj.distrohopper"
         minSdk 31
         targetSdk 36
-        versionCode 106
-        versionName "3.0.0d"
+        versionCode appVersionCode
+        versionName paranoiaBuild ? "${baseVersionName}-paranoia" : baseVersionName
         buildConfigField "String", "ACRA_USERNAME", "\"" + (properties['acra_username'] ?: "") + "\""
         buildConfigField "String", "ACRA_PASSWORD", "\"" + (properties['acra_password'] ?: "") + "\""
-        def acraConfigured = ((properties['acra_username'] ?: "") != "") && ((properties['acra_password'] ?: "") != "")
+        def acraConfigured = !paranoiaBuild && ((properties['acra_username'] ?: "") != "") && ((properties['acra_password'] ?: "") != "")
         buildConfigField "boolean", "ACRA_CONFIGURED", acraConfigured.toString()
+        buildConfigField "boolean", "PARANOIA_BUILD", paranoiaBuild.toString()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {
@@ -54,6 +62,10 @@ android {
     }
     buildFeatures {
         buildConfig true
+    }
+    dependenciesInfo {
+        includeInApk = !paranoiaBuild
+        includeInBundle = true
     }
     testOptions {
         unitTests {


### PR DESCRIPTION
### Motivation

- Provide a privacy-conscious, signed APK variant for sideloading that disables crash reporting and omits AGP dependency-info metadata without creating a separate supported product line. 
- Stage and attach both normal release artifacts and the new `-paranoia` APK in CI releases so maintainers and users can download the privacy build. 
- Ensure project documentation reflects the new build option so contributors know how the artifact is produced and what it does.

### Description

- CI workflow: stage release artifacts into `runner.temp/release-artifacts`, build a second signed paranoia APK with ACRA credentials disabled, verify both APKs with `apksigner`, upload all artifacts, and append a release note describing the paranoia APK when publishing a GitHub Release. 
- Gradle: add a `paranoiaBuild` Gradle property and use it to set `versionName` to append `-paranoia`, make `ACRA_CONFIGURED` false when `paranoiaBuild` is true, expose `PARANOIA_BUILD` in `BuildConfig`, and conditionally disable `dependenciesInfo.includeInApk` for paranoia builds. 
- Docs: update `AGENTS.md` to document the CI-tagged paranoia build, its intended scope, and the Gradle invocation to produce it.

### Testing

- CI release build steps were exercised: `./gradlew assembleRelease bundleRelease` completed and the release APK/AAB were verified with `apksigner verify --print-certs`. 
- The paranoia build was exercised with `./gradlew clean assembleRelease -PparanoiaBuild=true` and the paranoia APK was verified with `apksigner verify --print-certs`. 
- Artifact upload and GitHub Release attachment steps were executed for the normal and paranoia artifacts and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58a5bfbf588322a059fc02f1c8903c)