### PR TITLE
Clarify prerelease GitHub Release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,15 @@ jobs:
         run: |
           if [[ "$GITHUB_REF_NAME" =~ [[:alpha:]]$ ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "body<<RELEASE_BODY"
+              echo "> [!WARNING]"
+              echo "> Test version, not a stable release"
+              echo "RELEASE_BODY"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "body=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Attach to GitHub Release
@@ -161,16 +168,7 @@ jobs:
         with:
           prerelease: ${{ steps.release_metadata.outputs.prerelease }}
           append_body: true
-          body: |
-            ### Privacy-conscious APK
-
-            `DistroHopper-${{ env.RELEASE_VERSION }}-paranoia.apk` is a signed,
-            APK-only sideload build for
-            privacy-conscious users. It disables ACRA crash reporting at build
-            time and omits AGP dependency-info metadata from the APK.
-
-            This version is provided on a best-effort basis only, with no
-            guarantee of continued support or future releases.
+          body: ${{ steps.release_metadata.outputs.body }}
           files: |
             ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}.apk
             ${{ runner.temp }}/release-artifacts/DistroHopper-${{ env.RELEASE_VERSION }}.aab


### PR DESCRIPTION
### Motivation
- Remove the confusing privacy-conscious APK notice from CI-created GitHub Releases and add the requested visible warning callout to prerelease descriptions only.
- Ensure stable releases remain unchanged and no release-body is appended for normal numeric tags.
- AGENTS.md was reviewed and still accurately documents the release artifacts, so no documentation edits were required for this change.

### Description
- Update `.github/workflows/ci.yml` to emit a `body` output only for prerelease tags (tags whose name ends with a letter) containing the requested Markdown warning callout block.
- Replace the previously hard-coded `body` passed to `softprops/action-gh-release` with `steps.release_metadata.outputs.body` so the release description is conditional.
- Emit an empty `body` for stable tags to avoid appending any extra text.

### Testing
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'` which succeeded.
- Simulated the release metadata shell step for `v3.0.0e` (prerelease) and `v3.0.0` (stable) and confirmed the warning block is produced only for the prerelease tag.
- Ran `git diff --check` to verify no whitespace/patch issues and it passed.
- Attempted Python/YAML validation but it failed due to the environment lacking the `PyYAML` module, so Ruby was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a0b314b008322902b92afb1df6c07)