### PR TITLE
Add scheduled workflow to pull translations from Transifex and document it

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,0 +1,37 @@
+name: Update translations
+
+on:
+  schedule:
+    - cron: '0 0 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pull-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the default branch
+        uses: actions/checkout@v5
+        with:
+          ref: master
+
+      - name: Pull translations from Transifex
+        uses: transifex/cli-action@v2
+        with:
+          token: ${{ secrets.TRANSIFEX_TOKEN }}
+          args: pull -a
+
+      - name: Open a pull request for updated translations
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: app/src/main/res
+          branch: automation/update-translations
+          delete-branch: true
+          commit-message: "Update translations from Transifex"
+          title: "Update translations from Transifex"
+          body: |
+            Automated translation update pulled from Transifex.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ codebase — older Java alongside newer Kotlin.
   APKs. It deliberately does not remove dependencies/classes; it is a
   privacy-conscious courtesy sideload artifact, not a separately supported
   product line.
+- Translation updates run weekly through `.github/workflows/update-translations.yml`:
+  it runs at 00:00 UTC each Wednesday, uses the official Transifex CLI action
+  to run `tx pull -a` with the `TRANSIFEX_TOKEN` repository secret, and opens
+  or updates a pull request with changed Android resource translations.
 
 ## Repository layout
 


### PR DESCRIPTION
### Motivation
- Add a weekly automation to pull Android resource translations from Transifex and surface changes as a pull request, and document that behavior in `AGENTS.md`.

### Description
- Add `.github/workflows/update-translations.yml` which runs on a weekly schedule (`cron: '0 0 * * 3'`) and on `workflow_dispatch`, checks out `master`, runs `transifex/cli-action@v2` with `args: pull -a` using the `TRANSIFEX_TOKEN` secret, and opens/updates a PR on branch `automation/update-translations` via `peter-evans/create-pull-request@v7` for changed resources under `app/src/main/res`; and update `AGENTS.md` to document the new scheduled translation update workflow.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a0fa71fac8322b7c54dabf6ea161b)