### PR TITLE
Include version in CI release artifact filenames and update AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
           echo "acra_username=${ACRA_USERNAME}" > secret.properties
           echo "acra_password=${ACRA_PASSWORD}" >> secret.properties
 
+      - name: Set release artifact version
+        run: echo "RELEASE_VERSION=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+
       - name: Build signed APK and AAB
         run: ./gradlew assembleRelease bundleRelease
 
@@ -111,9 +114,9 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/release-artifacts"
           cp app/build/outputs/apk/release/app-release.apk \
-            "$RUNNER_TEMP/release-artifacts/app-release.apk"
+            "$RUNNER_TEMP/release-artifacts/DistroHopper-$RELEASE_VERSION.apk"
           cp app/build/outputs/bundle/release/app-release.aab \
-            "$RUNNER_TEMP/release-artifacts/app-release.aab"
+            "$RUNNER_TEMP/release-artifacts/DistroHopper-$RELEASE_VERSION.aab"
 
       - name: Disable ACRA credentials for paranoia build
         run: |
@@ -132,16 +135,16 @@ jobs:
       - name: Stage paranoia APK
         run: |
           cp app/build/outputs/apk/release/app-release.apk \
-            "$RUNNER_TEMP/release-artifacts/app-release-paranoia.apk"
+            "$RUNNER_TEMP/release-artifacts/DistroHopper-$RELEASE_VERSION-paranoia.apk"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v5
         with:
           name: distrohopper-release-android
           path: |
-            ${{ runner.temp }}/release-artifacts/app-release.apk
-            ${{ runner.temp }}/release-artifacts/app-release.aab
-            ${{ runner.temp }}/release-artifacts/app-release-paranoia.apk
+            ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}.apk
+            ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}.aab
+            ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}-paranoia.apk
 
       - name: Detect release type
         id: release_metadata
@@ -161,16 +164,17 @@ jobs:
           body: |
             ### Privacy-conscious APK
 
-            `app-release-paranoia.apk` is a signed, APK-only sideload build for
+            `DistroHopper-${{ env.RELEASE_VERSION }}-paranoia.apk` is a signed,
+            APK-only sideload build for
             privacy-conscious users. It disables ACRA crash reporting at build
             time and omits AGP dependency-info metadata from the APK.
 
             This version is provided on a best-effort basis only, with no
             guarantee of continued support or future releases.
           files: |
-            ${{ runner.temp }}/release-artifacts/app-release.apk
-            ${{ runner.temp }}/release-artifacts/app-release.aab
-            ${{ runner.temp }}/release-artifacts/app-release-paranoia.apk
+            ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}.apk
+            ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}.aab
+            ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}-paranoia.apk
 
       - name: Clean up secrets
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ codebase — older Java alongside newer Kotlin.
   attaches them to a GitHub Release. Tags whose version ends in a letter (for
   example `v3.0.0d`) are marked as GitHub pre-releases and are not promoted to
   latest; plain numeric versions (for example `v3.0.0`) remain full releases.
+  Release attachments are named `DistroHopper-<version>.apk`,
+  `DistroHopper-<version>.aab`, and `DistroHopper-<version>-paranoia.apk`,
+  where `<version>` is the full version tag, including its leading `v`.
 - Tagged CI releases build the normal signed APK/AAB plus a best-effort
   signed `-paranoia` APK (`./gradlew clean assembleRelease -PparanoiaBuild=true`):
   it appends `-paranoia` to `versionName`, forces `BuildConfig.ACRA_CONFIGURED`


### PR DESCRIPTION
### Motivation

- Ensure release artifacts are named with the full tag version to make uploaded files unambiguous and avoid name collisions. 
- Make the release artifact naming convention explicit in `AGENTS.md` so release consumers and maintainers know the expected filenames.

### Description

- Add a CI step that writes `RELEASE_VERSION=$GITHUB_REF_NAME` to the environment for use in later steps. 
- Rename staged artifacts to `DistroHopper-$RELEASE_VERSION.apk`, `DistroHopper-$RELEASE_VERSION.aab`, and `DistroHopper-$RELEASE_VERSION-paranoia.apk` when copying into the runner temp directory. 
- Update the `actions/upload-artifact` paths to reference `DistroHopper-${{ env.RELEASE_VERSION }}` filenames. 
- Update the GitHub Release attachment body and file list to reference the new artifact filenames, and document the naming convention in `AGENTS.md`.

### Testing

- No automated tests were run as part of this change; the edits only modify the CI workflow and repository documentation and will be exercised when the release workflow runs on a tag.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59face83d48322898d2a2cfe029ea4)