### PR TITLE
Remove stale developer mode translations

### DIFF
--- a/app/src/main/res/values-de/translations.xml
+++ b/app/src/main/res/values-de/translations.xml
@@ -46,7 +46,6 @@
   <string name="option_theme">Thema</string>
   <string name="hint_theme">Wähle, nach welcher Linux Distributation DistroHopper aussehen soll.</string>
   <string name="option_dev">Entwicklermodus</string>
-  <string name="hint_dev">Greife auf Debuglogs und andere technische Informationen zu. Aktivierung wird sich negativ auf Performance und stabilität auswirken.</string>
   <string name="option_dev_logs">Logs</string>
   <string name="hm_timvdstaaij_why">*Tester (Wenn er es nicht zum Absturz bringen konnte ist es für den Rest der Welt benutzbar).\n
 *Hilfe bei der Farbberechnungsfunktion.</string>

--- a/app/src/main/res/values-es/translations.xml
+++ b/app/src/main/res/values-es/translations.xml
@@ -49,7 +49,6 @@
   <string name="option_theme">Tema </string>
   <string name="hint_theme">Elija que distribución de Linux desea que DistroHopper se vea.</string>
   <string name="option_dev">Modo de desarrollador </string>
-  <string name="hint_dev">Acceder a registros de depuración y otra información técnica. Habilitando esto impactara negativamente sobre el rendimiento y estabilidad. </string>
   <string name="option_dev_logs">Registros </string>
   <string name="hm_timvdstaaij_why">* Pruebas (Si no logra destruirlo, entonces es probable que sea seguro para el consumo por el resto del mundo.)\n
 * Funcion para ayudar el cálculo del color dominante.</string>

--- a/app/src/main/res/values-fr/translations.xml
+++ b/app/src/main/res/values-fr/translations.xml
@@ -46,7 +46,6 @@
   <string name="option_theme">Theme</string>
   <string name="hint_theme">Choisissez la distribution Linux à laquelle vous souhaitez que DistroHopper ressemble.</string>
   <string name="option_dev">Mode développeur</string>
-  <string name="hint_dev">Accédez aux journaux de débogage et à d\'autres informations techniques. En activant cela, cela aura un impact négatif sur les performances et la stabilité.</string>
   <string name="option_dev_logs">Journaux</string>
   <string name="hm_timvdstaaij_why">* Testing (If he doesn\'t manage to wreck it then it\'s probably safe for consumption by the rest of the world.)\n
         * Help with the dominant colour calculation function.</string>

--- a/app/src/main/res/values-ru/translations.xml
+++ b/app/src/main/res/values-ru/translations.xml
@@ -55,7 +55,6 @@
   <string name="option_theme">Тема</string>
   <string name="hint_theme">Выберете дистрибутив Линукса внешний вид которого вы хотите использовать.</string>
   <string name="option_dev">Режим разработчика</string>
-  <string name="hint_dev">Доступ к отладочным логам и к другой технической информации. При включении стабильность и производительность может ухудшиться.</string>
   <string name="option_dev_logs">Логи</string>
   <string name="hm_timvdstaaij_why">* Тестирование\n * Помощь с функцией расчета доминирующего цвета\n</string>
   <string name="hm_todddavies_why">* Я использовал его компонент ProgressWheel, потому что стандартный компонент Android ProgressBar не хорошо работает.\n

--- a/app/src/main/res/values-uk/translations.xml
+++ b/app/src/main/res/values-uk/translations.xml
@@ -38,7 +38,6 @@
   <string name="option_theme">Тема</string>
   <string name="hint_theme">Виберіть дистрибутив Linux-а, на який повинен бути схожим DistroHopper.</string>
   <string name="option_dev">Режим розробника</string>
-  <string name="hint_dev">Отримайте доступ до логів та іншої технічної інформації. Увімкнення цієї функції негативно вплине на швидкість та стабільність роботи додатка.</string>
   <string name="option_dev_logs">Логи</string>
   <string name="hm_timvdstaaij_why">* Тестування\n 
 * Допомога з функцією розрахунку домінуючого кольору\n</string>

--- a/app/src/main/res/values-zh/translations.xml
+++ b/app/src/main/res/values-zh/translations.xml
@@ -39,7 +39,6 @@
   <string name="option_theme">主题</string>
   <string name="hint_theme">请选择你希望DistroHopper看起来像哪一个Linux发行版。</string>
   <string name="option_dev">开发者模式</string>
-  <string name="hint_dev">你可以访问调试日志和其他技术信息。 启用此选项将对性能和稳定性产生负面影响。</string>
   <string name="option_dev_logs">日志</string>
   <string name="hm_timvdstaaij_why">*帮助测试（如果他最终并没有破坏这个程序那么就代表其他人都可以放心使用了）
 *帮助开发主色计算功能</string>


### PR DESCRIPTION
### Motivation
- The English `hint_dev` string was expanded to mention experimental features not ready for the general public, making several existing locale translations inaccurate or misleading, so they should be removed to avoid incorrect user-facing text.

### Description
- Deleted the `hint_dev` entries from `app/src/main/res/values-de/translations.xml`, `app/src/main/res/values-es/translations.xml`, `app/src/main/res/values-fr/translations.xml`, `app/src/main/res/values-ru/translations.xml`, `app/src/main/res/values-uk/translations.xml`, and `app/src/main/res/values-zh/translations.xml`, while retaining the Dutch translation in `values-nl` because it already conveys the updated meaning.

### Testing
- Parsed all translation XML files with a `python3` XML parse script which succeeded, ran `git diff --check` which reported no whitespace errors, and attempted `./gradlew assembleDebug` which could not run in this environment because the Android SDK location is not configured (`ANDROID_HOME`/`local.properties`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59fb2b1a2483229c653634caa3d166)