### PR TITLE
Mark font-name strings as untranslatable

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,9 +95,9 @@
     <string name="option_font">Font</string>
     <string name="hint_font">Choose the font used for text throughout DistroHopper.</string>
     <string name="font_system">System default</string>
-    <string name="font_opendyslexic">OpenDyslexic</string>
-    <string name="font_ubuntu">Ubuntu</string>
-    <string name="font_oxygen">Oxygen</string>
+    <string name="font_opendyslexic" translatable="false">OpenDyslexic</string>
+    <string name="font_ubuntu" translatable="false">Ubuntu</string>
+    <string name="font_oxygen" translatable="false">Oxygen</string>
     <string name="option_crash_reports">Send crash reports</string>
     <string name="hint_crash_reports">Automatically send anonymous crash reports to help fix bugs. Reports go to a private server and are never shared with third parties.</string>
     <string name="option_dev">Developer mode</string>


### PR DESCRIPTION
## What

Adds `translatable="false"` to the three font-name strings in `app/src/main/res/values/strings.xml`:

- `font_opendyslexic` (OpenDyslexic)
- `font_ubuntu` (Ubuntu)
- `font_oxygen` (Oxygen)

## Why

These are proper names and shouldn't be translated (as noted in review on #97, where the hand-translated Dutch versions were removed). Marking them `translatable="false"`:

- Removes them from the Transifex source resource (160 → 157 strings), so they're no longer offered to translators and won't drift back into locale files.
- Stops Android lint flagging them as missing translations in every locale.

`font_system` ("System default") stays translatable — only the proper-noun font names are affected. Uses the same `translatable="false"` convention already present in `untranslatable-strings.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoWHigDqjrL73msxckA91H)_