### PR TITLE
Change default launcher pin mode from per-desktop to global

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ etc/                                        — design assets (SVG/XCF sources, 
     in new model-level code.
     Pinned apps are **per widget desktop**: `AppRepository` holds a list per
     desktop and a `perDesktop` flag from `preferences/LauncherPinMode`
-    (`LAUNCHER_APP_PIN_MODE` = `global`|`desktop`, default `desktop`; unknown
+    (`LAUNCHER_APP_PIN_MODE` = `global`|`desktop`, default `global`; unknown
     → global). In global mode every desktop maps onto desktop 0, so it is
     exactly the old single shared list. The no-desktop ops (`pin`/`unpin`/…)
     act on `currentDesktop` (set as the pager settles); desktop-explicit

--- a/app/src/main/java/be/robinj/distrohopper/preferences/LauncherPinMode.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/LauncherPinMode.kt
@@ -7,9 +7,9 @@ import android.content.SharedPreferences
  * ([GLOBAL]) or kept separately per desktop ([DESKTOP]).
  *
  * Stored as the string [Preference.LAUNCHER_APP_PIN_MODE] (`global`/`desktop`).
- * The default is per-desktop, so an unset preference resolves to [DESKTOP]
- * (reads pass `"desktop"` as the SharedPreferences default); any other value,
- * including an unrecognised one, resolves to [GLOBAL] as a safe fallback.
+ * The default is global, so an unset preference resolves to [GLOBAL] (reads
+ * pass `"global"` as the SharedPreferences default); any other value,
+ * including an unrecognised one, also resolves to [GLOBAL] as a safe fallback.
  */
 enum class LauncherPinMode(val value: String) {
 	GLOBAL("global"),

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
@@ -21,7 +21,7 @@ enum class Preference(
 	/** Whether running (unpinned) apps are shown in the launcher. */
 	LAUNCHER_SHOW_RUNNING_APPS("launcher_running_show"),
 	/** Whether pinned launcher apps are shared globally or kept per desktop. */
-	LAUNCHER_APP_PIN_MODE("launcher_app_pin_mode", "desktop"),
+	LAUNCHER_APP_PIN_MODE("launcher_app_pin_mode", "global"),
 	/** Launcher icon size (the customise-mode slider value). */
 	LAUNCHERICON_WIDTH("launchericon_width"),
 	/** Whether the accessibility-based launcher service is enabled. */

--- a/app/src/test/java/be/robinj/distrohopper/AppRepositoryGlobalModeTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/AppRepositoryGlobalModeTest.kt
@@ -1,0 +1,96 @@
+package be.robinj.distrohopper
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.Preferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** AppRepository's global pin behaviour (the GLOBAL launcher pin mode): every desktop collapses onto desktop 0. */
+@RunWith(RobolectricTestRunner::class)
+class AppRepositoryGlobalModeTest {
+	private val context: Context = ApplicationProvider.getApplicationContext()
+	private val repository = AppRepository(this.context)
+
+	private fun app(packageName: String): App =
+		App(this.context, null,
+			ActivityTestSupport.resolveInfo(packageName, packageName.uppercase(), packageName))
+
+	@Before fun setUp() {
+		Preferences.getSharedPreferences(this.context, Preferences.PINNED_APPS).edit().clear().commit()
+		Preferences.getSharedPreferences(this.context).edit()
+			.putString(Preference.LAUNCHER_APP_PIN_MODE.getName(), "global").commit()
+		this.repository.loadPinnedApps() // perDesktop = false, empty //
+	}
+
+	@Test fun pinsAreSharedAcrossEveryDesktop() {
+		val a = this.app("a")
+		val b = this.app("b")
+
+		this.repository.pin(a, 0)
+		this.repository.pin(b, 1) // collapses onto the same page as desktop 0 //
+
+		assertEquals(listOf(a, b), this.repository.pinnedOn(0))
+		assertEquals(listOf(a, b), this.repository.pinnedOn(1))
+		assertEquals(listOf(a, b), this.repository.pinnedOn(5))
+	}
+
+	@Test fun unpinFromAnyDesktopAffectsTheSharedList() {
+		val a = this.app("a")
+		this.repository.pin(a, 0)
+
+		this.repository.unpin(a, 3) // still the shared page //
+
+		assertFalse(this.repository.isPinnedOn(a, 0))
+		assertFalse(this.repository.isPinnedOn(a, 3))
+	}
+
+	@Test fun highestPinnedDesktopIsAlwaysAbsentInGlobalMode() {
+		val a = this.app("a")
+		this.repository.pin(a, 4)
+
+		assertEquals(-1, this.repository.highestPinnedDesktop())
+	}
+
+	@Test fun removingADesktopLeavesTheSharedPinsUntouched() {
+		val a = this.app("a")
+		val b = this.app("b")
+		this.repository.pin(a, 0)
+		this.repository.pin(b, 1)
+
+		this.repository.removePinnedDesktop(0) // no-op: pins aren't desktop-bound //
+
+		assertEquals(listOf(a, b), this.repository.pinnedOn(0))
+	}
+
+	@Test fun noDesktopOpsAlwaysTargetTheSharedPage() {
+		val a = this.app("a")
+		this.repository.setCurrentDesktop(3)
+
+		this.repository.pin(a) // no-desktop overload //
+
+		assertTrue(this.repository.isPinnedOn(a, 0))
+		assertTrue(this.repository.isPinnedOn(a, 3))
+		assertEquals(listOf(a), this.repository.pinned.value)
+	}
+
+	@Test fun savePersistsTheFlatGlobalFormat() {
+		val a = this.app("a")
+		val b = this.app("b")
+		this.repository.pin(a, 0)
+		this.repository.pin(b, 2)
+
+		this.repository.savePinnedApps()
+
+		val prefs = Preferences.getSharedPreferences(this.context, Preferences.PINNED_APPS)
+		assertEquals(
+			listOf(listOf(a.packageAndActivityName, b.packageAndActivityName)),
+			PinnedAppsStorage.read(prefs))
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/home/DesktopsTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/DesktopsTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ActivityScenario
 import be.robinj.distrohopper.ActivityTestSupport
 import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.R
+import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.widgets.WidgetContainer
 import be.robinj.distrohopper.widgets.WidgetTestSupport
 import be.robinj.distrohopper.widgets.WidgetsPager
@@ -27,7 +28,13 @@ import org.robolectric.annotation.LooperMode
 class DesktopsTest {
 	private lateinit var scenario: ActivityScenario<HomeActivity>
 
-	@Before fun setUp() { this.scenario = ActivityTestSupport.launchHome() } // per-desktop default //
+	@Before fun setUp() {
+		// This suite exercises the desktop-explicit pin API, so force DESKTOP
+		// mode regardless of the app's own default //
+		this.scenario = ActivityTestSupport.launchHome {
+			it.putString(Preference.LAUNCHER_APP_PIN_MODE.getName(), "desktop")
+		}
+	}
 
 	@After fun tearDown() { this.scenario.close() }
 

--- a/app/src/test/java/be/robinj/distrohopper/preferences/LauncherPinModeTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/LauncherPinModeTest.kt
@@ -22,17 +22,17 @@ class LauncherPinModeTest {
 		assertEquals(LauncherPinMode.GLOBAL, LauncherPinMode.of(""))
 	}
 
-	@Test fun currentDefaultsToDesktopWhenUnset() {
+	@Test fun currentDefaultsToGlobalWhenUnset() {
 		val prefs = Preferences.getSharedPreferences(this.context)
 		prefs.edit().remove(Preference.LAUNCHER_APP_PIN_MODE.getName()).commit()
 
-		assertEquals(LauncherPinMode.DESKTOP, LauncherPinMode.current(prefs))
+		assertEquals(LauncherPinMode.GLOBAL, LauncherPinMode.current(prefs))
 	}
 
-	@Test fun currentReadsAnExplicitGlobalValue() {
+	@Test fun currentReadsAnExplicitDesktopValue() {
 		val prefs = Preferences.getSharedPreferences(this.context)
-		prefs.edit().putString(Preference.LAUNCHER_APP_PIN_MODE.getName(), "global").commit()
+		prefs.edit().putString(Preference.LAUNCHER_APP_PIN_MODE.getName(), "desktop").commit()
 
-		assertEquals(LauncherPinMode.GLOBAL, LauncherPinMode.current(prefs))
+		assertEquals(LauncherPinMode.DESKTOP, LauncherPinMode.current(prefs))
 	}
 }


### PR DESCRIPTION
## Summary
This PR changes the default behavior for pinned launcher apps from being kept separately per desktop to being shared globally across all desktops.

## Key Changes
- Updated `Preference.LAUNCHER_APP_PIN_MODE` default value from `"desktop"` to `"global"`
- Updated `LauncherPinMode` documentation to reflect that the default is now global, with unset preferences resolving to `GLOBAL` instead of `DESKTOP`
- Updated test cases to verify the new default behavior:
  - `currentDefaultsToGlobalWhenUnset()` now expects `GLOBAL` instead of `DESKTOP`
  - `currentReadsAnExplicitDesktopValue()` now tests reading an explicit `"desktop"` value instead of `"global"`
- Updated `AGENTS.md` documentation to reflect the new default

## Implementation Details
The change affects how the `LauncherPinMode.current()` method resolves unset preferences. Previously, an unset preference would default to `DESKTOP` mode; now it defaults to `GLOBAL` mode. The fallback behavior for unrecognized values remains unchanged (resolves to `GLOBAL` as a safe fallback).

https://claude.ai/code/session_01TRszuB9qL8419gYRQgfDP7