### PR TITLE
Desktop grid: snapshot presets, size setting, and display-size immunity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -656,9 +656,18 @@ etc/                                        — design assets (SVG/XCF sources, 
   swiping and fades out after settling.
   The per-page grid maths stay inside `WidgetsContainer` (page insets are
   applied as padding per page, not on the pager), which lays widgets out on
-  an invisible 8×8 grid (`WidgetGrid` holds the pure grid maths — snapping,
-  span clamping, overlap checks, and the initial span for new/restored
-  widgets). Widget sizing reads the provider's hints — `targetCellWidth/Height`
+  an invisible COLS×ROWS grid (`WidgetGrid` holds the pure grid maths —
+  snapping, span clamping, overlap checks, and the initial span for
+  new/restored widgets). The grid dimensions follow the dash/launcher
+  pattern: an adaptive default from the screen plus a customise-mode column
+  slider (`DESKTOP_GRID_COLUMNS`; changing it relaunches home, since the
+  stored layout reloads against the new grid). Because the desktop persists
+  ABSOLUTE col/row coordinates (`DesktopLayoutStorage`), the screen edges
+  feeding the grid are corrected back to the device's stable density
+  (`WidgetGrid.stableEdgeDp`), so the system "Display size" setting — which
+  rescales dp while pixels stay fixed — cannot change the grid underneath
+  the stored layout. At the default column count the row formula is the
+  exact legacy one, so existing desktops keep their grid across the update. Widget sizing reads the provider's hints — `targetCellWidth/Height`
   (API 33), else `minResizeWidth/Height`, else `minWidth/Height` — and clamps
   to `maxResize*`; `clampSpan` uses nearest rounding for both bounds so the
   coarse grid keeps a real resize range instead of collapsing to one span.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -658,16 +658,18 @@ etc/                                        — design assets (SVG/XCF sources, 
   applied as padding per page, not on the pager), which lays widgets out on
   an invisible COLS×ROWS grid (`WidgetGrid` holds the pure grid maths —
   snapping, span clamping, overlap checks, and the initial span for
-  new/restored widgets). The grid dimensions follow the dash/launcher
-  pattern: an adaptive default from the screen plus a customise-mode column
-  slider (`DESKTOP_GRID_COLUMNS`; changing it relaunches home, since the
-  stored layout reloads against the new grid). Because the desktop persists
-  ABSOLUTE col/row coordinates (`DesktopLayoutStorage`), the screen edges
-  feeding the grid are corrected back to the device's stable density
-  (`WidgetGrid.stableEdgeDp`), so the system "Display size" setting — which
-  rescales dp while pixels stay fixed — cannot change the grid underneath
-  the stored layout. At the default column count the row formula is the
-  exact legacy one, so existing desktops keep their grid across the update. Widget sizing reads the provider's hints — `targetCellWidth/Height`
+  new/restored widgets). Because the desktop persists ABSOLUTE col/row
+  coordinates (`DesktopLayoutStorage`), the grid dimensions are Launcher3-style
+  snapshot state, not a runtime formula: on first launch `WidgetGrid`
+  computes five preset sizes from the stable-density screen edges
+  (`stableEdgeDp`; the middle is the adaptive default, ±2 coarser/finer
+  steps around it) and persists both the ladder (`DESKTOP_GRID_PRESETS`)
+  and the ACTUAL grid in use (`DESKTOP_GRID_SIZE`, "colsxrows"). From then
+  on the stored size is applied verbatim — orientation, density/Display-size
+  changes, and future retuning of the calculation constants can never move
+  the grid underneath the stored layout. The customise-mode slider picks
+  among the five persisted presets; changing it relaunches home, since the
+  stored layout reloads against the new grid. Widget sizing reads the provider's hints — `targetCellWidth/Height`
   (API 33), else `minResizeWidth/Height`, else `minWidth/Height` — and clamps
   to `maxResize*`; `clampSpan` uses nearest rounding for both bounds so the
   coarse grid keeps a real resize range instead of collapsing to one span.

--- a/app/src/main/java/be/robinj/distrohopper/AdaptiveCells.kt
+++ b/app/src/main/java/be/robinj/distrohopper/AdaptiveCells.kt
@@ -1,0 +1,32 @@
+package be.robinj.distrohopper
+
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * The one adaptive cell-count formula shared by the three sizing surfaces —
+ * the dash grid ([be.robinj.distrohopper.desktop.dash.DashGrid]), the pinned
+ * launcher icons ([be.robinj.distrohopper.desktop.launcher.LauncherIconGrid])
+ * and the desktop grid ([be.robinj.distrohopper.widgets.WidgetGrid]). Each
+ * surface keeps its own target/min/max cell-dp constants and passes them in;
+ * the shape is always the same: the target cell size picks the device's
+ * default count, and the min/max cell sizes bound the offered range.
+ */
+object AdaptiveCells {
+	/** Fewest cells on an [edgeDp]-wide edge (cell size capped at [maxCellDp]). */
+	@JvmStatic
+	fun minCount(edgeDp: Int, maxCellDp: Int): Int =
+		max(2, ceil(edgeDp.toDouble() / maxCellDp).toInt())
+
+	/** Most cells on an [edgeDp]-wide edge (cell size floored at [minCellDp]). */
+	@JvmStatic
+	fun maxCount(edgeDp: Int, minCellDp: Int, maxCellDp: Int): Int =
+		max(minCount(edgeDp, maxCellDp), edgeDp / minCellDp)
+
+	/** The device-adaptive default count for an [edgeDp]-wide edge. */
+	@JvmStatic
+	fun defaultCount(edgeDp: Int, targetCellDp: Int, minCellDp: Int, maxCellDp: Int): Int =
+		(edgeDp.toDouble() / targetCellDp).roundToInt()
+			.coerceIn(minCount(edgeDp, maxCellDp), maxCount(edgeDp, minCellDp, maxCellDp))
+}

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/DashGrid.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/DashGrid.kt
@@ -1,9 +1,9 @@
 package be.robinj.distrohopper.desktop.dash
 
 import android.content.Context
+import be.robinj.distrohopper.AdaptiveCells
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
-import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -37,16 +37,16 @@ object DashGrid {
 
 	/** Fewest columns offered on a screen [swDp] dp wide (cells capped at [MAX_CELL_DP]). */
 	@JvmStatic
-	fun minColumns(swDp: Int): Int = max(2, ceil(swDp.toDouble() / MAX_CELL_DP).toInt())
+	fun minColumns(swDp: Int): Int = AdaptiveCells.minCount(swDp, MAX_CELL_DP)
 
 	/** Most columns offered on a screen [swDp] dp wide (cells floored at [MIN_CELL_DP]). */
 	@JvmStatic
-	fun maxColumns(swDp: Int): Int = max(minColumns(swDp), swDp / MIN_CELL_DP)
+	fun maxColumns(swDp: Int): Int = AdaptiveCells.maxCount(swDp, MIN_CELL_DP, MAX_CELL_DP)
 
 	/** The adaptive default short-edge column count for a screen [swDp] dp wide. */
 	@JvmStatic
 	fun defaultColumns(swDp: Int): Int =
-		(swDp.toDouble() / TARGET_CELL_DP).roundToInt().coerceIn(minColumns(swDp), maxColumns(swDp))
+		AdaptiveCells.defaultCount(swDp, TARGET_CELL_DP, MIN_CELL_DP, MAX_CELL_DP)
 
 	/**
 	 * The number of columns to show for the current orientation. [n] is the

--- a/app/src/main/java/be/robinj/distrohopper/desktop/launcher/LauncherIconGrid.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/launcher/LauncherIconGrid.kt
@@ -9,10 +9,9 @@ import androidx.core.content.ContextCompat
 import be.robinj.distrohopper.DependencyContainer
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
+import be.robinj.distrohopper.AdaptiveCells
 import be.robinj.distrohopper.theme.Location
-import kotlin.math.ceil
 import kotlin.math.max
-import kotlin.math.roundToInt
 
 /**
  * Pure maths (plus thin runtime resolvers) for the launcher's pinned-icon size — the
@@ -57,18 +56,17 @@ object LauncherIconGrid {
 
 	/** Fewest slots offered on a screen [shortEdgeDp] dp wide (icons capped at [MAX_ICON_DP]). */
 	@JvmStatic
-	fun minCount(shortEdgeDp: Int): Int =
-		max(2, ceil(shortEdgeDp.toDouble() / MAX_ICON_DP).toInt())
+	fun minCount(shortEdgeDp: Int): Int = AdaptiveCells.minCount(shortEdgeDp, MAX_ICON_DP)
 
 	/** Most slots offered on a screen [shortEdgeDp] dp wide (icons floored at [MIN_ICON_DP]). */
 	@JvmStatic
-	fun maxCount(shortEdgeDp: Int): Int = max(minCount(shortEdgeDp), shortEdgeDp / MIN_ICON_DP)
+	fun maxCount(shortEdgeDp: Int): Int =
+		AdaptiveCells.maxCount(shortEdgeDp, MIN_ICON_DP, MAX_ICON_DP)
 
 	/** The device-adaptive default slot count (the middle preset) for [shortEdgeDp]. */
 	@JvmStatic
 	fun defaultCount(shortEdgeDp: Int): Int =
-		(shortEdgeDp.toDouble() / TARGET_ICON_DP).roundToInt()
-			.coerceIn(minCount(shortEdgeDp), maxCount(shortEdgeDp))
+		AdaptiveCells.defaultCount(shortEdgeDp, TARGET_ICON_DP, MIN_ICON_DP, MAX_ICON_DP)
 
 	/**
 	 * The slot count for [presetIndex] (0 = Tiny … [PRESET_COUNT]-1 = Huge): an offset from the

--- a/app/src/main/java/be/robinj/distrohopper/home/CustomiseModeUi.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/CustomiseModeUi.kt
@@ -10,6 +10,7 @@ import be.robinj.distrohopper.HomeActivity
 import be.robinj.distrohopper.R
 import be.robinj.distrohopper.ViewFinder
 import be.robinj.distrohopper.desktop.dash.DashGrid
+import be.robinj.distrohopper.widgets.WidgetGrid
 import be.robinj.distrohopper.desktop.launcher.LauncherIconGrid
 import be.robinj.distrohopper.preferences.BfbLocation
 import be.robinj.distrohopper.preferences.Preference
@@ -107,6 +108,37 @@ class CustomiseModeUi(
 					prefsEdit.putInt(Preference.DASH_GRID_COLUMNS.getName(), value)
 					prefsEdit.commit()
 					this@CustomiseModeUi.updateDashGridHint(dashGridHint)
+				}
+			})
+
+		// Desktop Grid Size // The user picks how many cells span the short screen
+		// edge; the rows derive from that (see WidgetGrid). Unlike the dash, the
+		// desktop persists absolute positions against the grid, so the change is
+		// committed on release and applied by relaunching home (like the edge
+		// spinners): the stored layout reloads against the new grid //
+		val desktopRange = WidgetGrid.columnsRange(this.activity)
+		val desktopGridHint = this.viewFinder.get<TextView>(R.id.tvCustomiseDesktopGridHint)
+		val sbCustomiseDesktopColumns = this.viewFinder.get<SeekBar>(R.id.sbCustomiseDesktopColumns)
+		sbCustomiseDesktopColumns.min = desktopRange.first
+		sbCustomiseDesktopColumns.max = desktopRange.last
+		sbCustomiseDesktopColumns.progress = WidgetGrid.columns(this.activity)
+		this.updateDesktopGridHint(desktopGridHint, sbCustomiseDesktopColumns.progress)
+		sbCustomiseDesktopColumns.setOnSeekBarChangeListener(
+			object : SeekBar.OnSeekBarChangeListener {
+				override fun onProgressChanged(seekBar: SeekBar, i: Int, b: Boolean) {
+					this@CustomiseModeUi.updateDesktopGridHint(desktopGridHint, i)
+				}
+
+				override fun onStartTrackingTouch(seekBar: SeekBar) {}
+
+				override fun onStopTrackingTouch(seekBar: SeekBar) {
+					if (seekBar.progress == WidgetGrid.columns(this@CustomiseModeUi.activity)) {
+						return
+					}
+
+					prefsEdit.putInt(Preference.DESKTOP_GRID_COLUMNS.getName(), seekBar.progress)
+					prefsEdit.commit()
+					this@CustomiseModeUi.relaunchInCustomiseMode.run()
 				}
 			})
 
@@ -246,6 +278,12 @@ class CustomiseModeUi(
 		val label = labels.getOrElse(presetIndex.coerceIn(0, labels.size - 1)) { "" }
 		val count = LauncherIconGrid.visibleCountForPreset(this.activity, presetIndex)
 		hint.text = this.activity.getString(R.string.launcher_icon_hint, label, count)
+	}
+
+	/** Updates the desktop grid "cols × rows" hint for a candidate column count. */
+	private fun updateDesktopGridHint(hint: TextView, cols: Int) {
+		val (c, r) = WidgetGrid.dimensionsFor(this.activity, cols)
+		hint.text = this.activity.getString(R.string.dash_grid_hint, c, r)
 	}
 
 	/** Re-renders the grid-size hint; called on rotation while customising. */

--- a/app/src/main/java/be/robinj/distrohopper/home/CustomiseModeUi.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/CustomiseModeUi.kt
@@ -111,33 +111,33 @@ class CustomiseModeUi(
 				}
 			})
 
-		// Desktop Grid Size // The user picks how many cells span the short screen
-		// edge; the rows derive from that (see WidgetGrid). Unlike the dash, the
-		// desktop persists absolute positions against the grid, so the change is
-		// committed on release and applied by relaunching home (like the edge
-		// spinners): the stored layout reloads against the new grid //
-		val desktopRange = WidgetGrid.columnsRange(this.activity)
+		// Desktop Grid Size // Five presets snapshotted on first launch (the
+		// middle is the device default); the slider picks among them. Unlike the
+		// dash, the desktop persists absolute positions against the grid, so the
+		// change is committed on release and applied by relaunching home (like
+		// the edge segments): the stored layout reloads against the new grid //
+		val desktopPresets = WidgetGrid.presets(this.activity)
 		val desktopGridHint = this.viewFinder.get<TextView>(R.id.tvCustomiseDesktopGridHint)
 		val sbCustomiseDesktopColumns = this.viewFinder.get<SeekBar>(R.id.sbCustomiseDesktopColumns)
-		sbCustomiseDesktopColumns.min = desktopRange.first
-		sbCustomiseDesktopColumns.max = desktopRange.last
-		sbCustomiseDesktopColumns.progress = WidgetGrid.columns(this.activity)
-		this.updateDesktopGridHint(desktopGridHint, sbCustomiseDesktopColumns.progress)
+		sbCustomiseDesktopColumns.min = 0
+		sbCustomiseDesktopColumns.max = WidgetGrid.PRESET_COUNT - 1
+		sbCustomiseDesktopColumns.progress = WidgetGrid.selectedPreset(this.activity)
+		this.updateDesktopGridHint(desktopGridHint, desktopPresets, sbCustomiseDesktopColumns.progress)
 		sbCustomiseDesktopColumns.setOnSeekBarChangeListener(
 			object : SeekBar.OnSeekBarChangeListener {
 				override fun onProgressChanged(seekBar: SeekBar, i: Int, b: Boolean) {
-					this@CustomiseModeUi.updateDesktopGridHint(desktopGridHint, i)
+					this@CustomiseModeUi.updateDesktopGridHint(desktopGridHint, desktopPresets, i)
 				}
 
 				override fun onStartTrackingTouch(seekBar: SeekBar) {}
 
 				override fun onStopTrackingTouch(seekBar: SeekBar) {
-					if (seekBar.progress == WidgetGrid.columns(this@CustomiseModeUi.activity)) {
+					val chosen = desktopPresets[seekBar.progress]
+					if (chosen == WidgetGrid.size(this@CustomiseModeUi.activity)) {
 						return
 					}
 
-					prefsEdit.putInt(Preference.DESKTOP_GRID_COLUMNS.getName(), seekBar.progress)
-					prefsEdit.commit()
+					WidgetGrid.setSize(this@CustomiseModeUi.activity, chosen)
 					this@CustomiseModeUi.relaunchInCustomiseMode.run()
 				}
 			})
@@ -281,8 +281,8 @@ class CustomiseModeUi(
 	}
 
 	/** Updates the desktop grid "cols × rows" hint for a candidate column count. */
-	private fun updateDesktopGridHint(hint: TextView, cols: Int) {
-		val (c, r) = WidgetGrid.dimensionsFor(this.activity, cols)
+	private fun updateDesktopGridHint(hint: TextView, presets: List<Pair<Int, Int>>, index: Int) {
+		val (c, r) = presets[index.coerceIn(0, presets.size - 1)]
 		hint.text = this.activity.getString(R.string.dash_grid_hint, c, r)
 	}
 

--- a/app/src/main/java/be/robinj/distrohopper/home/ThemeApplier.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/ThemeApplier.kt
@@ -197,6 +197,7 @@ class ThemeApplier(
 			R.id.tvCustomiseDone,
 			R.id.tvCustomiseGroupLauncher,
 			R.id.tvCustomiseGroupDash,
+			R.id.tvCustomiseGroupDesktop,
 			R.id.tvCustomiseGroupPanel,
 		)
 	}

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
@@ -42,13 +42,20 @@ enum class Preference(
 	/** Number of icon columns across the dash app grid. */
 	DASH_GRID_COLUMNS("dash_grid_columns"),
 	/**
-	 * Number of columns across the desktop (widget) grid; unset means the
-	 * adaptive default. Resolved against the device's STABLE density (see
-	 * [be.robinj.distrohopper.widgets.WidgetGrid]) so the grid — and the
-	 * absolute col/row coordinates persisted against it — survives the system
-	 * "Display size" setting unchanged.
+	 * The desktop (widget) grid's five size options as "colsxrows" entries,
+	 * comma-separated — snapshotted from the stable screen size on first launch
+	 * and read back verbatim forever, so later calculation changes can never
+	 * alter a user's options. See [be.robinj.distrohopper.widgets.WidgetGrid].
 	 */
-	DESKTOP_GRID_COLUMNS("desktop_grid_columns"),
+	DESKTOP_GRID_PRESETS("desktop_grid_presets"),
+	/**
+	 * The desktop grid's ACTUAL size as "colsxrows" — snapshotted to the middle
+	 * preset on first launch, changed only by the customise slider. Persisting
+	 * the resolved size (not a count or an index) keeps the grid — and the
+	 * absolute col/row coordinates stored against it — stable across
+	 * orientation, density/Display-size and future formula changes.
+	 */
+	DESKTOP_GRID_SIZE("desktop_grid_size"),
 	/** How dash apps are ordered (alphabetical, usage, custom, …). */
 	APP_SORT_ORDER("app_sort_order", "alphabetical"),
 	/** Whether opt-in crash reporting is enabled. */

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
@@ -41,6 +41,14 @@ enum class Preference(
 	DASH_SEARCH_LENSES_MAX_RESULTS("dashsearch_lenses_maxresults"),
 	/** Number of icon columns across the dash app grid. */
 	DASH_GRID_COLUMNS("dash_grid_columns"),
+	/**
+	 * Number of columns across the desktop (widget) grid; unset means the
+	 * adaptive default. Resolved against the device's STABLE density (see
+	 * [be.robinj.distrohopper.widgets.WidgetGrid]) so the grid — and the
+	 * absolute col/row coordinates persisted against it — survives the system
+	 * "Display size" setting unchanged.
+	 */
+	DESKTOP_GRID_COLUMNS("desktop_grid_columns"),
 	/** How dash apps are ordered (alphabetical, usage, custom, …). */
 	APP_SORT_ORDER("app_sort_order", "alphabetical"),
 	/** Whether opt-in crash reporting is enabled. */

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
@@ -2,6 +2,8 @@ package be.robinj.distrohopper.widgets
 
 import android.content.Context
 import android.view.Surface
+import be.robinj.distrohopper.preferences.Preference
+import be.robinj.distrohopper.preferences.Preferences
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.roundToInt
@@ -38,31 +40,122 @@ object WidgetGrid {
 	@JvmField
 	var ROWS = 8
 
+	/** Fewest columns offered on a screen [shortEdgeDp] dp wide (cells capped at [MAX_CELL_DP]). */
+	@JvmStatic
+	fun minColumns(shortEdgeDp: Int): Int = max(2, ceil(shortEdgeDp.toDouble() / MAX_CELL_DP).toInt())
+
+	/** Most columns offered on a screen [shortEdgeDp] dp wide (cells floored at [MIN_CELL_DP]). */
+	@JvmStatic
+	fun maxColumns(shortEdgeDp: Int): Int = max(minColumns(shortEdgeDp), shortEdgeDp / MIN_CELL_DP)
+
+	/** The adaptive default column count for a screen [shortEdgeDp] dp wide. */
+	@JvmStatic
+	fun defaultColumns(shortEdgeDp: Int): Int =
+		(shortEdgeDp.toDouble() / TARGET_CELL_DP).roundToInt()
+			.coerceIn(minColumns(shortEdgeDp), maxColumns(shortEdgeDp))
+
 	/**
 	 * Computes sensible (cols, rows) for a screen with the given dp dimensions.
 	 * Cells are approximately [TARGET_CELL_DP] dp square, clamped to
 	 * [[MIN_CELL_DP], [MAX_CELL_DP]] and proportional to the screen aspect ratio.
 	 */
 	@JvmStatic
-	fun calculate(shortEdgeDp: Int, longEdgeDp: Int): Pair<Int, Int> {
-		val minCols = max(2, ceil(shortEdgeDp.toDouble() / MAX_CELL_DP).toInt())
-		val maxCols = max(minCols, shortEdgeDp / MIN_CELL_DP)
-		val cols = (shortEdgeDp.toDouble() / TARGET_CELL_DP).roundToInt().coerceIn(minCols, maxCols)
-		val rows = max(cols, (longEdgeDp.toDouble() / TARGET_CELL_DP).roundToInt())
-		return cols to rows
+	fun calculate(shortEdgeDp: Int, longEdgeDp: Int): Pair<Int, Int> =
+		calculate(shortEdgeDp, longEdgeDp, defaultColumns(shortEdgeDp))
+
+	/**
+	 * The (cols, rows) grid for a user-chosen [cols] count. At the adaptive
+	 * default the row count keeps the EXACT legacy formula (rows from
+	 * [TARGET_CELL_DP]), so existing desktops keep the grid their stored
+	 * coordinates were written against; a non-default choice derives the rows
+	 * from the screen's aspect ratio so cells stay roughly square.
+	 */
+	@JvmStatic
+	fun calculate(shortEdgeDp: Int, longEdgeDp: Int, cols: Int): Pair<Int, Int> {
+		val chosen = cols.coerceIn(minColumns(shortEdgeDp), maxColumns(shortEdgeDp))
+		val rows = if (chosen == defaultColumns(shortEdgeDp) || shortEdgeDp <= 0) {
+			(longEdgeDp.toDouble() / TARGET_CELL_DP).roundToInt()
+		} else {
+			(longEdgeDp.toDouble() * chosen / shortEdgeDp).roundToInt()
+		}
+		return chosen to max(chosen, rows)
 	}
 
 	/**
-	 * Initialises [COLS] and [ROWS] from the device's screen configuration.
-	 * Call once from [be.robinj.distrohopper.HomeActivity.onCreate] before
-	 * the first layout pass.
+	 * Corrects a dp length back to the device's STABLE density, so the grid is
+	 * immune to the system "Display size" setting: that setting rescales dp
+	 * (pixels stay fixed), and a grid derived from live dp would change its
+	 * COLS×ROWS underneath the absolute col/row coordinates persisted in
+	 * [DesktopLayoutStorage] — scattering items on load. Corrected back to the
+	 * stable density, every input the grid depends on is fixed for the device.
+	 *
+	 * When [stableDensityDpi] is unset or implausibly far from the current
+	 * density (the Display-size setting only ranges ~0.85×–1.5×), the value is
+	 * treated as unreliable and the live [edgeDp] is used unchanged — this also
+	 * keeps test environments (Robolectric reports a bogus stable density) on
+	 * the geometry their qualifiers declare.
+	 */
+	@JvmStatic
+	fun stableEdgeDp(edgeDp: Int, currentDensityDpi: Int, stableDensityDpi: Int): Int {
+		if (stableDensityDpi <= 0 || currentDensityDpi <= 0) {
+			return edgeDp
+		}
+
+		val factor = currentDensityDpi.toDouble() / stableDensityDpi
+		if (factor < 0.5 || factor > 2.0) {
+			return edgeDp
+		}
+
+		return (edgeDp * factor).roundToInt()
+	}
+
+	/** The stable-density (short, long) screen edges in dp; see [stableEdgeDp]. */
+	@JvmStatic
+	fun stableEdgesDp(context: Context): Pair<Int, Int> {
+		val config = context.resources.configuration
+		val currentDpi = context.resources.displayMetrics.densityDpi
+		val stableDpi = android.util.DisplayMetrics.DENSITY_DEVICE_STABLE
+
+		return stableEdgeDp(config.smallestScreenWidthDp, currentDpi, stableDpi) to
+			stableEdgeDp(max(config.screenWidthDp, config.screenHeightDp), currentDpi, stableDpi)
+	}
+
+	/** The valid column counts for this device (the customise slider's range). */
+	@JvmStatic
+	fun columnsRange(context: Context): IntRange {
+		val (shortEdgeDp, _) = stableEdgesDp(context)
+		return minColumns(shortEdgeDp)..maxColumns(shortEdgeDp)
+	}
+
+	/** The stored column count, clamped to the device's range; adaptive default when unset. */
+	@JvmStatic
+	fun columns(context: Context): Int {
+		val (shortEdgeDp, _) = stableEdgesDp(context)
+		val cols = Preferences.getSharedPreferences(context)
+			.getInt(Preference.DESKTOP_GRID_COLUMNS.getName(), defaultColumns(shortEdgeDp))
+
+		return cols.coerceIn(minColumns(shortEdgeDp), maxColumns(shortEdgeDp))
+	}
+
+	/** The (cols, rows) the grid would have for [cols] on this device (the customise hint). */
+	@JvmStatic
+	fun dimensionsFor(context: Context, cols: Int): Pair<Int, Int> {
+		val (shortEdgeDp, longEdgeDp) = stableEdgesDp(context)
+		return calculate(shortEdgeDp, longEdgeDp, cols)
+	}
+
+	/**
+	 * Initialises [COLS] and [ROWS] from the device's screen configuration —
+	 * anchored to the stable density ([stableEdgeDp]) — and the user's desktop
+	 * grid preference. Call once from
+	 * [be.robinj.distrohopper.HomeActivity.onCreate] before the first layout
+	 * pass; a preference change re-applies by relaunching home (the stored
+	 * desktop layout is reloaded against the new grid).
 	 */
 	@JvmStatic
 	fun init(context: Context) {
-		val config = context.resources.configuration
-		val shortEdgeDp = config.smallestScreenWidthDp
-		val longEdgeDp = max(config.screenWidthDp, config.screenHeightDp)
-		val (cols, rows) = calculate(shortEdgeDp, longEdgeDp)
+		val (shortEdgeDp, longEdgeDp) = stableEdgesDp(context)
+		val (cols, rows) = calculate(shortEdgeDp, longEdgeDp, columns(context))
 		COLS = cols
 		ROWS = rows
 	}

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
@@ -120,42 +120,118 @@ object WidgetGrid {
 			stableEdgeDp(max(config.screenWidthDp, config.screenHeightDp), currentDpi, stableDpi)
 	}
 
-	/** The valid column counts for this device (the customise slider's range). */
-	@JvmStatic
-	fun columnsRange(context: Context): IntRange {
-		val (shortEdgeDp, _) = stableEdgesDp(context)
-		return minColumns(shortEdgeDp)..maxColumns(shortEdgeDp)
-	}
+	// ---- Persisted presets and grid size ------------------------------------
 
-	/** The stored column count, clamped to the device's range; adaptive default when unset. */
-	@JvmStatic
-	fun columns(context: Context): Int {
-		val (shortEdgeDp, _) = stableEdgesDp(context)
-		val cols = Preferences.getSharedPreferences(context)
-			.getInt(Preference.DESKTOP_GRID_COLUMNS.getName(), defaultColumns(shortEdgeDp))
+	/** Number of grid-size presets offered; [DEFAULT_PRESET] is the middle one. */
+	const val PRESET_COUNT = 5
 
-		return cols.coerceIn(minColumns(shortEdgeDp), maxColumns(shortEdgeDp))
-	}
+	/** Index of the default (device-derived) preset — the middle of the ladder. */
+	const val DEFAULT_PRESET = 2
 
-	/** The (cols, rows) the grid would have for [cols] on this device (the customise hint). */
+	/** The on-disk form of one grid size: "8x17". */
 	@JvmStatic
-	fun dimensionsFor(context: Context, cols: Int): Pair<Int, Int> {
-		val (shortEdgeDp, longEdgeDp) = stableEdgesDp(context)
-		return calculate(shortEdgeDp, longEdgeDp, cols)
+	fun formatSize(size: Pair<Int, Int>): String = "${size.first}x${size.second}"
+
+	/** Parses [formatSize]'s form; null when malformed or non-positive. */
+	@JvmStatic
+	fun parseSize(raw: String?): Pair<Int, Int>? {
+		val parts = raw?.split('x') ?: return null
+		if (parts.size != 2) {
+			return null
+		}
+
+		val cols = parts[0].toIntOrNull() ?: return null
+		val rows = parts[1].toIntOrNull() ?: return null
+		return if (cols > 0 && rows > 0) cols to rows else null
 	}
 
 	/**
-	 * Initialises [COLS] and [ROWS] from the device's screen configuration —
-	 * anchored to the stable density ([stableEdgeDp]) — and the user's desktop
-	 * grid preference. Call once from
+	 * The five (cols, rows) preset options for a screen: the adaptive default in
+	 * the middle, two steps larger-celled below it and two steps finer above,
+	 * clamped to the device's column range (ends may collapse on small screens).
+	 * Generated ONCE per install and persisted (see [presets]); this function
+	 * never runs against a live screen again afterwards.
+	 */
+	@JvmStatic
+	fun generatePresets(shortEdgeDp: Int, longEdgeDp: Int): List<Pair<Int, Int>> {
+		val default = defaultColumns(shortEdgeDp)
+		return (-DEFAULT_PRESET..DEFAULT_PRESET).map { offset ->
+			calculate(shortEdgeDp, longEdgeDp, default + offset)
+		}
+	}
+
+	/**
+	 * The persisted preset ladder, snapshotted from the stable screen edges on
+	 * first launch. Once written it is read back verbatim forever: neither
+	 * density/Display-size/orientation changes nor future retuning of the
+	 * calculation constants can move a user's options from under their layout.
+	 */
+	@JvmStatic
+	fun presets(context: Context): List<Pair<Int, Int>> {
+		val prefs = Preferences.getSharedPreferences(context)
+		val stored = prefs.getString(Preference.DESKTOP_GRID_PRESETS.getName(), null)
+			?.split(',')?.mapNotNull { parseSize(it) }
+		if (stored != null && stored.size == PRESET_COUNT) {
+			return stored
+		}
+
+		val (shortEdgeDp, longEdgeDp) = stableEdgesDp(context)
+		val generated = generatePresets(shortEdgeDp, longEdgeDp)
+		prefs.edit()
+			.putString(Preference.DESKTOP_GRID_PRESETS.getName(),
+				generated.joinToString(",") { formatSize(it) })
+			.apply()
+
+		return generated
+	}
+
+	/**
+	 * The ACTUAL persisted grid size in use. Snapshotted to the middle preset on
+	 * first launch and only ever changed by the customise slider, so the grid —
+	 * and the absolute col/row coordinates [DesktopLayoutStorage] holds against
+	 * it — is stable by construction.
+	 */
+	@JvmStatic
+	fun size(context: Context): Pair<Int, Int> {
+		val prefs = Preferences.getSharedPreferences(context)
+		val stored = parseSize(prefs.getString(Preference.DESKTOP_GRID_SIZE.getName(), null))
+		if (stored != null) {
+			return stored
+		}
+
+		val middle = presets(context)[DEFAULT_PRESET]
+		prefs.edit()
+			.putString(Preference.DESKTOP_GRID_SIZE.getName(), formatSize(middle))
+			.apply()
+
+		return middle
+	}
+
+	/** Persists [size] as the grid to use; applied by relaunching home. */
+	@JvmStatic
+	fun setSize(context: Context, size: Pair<Int, Int>) {
+		Preferences.getSharedPreferences(context).edit()
+			.putString(Preference.DESKTOP_GRID_SIZE.getName(), formatSize(size))
+			.commit()
+	}
+
+	/** The preset index matching the current [size]; the middle when it matches none. */
+	@JvmStatic
+	fun selectedPreset(context: Context): Int {
+		val index = presets(context).indexOf(size(context))
+		return if (index >= 0) index else DEFAULT_PRESET
+	}
+
+	/**
+	 * Initialises [COLS] and [ROWS] from the persisted grid size (snapshotting
+	 * the presets and the default size on first launch). Call once from
 	 * [be.robinj.distrohopper.HomeActivity.onCreate] before the first layout
-	 * pass; a preference change re-applies by relaunching home (the stored
-	 * desktop layout is reloaded against the new grid).
+	 * pass; a preset change re-applies by relaunching home (the stored desktop
+	 * layout is reloaded against the new grid).
 	 */
 	@JvmStatic
 	fun init(context: Context) {
-		val (shortEdgeDp, longEdgeDp) = stableEdgesDp(context)
-		val (cols, rows) = calculate(shortEdgeDp, longEdgeDp, columns(context))
+		val (cols, rows) = size(context)
 		COLS = cols
 		ROWS = rows
 	}

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
@@ -2,9 +2,9 @@ package be.robinj.distrohopper.widgets
 
 import android.content.Context
 import android.view.Surface
+import be.robinj.distrohopper.AdaptiveCells
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
-import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -42,17 +42,17 @@ object WidgetGrid {
 
 	/** Fewest columns offered on a screen [shortEdgeDp] dp wide (cells capped at [MAX_CELL_DP]). */
 	@JvmStatic
-	fun minColumns(shortEdgeDp: Int): Int = max(2, ceil(shortEdgeDp.toDouble() / MAX_CELL_DP).toInt())
+	fun minColumns(shortEdgeDp: Int): Int = AdaptiveCells.minCount(shortEdgeDp, MAX_CELL_DP)
 
 	/** Most columns offered on a screen [shortEdgeDp] dp wide (cells floored at [MIN_CELL_DP]). */
 	@JvmStatic
-	fun maxColumns(shortEdgeDp: Int): Int = max(minColumns(shortEdgeDp), shortEdgeDp / MIN_CELL_DP)
+	fun maxColumns(shortEdgeDp: Int): Int =
+		AdaptiveCells.maxCount(shortEdgeDp, MIN_CELL_DP, MAX_CELL_DP)
 
 	/** The adaptive default column count for a screen [shortEdgeDp] dp wide. */
 	@JvmStatic
 	fun defaultColumns(shortEdgeDp: Int): Int =
-		(shortEdgeDp.toDouble() / TARGET_CELL_DP).roundToInt()
-			.coerceIn(minColumns(shortEdgeDp), maxColumns(shortEdgeDp))
+		AdaptiveCells.defaultCount(shortEdgeDp, TARGET_CELL_DP, MIN_CELL_DP, MAX_CELL_DP)
 
 	/**
 	 * Computes sensible (cols, rows) for a screen with the given dp dimensions.

--- a/app/src/main/res/layout/activity_home_customise.xml
+++ b/app/src/main/res/layout/activity_home_customise.xml
@@ -179,6 +179,40 @@
 
 			</LinearLayout>
 
+			<!-- Desktop -->
+
+			<TextView
+				android:id="@+id/tvCustomiseGroupDesktop"
+				style="@style/CustomiseGroupLabel"
+				android:text="@string/pref_header_desktop" />
+
+			<LinearLayout style="@style/CustomiseCard">
+
+				<LinearLayout style="@style/CustomiseSetting">
+
+					<TextView
+						style="@style/CustomiseSettingTitle"
+						android:text="@string/customise_option_desktop_grid_size" />
+
+					<TextView
+						style="@style/CustomiseSettingHint"
+						android:text="@string/customise_hint_desktop_grid_size" />
+
+					<SeekBar
+						android:id="@+id/sbCustomiseDesktopColumns"
+						style="@style/CustomiseSeekBar"
+						android:saveEnabled="false" /><!-- see sbCustomiseLauncherIconSize -->
+
+					<!-- The live "columns × rows" readout; see
+					     CustomiseModeUi.updateDesktopGridHint(). -->
+					<TextView
+						android:id="@+id/tvCustomiseDesktopGridHint"
+						style="@style/CustomiseSettingValue" />
+
+				</LinearLayout>
+
+			</LinearLayout>
+
 			<!-- Panel: the whole group goes when the theme doesn't let the
 			     panel move (CustomiseModeUi.show()). -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,9 @@
     <string name="customise_option_dash_grid_size">Grid size</string>
     <string name="customise_hint_dash_grid_size">Larger grid means smaller icons.</string>
     <string name="dash_grid_hint">%1$d × %2$d</string>
+    <string name="pref_header_desktop">Desktop</string>
+    <string name="customise_option_desktop_grid_size">Grid size</string>
+    <string name="customise_hint_desktop_grid_size">Larger grid means smaller cells. Changing it rearranges items that no longer fit.</string>
     <!-- Which screen edge the launcher or panel is attached to; the group it
          sits under names the one it applies to. -->
     <string name="customise_option_screen_edge">Screen edge</string>

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridColumnsTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridColumnsTest.kt
@@ -6,17 +6,18 @@ import be.robinj.distrohopper.DependencyContainer
 import be.robinj.distrohopper.preferences.Preference
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * The desktop grid's column preference wiring: the adaptive default when unset,
- * the stored count when set (clamped to the device range), and [WidgetGrid.init]
- * applying it to COLS/ROWS. The maths themselves are covered by [WidgetGridTest];
- * these exercise the Context resolvers end-to-end.
+ * The desktop grid's persisted presets and size: snapshotted on first launch
+ * (middle preset = the device default), then read back verbatim forever — the
+ * stored values, not any live-screen calculation, are what [WidgetGrid.init]
+ * applies. The generation maths are covered by [WidgetGridTest]; these
+ * exercise the persistence contract end-to-end.
  */
 @RunWith(RobolectricTestRunner::class)
 class WidgetGridColumnsTest {
@@ -27,49 +28,90 @@ class WidgetGridColumnsTest {
 		WidgetGrid.ROWS = 8
 	}
 
-	private fun setColumns(cols: Int) {
+	private fun stored(pref: Preference): String? =
+		be.robinj.distrohopper.preferences.Preferences.getSharedPreferences(this.context)
+			.getString(pref.getName(), null)
+
+	@Test fun firstLaunchSnapshotsPresetsAndDefaultSize() {
+		val presets = WidgetGrid.presets(this.context)
+		val size = WidgetGrid.size(this.context)
+
+		assertEquals(WidgetGrid.PRESET_COUNT, presets.size)
+		assertEquals("middle preset is the default selection",
+			presets[WidgetGrid.DEFAULT_PRESET], size)
+		// Both snapshots are persisted, not just computed.
+		assertNotNull(this.stored(Preference.DESKTOP_GRID_PRESETS))
+		assertEquals(WidgetGrid.formatSize(size), this.stored(Preference.DESKTOP_GRID_SIZE))
+	}
+
+	/**
+	 * The core stability contract: init applies the STORED size verbatim —
+	 * whatever the current screen or today's formula would say. A future
+	 * calculation change (or any density/orientation game) can therefore never
+	 * move a persisted grid.
+	 */
+	@Test fun initAppliesTheStoredSizeVerbatim() {
 		DependencyContainer.of(this.context).prefs.edit {
-			putInt(Preference.DESKTOP_GRID_COLUMNS.getName(), cols)
+			putString(Preference.DESKTOP_GRID_SIZE.getName(), "3x9")
 		}
-	}
-
-	@Test fun unsetPreferenceYieldsTheAdaptiveDefault() {
-		val (shortEdgeDp, _) = WidgetGrid.stableEdgesDp(this.context)
-		assertEquals(WidgetGrid.defaultColumns(shortEdgeDp), WidgetGrid.columns(this.context))
-	}
-
-	@Test fun storedColumnsAreRespected() {
-		val range = WidgetGrid.columnsRange(this.context)
-		assertTrue("range must offer a non-default choice", range.count() > 1)
-		val choice = if (WidgetGrid.columns(this.context) == range.last) range.first else range.last
-
-		this.setColumns(choice)
-		assertEquals(choice, WidgetGrid.columns(this.context))
-	}
-
-	@Test fun storedColumnsAreClampedToTheDeviceRange() {
-		val range = WidgetGrid.columnsRange(this.context)
-
-		this.setColumns(99)
-		assertEquals(range.last, WidgetGrid.columns(this.context))
-		this.setColumns(1)
-		assertEquals(range.first, WidgetGrid.columns(this.context))
-	}
-
-	@Test fun initAppliesTheStoredColumns() {
-		val range = WidgetGrid.columnsRange(this.context)
-		this.setColumns(range.last)
 
 		WidgetGrid.init(this.context)
 
-		assertEquals(range.last, WidgetGrid.COLS)
-		val (shortEdgeDp, longEdgeDp) = WidgetGrid.stableEdgesDp(this.context)
-		assertEquals(WidgetGrid.calculate(shortEdgeDp, longEdgeDp, range.last).second, WidgetGrid.ROWS)
+		assertEquals(3, WidgetGrid.COLS)
+		assertEquals(9, WidgetGrid.ROWS)
 	}
 
-	@Test fun dimensionsForMatchesInitGeometry() {
-		val cols = WidgetGrid.columns(this.context)
+	/** Stored presets are read back verbatim too — never regenerated. */
+	@Test fun storedPresetsAreNeverRegenerated() {
+		DependencyContainer.of(this.context).prefs.edit {
+			putString(Preference.DESKTOP_GRID_PRESETS.getName(), "2x4,3x6,4x8,5x10,6x12")
+		}
+
+		assertEquals(
+			listOf(2 to 4, 3 to 6, 4 to 8, 5 to 10, 6 to 12),
+			WidgetGrid.presets(this.context))
+	}
+
+	@Test fun selectedPresetMatchesTheStoredSize() {
+		DependencyContainer.of(this.context).prefs.edit {
+			putString(Preference.DESKTOP_GRID_PRESETS.getName(), "2x4,3x6,4x8,5x10,6x12")
+			putString(Preference.DESKTOP_GRID_SIZE.getName(), "5x10")
+		}
+
+		assertEquals(3, WidgetGrid.selectedPreset(this.context))
+	}
+
+	@Test fun sizeOutsideTheLadderFallsBackToTheMiddleIndex() {
+		DependencyContainer.of(this.context).prefs.edit {
+			putString(Preference.DESKTOP_GRID_PRESETS.getName(), "2x4,3x6,4x8,5x10,6x12")
+			putString(Preference.DESKTOP_GRID_SIZE.getName(), "9x9")
+		}
+
+		// The grid itself keeps the stored size; only the slider position falls back.
+		assertEquals(WidgetGrid.DEFAULT_PRESET, WidgetGrid.selectedPreset(this.context))
 		WidgetGrid.init(this.context)
-		assertEquals(WidgetGrid.COLS to WidgetGrid.ROWS, WidgetGrid.dimensionsFor(this.context, cols))
+		assertEquals(9, WidgetGrid.COLS)
+	}
+
+	@Test fun malformedStoredValuesAreReplacedByAFreshSnapshot() {
+		DependencyContainer.of(this.context).prefs.edit {
+			putString(Preference.DESKTOP_GRID_PRESETS.getName(), "garbage")
+			putString(Preference.DESKTOP_GRID_SIZE.getName(), "alsoxgarbage")
+		}
+
+		val presets = WidgetGrid.presets(this.context)
+		assertEquals(WidgetGrid.PRESET_COUNT, presets.size)
+		assertEquals(presets[WidgetGrid.DEFAULT_PRESET], WidgetGrid.size(this.context))
+	}
+
+	@Test fun setSizePersistsAndInitApplies() {
+		val presets = WidgetGrid.presets(this.context)
+		val finest = presets.last()
+
+		WidgetGrid.setSize(this.context, finest)
+		WidgetGrid.init(this.context)
+
+		assertEquals(finest, WidgetGrid.COLS to WidgetGrid.ROWS)
+		assertEquals(WidgetGrid.PRESET_COUNT - 1, WidgetGrid.selectedPreset(this.context))
 	}
 }

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridColumnsTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridColumnsTest.kt
@@ -6,11 +6,14 @@ import be.robinj.distrohopper.DependencyContainer
 import be.robinj.distrohopper.preferences.Preference
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 /**
  * The desktop grid's persisted presets and size: snapshotted on first launch
@@ -113,5 +116,66 @@ class WidgetGridColumnsTest {
 
 		assertEquals(finest, WidgetGrid.COLS to WidgetGrid.ROWS)
 		assertEquals(WidgetGrid.PRESET_COUNT - 1, WidgetGrid.selectedPreset(this.context))
+	}
+
+	// ---- configuration changes ----------------------------------------------
+	// True cross-config checks: snapshot under one configuration, change it
+	// in-process (RuntimeEnvironment.setQualifiers updates the same application,
+	// so SharedPreferences persist — like a real device would), re-init, and
+	// assert the grid, ladder and selection did not move.
+
+	private fun snapshotThenReinitUnder(qualifiers: String): Triple<Pair<Int, Int>, List<Pair<Int, Int>>, Int> {
+		WidgetGrid.init(this.context)
+		val grid = WidgetGrid.COLS to WidgetGrid.ROWS
+		val presets = WidgetGrid.presets(this.context)
+		val selected = WidgetGrid.selectedPreset(this.context)
+
+		RuntimeEnvironment.setQualifiers(qualifiers)
+		WidgetGrid.init(this.context)
+
+		assertEquals("grid must not move", grid, WidgetGrid.COLS to WidgetGrid.ROWS)
+		assertEquals("ladder must not regenerate", presets, WidgetGrid.presets(this.context))
+		assertEquals("selection must not move", selected, WidgetGrid.selectedPreset(this.context))
+		return Triple(grid, presets, selected)
+	}
+
+	@Test @Config(qualifiers = "w360dp-h800dp-xxhdpi")
+	fun gridSurvivesOrientationChange() {
+		this.snapshotThenReinitUnder("+land")
+	}
+
+	@Test @Config(qualifiers = "w360dp-h800dp-480dpi")
+	fun gridSurvivesDisplaySizeChange() {
+		// The same 1080×2400 px panel at a smaller "Display size" setting: dp
+		// grow, density drops. Precondition: a fresh snapshot HERE would yield a
+		// different ladder — proving the assertion discriminates.
+		WidgetGrid.init(this.context)
+		assertNotEquals("precondition: the new config must disagree with the stored ladder",
+			WidgetGrid.presets(this.context), WidgetGrid.generatePresets(432, 960))
+
+		this.snapshotThenReinitUnder("w432dp-h960dp-400dpi")
+	}
+
+	@Test @Config(qualifiers = "w360dp-h800dp-xxhdpi")
+	fun gridSurvivesScreenSizeChange() {
+		// A foldable unfolding to a tablet-sized inner display: everything —
+		// width, height, smallest width, density — changes at once.
+		WidgetGrid.init(this.context)
+		assertNotEquals("precondition: the new config must disagree with the stored ladder",
+			WidgetGrid.presets(this.context), WidgetGrid.generatePresets(800, 1280))
+
+		this.snapshotThenReinitUnder("w800dp-h1280dp-xhdpi")
+	}
+
+	@Test @Config(qualifiers = "w360dp-h800dp-xxhdpi")
+	fun nonDefaultSelectionSurvivesConfigurationChanges() {
+		// The stability contract must hold for a user-chosen preset too, across
+		// a rotation and a display-size change back to back.
+		WidgetGrid.setSize(this.context, WidgetGrid.presets(this.context).first())
+
+		this.snapshotThenReinitUnder("+land")
+		this.snapshotThenReinitUnder("w432dp-h960dp-400dpi")
+
+		assertEquals(0, WidgetGrid.selectedPreset(this.context))
 	}
 }

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridColumnsTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridColumnsTest.kt
@@ -1,0 +1,75 @@
+package be.robinj.distrohopper.widgets
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import be.robinj.distrohopper.DependencyContainer
+import be.robinj.distrohopper.preferences.Preference
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The desktop grid's column preference wiring: the adaptive default when unset,
+ * the stored count when set (clamped to the device range), and [WidgetGrid.init]
+ * applying it to COLS/ROWS. The maths themselves are covered by [WidgetGridTest];
+ * these exercise the Context resolvers end-to-end.
+ */
+@RunWith(RobolectricTestRunner::class)
+class WidgetGridColumnsTest {
+	private val context: Context = ApplicationProvider.getApplicationContext()
+
+	@Before @After fun resetGrid() {
+		WidgetGrid.COLS = 8
+		WidgetGrid.ROWS = 8
+	}
+
+	private fun setColumns(cols: Int) {
+		DependencyContainer.of(this.context).prefs.edit {
+			putInt(Preference.DESKTOP_GRID_COLUMNS.getName(), cols)
+		}
+	}
+
+	@Test fun unsetPreferenceYieldsTheAdaptiveDefault() {
+		val (shortEdgeDp, _) = WidgetGrid.stableEdgesDp(this.context)
+		assertEquals(WidgetGrid.defaultColumns(shortEdgeDp), WidgetGrid.columns(this.context))
+	}
+
+	@Test fun storedColumnsAreRespected() {
+		val range = WidgetGrid.columnsRange(this.context)
+		assertTrue("range must offer a non-default choice", range.count() > 1)
+		val choice = if (WidgetGrid.columns(this.context) == range.last) range.first else range.last
+
+		this.setColumns(choice)
+		assertEquals(choice, WidgetGrid.columns(this.context))
+	}
+
+	@Test fun storedColumnsAreClampedToTheDeviceRange() {
+		val range = WidgetGrid.columnsRange(this.context)
+
+		this.setColumns(99)
+		assertEquals(range.last, WidgetGrid.columns(this.context))
+		this.setColumns(1)
+		assertEquals(range.first, WidgetGrid.columns(this.context))
+	}
+
+	@Test fun initAppliesTheStoredColumns() {
+		val range = WidgetGrid.columnsRange(this.context)
+		this.setColumns(range.last)
+
+		WidgetGrid.init(this.context)
+
+		assertEquals(range.last, WidgetGrid.COLS)
+		val (shortEdgeDp, longEdgeDp) = WidgetGrid.stableEdgesDp(this.context)
+		assertEquals(WidgetGrid.calculate(shortEdgeDp, longEdgeDp, range.last).second, WidgetGrid.ROWS)
+	}
+
+	@Test fun dimensionsForMatchesInitGeometry() {
+		val cols = WidgetGrid.columns(this.context)
+		WidgetGrid.init(this.context)
+		assertEquals(WidgetGrid.COLS to WidgetGrid.ROWS, WidgetGrid.dimensionsFor(this.context, cols))
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridTest.kt
@@ -82,6 +82,39 @@ class WidgetGridTest {
         }
     }
 
+    // ---- preset ladder + serialisation -------------------------------------
+
+    @Test fun presetLadderStepsAroundTheDefault() {
+        val presets = WidgetGrid.generatePresets(360, 800)
+        assertEquals(WidgetGrid.PRESET_COUNT, presets.size)
+        assertEquals("middle preset is the exact adaptive default (legacy rows)",
+            WidgetGrid.calculate(360, 800), presets[WidgetGrid.DEFAULT_PRESET])
+        assertEquals(listOf(6, 7, 8, 9, 10), presets.map { it.first })
+    }
+
+    @Test fun presetLadderCollapsesAtTheRangeEnds() {
+        // sw 200: columns range 3..5 around a default of 4 — the ±2 steps clamp.
+        val presets = WidgetGrid.generatePresets(200, 400)
+        assertEquals(listOf(3, 3, 4, 5, 5), presets.map { it.first })
+    }
+
+    @Test fun sizeSerialisationRoundTrips() {
+        assertEquals(8 to 17, WidgetGrid.parseSize(WidgetGrid.formatSize(8 to 17)))
+        assertEquals("8x17", WidgetGrid.formatSize(8 to 17))
+    }
+
+    @Test fun parseSizeRejectsMalformedInput() {
+        assertNull(WidgetGrid.parseSize(null))
+        assertNull(WidgetGrid.parseSize(""))
+        assertNull(WidgetGrid.parseSize("8"))
+        assertNull(WidgetGrid.parseSize("8x"))
+        assertNull(WidgetGrid.parseSize("x17"))
+        assertNull(WidgetGrid.parseSize("8x17x2"))
+        assertNull(WidgetGrid.parseSize("0x5"))
+        assertNull(WidgetGrid.parseSize("-1x5"))
+        assertNull(WidgetGrid.parseSize("axb"))
+    }
+
     // ---- stable-density anchor ---------------------------------------------
 
     /**

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridTest.kt
@@ -44,6 +44,69 @@ class WidgetGridTest {
         assertTrue(cols >= 2)
     }
 
+    // ---- user-chosen column count ------------------------------------------
+
+    @Test fun columnRangeAndDefaultForTypicalPhone() {
+        assertEquals(5, WidgetGrid.minColumns(360))  // ceil(360/72)
+        assertEquals(10, WidgetGrid.maxColumns(360)) // 360/36
+        assertEquals(8, WidgetGrid.defaultColumns(360))
+    }
+
+    /**
+     * At the adaptive default the rows keep the EXACT legacy formula, so
+     * existing desktops keep the grid their stored coordinates were written
+     * against across the update that introduced the column setting.
+     */
+    @Test fun defaultColumnsKeepLegacyRows() {
+        assertEquals(WidgetGrid.calculate(360, 800),
+            WidgetGrid.calculate(360, 800, WidgetGrid.defaultColumns(360)))
+        assertEquals(8 to 17, WidgetGrid.calculate(360, 800, 8))
+    }
+
+    @Test fun chosenColumnsDeriveRowsFromAspectRatio() {
+        // 10 cols on 360×800: rows = round(800 * 10 / 360) = 22
+        assertEquals(10 to 22, WidgetGrid.calculate(360, 800, 10))
+        // 5 cols: rows = round(800 * 5 / 360) = 11
+        assertEquals(5 to 11, WidgetGrid.calculate(360, 800, 5))
+    }
+
+    @Test fun chosenColumnsAreClampedToRange() {
+        assertEquals(WidgetGrid.maxColumns(360), WidgetGrid.calculate(360, 800, 99).first)
+        assertEquals(WidgetGrid.minColumns(360), WidgetGrid.calculate(360, 800, 1).first)
+    }
+
+    @Test fun chosenColumnsRowsNeverBelowCols() {
+        for (cols in WidgetGrid.minColumns(360)..WidgetGrid.maxColumns(360)) {
+            val (c, r) = WidgetGrid.calculate(360, 360, cols)
+            assertTrue(r >= c)
+        }
+    }
+
+    // ---- stable-density anchor ---------------------------------------------
+
+    /**
+     * The system "Display size" setting rescales dp while pixels stay fixed;
+     * correcting the live dp back to the stable density must recover the same
+     * edge regardless of the chosen display size, so the grid (and the
+     * absolute coordinates stored against it) never changes underneath.
+     */
+    @Test fun stableEdgeDpIsInvariantAcrossDisplaySizes() {
+        // A 411 dp at 420 dpi device: px = 411 * 420/160.
+        // Larger display size (480dpi): live dp = round(px / 3.0) = 360.
+        assertEquals(411, WidgetGrid.stableEdgeDp(360, 480, 420))
+        // Smaller display size (356dpi): live dp ≈ 485.
+        assertEquals(411, WidgetGrid.stableEdgeDp(485, 356, 420))
+        // Default display size: identity.
+        assertEquals(411, WidgetGrid.stableEdgeDp(411, 420, 420))
+    }
+
+    @Test fun stableEdgeDpFallsBackWhenStableDensityIsUnreliable() {
+        assertEquals(360, WidgetGrid.stableEdgeDp(360, 480, 0))    // unset
+        assertEquals(360, WidgetGrid.stableEdgeDp(360, 0, 420))    // bogus current
+        assertEquals(360, WidgetGrid.stableEdgeDp(360, 480, 160))  // 3× — outside any real display-size range
+        assertEquals(360, WidgetGrid.stableEdgeDp(360, 160, 480))  // ⅓× likewise
+    }
+
     // ---- rotation transforms -----------------------------------------------
 
     private fun portraitToDisplay(col: Int, row: Int, colSpan: Int, rowSpan: Int, rotation: Int) =


### PR DESCRIPTION
## Problem

The desktop grid sized itself from **live dp** (`WidgetGrid.init` off `smallestScreenWidthDp`), while `DesktopLayoutStorage` persists **absolute** col/row coordinates against it. The system "Display size" setting rescales dp with pixels fixed, so it silently changed `COLS × ROWS` underneath the stored layout; anything out of bounds on the shrunken grid was relocated to the first free slot on load and persisted — scattering desktop items, unrecoverably.

## What

Launcher3-style **snapshot state** instead of any runtime formula (positions demand a grid that never moves; the dash/launcher stay live-adaptive because they persist nothing positional):

- **Five presets, snapshotted on first launch**: `WidgetGrid` computes a ladder of five grid sizes from the stable-density screen edges (`stableEdgeDp`, via `DENSITY_DEVICE_STABLE`) — the middle is the adaptive device default, with two coarser and two finer steps around it (clamped to the device's range; ends may collapse on small screens) — and persists it verbatim (`DESKTOP_GRID_PRESETS`, `"colsxrows"` entries).
- **The actual grid size is persisted** (`DESKTOP_GRID_SIZE`, defaulting to the middle preset) and applied verbatim by `init()` from then on. Orientation, density/Display-size changes, **and future retuning of the calculation constants** can never move the grid underneath the stored layout — which also means formula changes will never need a migration.
- **Customise-mode slider** (5 positions, in the new card UI with its own "Desktop" group) picks among the persisted presets with a live "cols × rows" readout; a change commits on release and relaunches home so the stored layout reloads deterministically against the new grid.
- **No migration** for the replaced `desktop_grid_columns` key from an earlier iteration of this PR: nothing after 2.7.0 has shipped.
- **Dedup** (self-review finding): the adaptive min/max/default count formula existed in three verbatim copies (`DashGrid`, `LauncherIconGrid`, `WidgetGrid`) — extracted into a shared `AdaptiveCells` helper; each surface keeps its own cell-dp constants.

## Testing

- `WidgetGridTest`: preset-ladder generation (±2 steps around the exact legacy default, clamped collapse on small screens), `"colsxrows"` serialisation round-trip and malformed-input rejection, stable-anchor invariance across display sizes, chosen-column geometry.
- `WidgetGridColumnsTest`: the persistence contract end-to-end — first-launch snapshot writes both keys with the middle preset selected; **`init` applies the stored size verbatim** (the stability guarantee, tested with a size no formula would produce); stored presets are never regenerated; malformed values fall back to a fresh snapshot; slider index tracks the stored size.
- Full suite: **975 tests, 0 failures** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hg7YREsBsCX87ZsrRf6MNw