### PR TITLE
Skip untranslated languages when pulling from Transifex

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Pull translations from Transifex
         env:
           TX_TOKEN: ${{ secrets.TRANSIFEX_TOKEN }}
-        run: ./tx pull -a --force
+        run: ./tx pull -a --minimum-perc 1 --force
 
       - name: Open a pull request for updated translations
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary
The automated translation update (e.g. #109) pulls in empty, comment-only `translations.xml` files for languages that have no translated strings yet. This adds a completion threshold so those languages are skipped.

## Why it happens
`tx pull -a` pulls **every** language configured in the Transifex project, including ones at 0% completion. For those, Transifex still writes a file containing only the developer comments from the source strings and no `<string>` elements — e.g. the new `values-fi` and the churn in `values-bn`, `values-el`, `values-ka`, `values-ko`, `values-hi-rIN` in #109:

```xml
<resources>
  <!--Gestures preferences-->
  <!--Accessibility gesture setup wizard-->
</resources>
```

## Fix
Add `--minimum-perc 1` to the pull command, so any language below 1% translated is skipped:

```
./tx pull -a --minimum-perc 1 --force
```

This only affects future runs. Empty files already committed by earlier runs would need to be removed separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9NL4wVA5REW9W1vwyrgZq)_