### PR TITLE
Add scheduled workflow to pull Transifex translations and document it

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,0 +1,39 @@
+name: Update translations
+
+on:
+  schedule:
+    - cron: '0 0 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pull-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@v5
+        with:
+          ref: master
+
+      - name: Install the Transifex CLI
+        run: python -m pip install --user transifex-client
+
+      - name: Pull translations from Transifex
+        env:
+          TX_TOKEN: ${{ secrets.TRANSIFEX_TOKEN }}
+        run: $HOME/.local/bin/tx pull -a
+
+      - name: Open a pull request for updated translations
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: app/src/main/res
+          branch: automation/update-translations
+          delete-branch: true
+          commit-message: "Update translations from Transifex"
+          title: "Update translations from Transifex"
+          body: |
+            Automated translation update pulled from Transifex.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ codebase — older Java alongside newer Kotlin.
   APKs. It deliberately does not remove dependencies/classes; it is a
   privacy-conscious courtesy sideload artifact, not a separately supported
   product line.
+- Translation updates run weekly through `.github/workflows/update-translations.yml`:
+  it runs at 00:00 UTC each Wednesday, installs the Transifex CLI, runs `tx
+  pull -a` using the `TRANSIFEX_TOKEN` repository secret, and opens or updates
+  a pull request with changed Android resource translations.
 
 ## Repository layout
 


### PR DESCRIPTION
### Motivation
- Automate regular synchronization of Android resource translations from Transifex and surface changes as a pull request to keep localized strings up to date.

### Description
- Add `.github/workflows/update-translations.yml` which runs weekly (cron `0 0 * * 3`), installs the Transifex CLI, runs `tx pull -a`, and opens or updates a pull request on branch `automation/update-translations` using `peter-evans/create-pull-request@v7` with changed paths under `app/src/main/res`.
- Update `AGENTS.md` to document the new translation update workflow, including the use of the `TRANSIFEX_TOKEN` repository secret and the workflow's schedule and behavior.

### Testing
- No unit or instrumented tests were executed for this documentation and CI/workflow addition, and the workflow can be validated manually using the `workflow_dispatch` trigger.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a0fa71fac8322b7c54dabf6ea161b)