### PR TITLE
Update Transifex CLI installation and usage method

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -20,12 +20,12 @@ jobs:
           ref: master
 
       - name: Install the Transifex CLI
-        run: python -m pip install --user transifex-client
+        run: curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 
       - name: Pull translations from Transifex
         env:
           TX_TOKEN: ${{ secrets.TRANSIFEX_TOKEN }}
-        run: $HOME/.local/bin/tx pull -a
+        run: ./tx pull -a --force
 
       - name: Open a pull request for updated translations
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary
Updated the translation workflow to use the official Transifex CLI installation script instead of pip, and adjusted the pull command to use the locally installed binary with the `--force` flag.

## Key Changes
- Replaced pip-based installation (`python -m pip install --user transifex-client`) with the official Transifex CLI installation script via curl
- Updated the tx command path from `$HOME/.local/bin/tx` to `./tx` (relative path to the installed binary)
- Added the `--force` flag to the `tx pull` command to ensure translations are overwritten

## Implementation Details
- The installation now uses the official bash installer from the Transifex CLI repository, which may provide better compatibility and maintenance
- The command execution is simplified by using a relative path instead of an absolute home directory path
- The `--force` flag ensures that existing translation files are updated without prompts

https://claude.ai/code/session_01G9NL4wVA5REW9W1vwyrgZq