### PR TITLE
Move dash_app_sort_order_entries to untranslatable strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,12 +167,6 @@
     <string name="option_dash_app_sort_order_recent">Most recently used</string>
     <string name="option_dash_app_sort_order_most_used">Most used</string>
     <string name="option_dash_app_sort_order_custom">Custom (drag to reorder)</string>
-    <string-array name="dash_app_sort_order_entries">
-        <item>@string/option_dash_app_sort_order_alphabetic</item>
-        <item>@string/option_dash_app_sort_order_recent</item>
-        <item>@string/option_dash_app_sort_order_most_used</item>
-        <item>@string/option_dash_app_sort_order_custom</item>
-    </string-array>
     <string name="folder_full">Folder is full</string>
     <string name="option_pin_per_desktop">Per-desktop pinned apps</string>
     <string name="hint_pin_per_desktop">Give each desktop its own pinned apps in the Launcher, instead of sharing the same ones across every desktop.</string>

--- a/app/src/main/res/values/untranslatable-strings.xml
+++ b/app/src/main/res/values/untranslatable-strings.xml
@@ -2,6 +2,15 @@
 <resources>
     <string name="app_name">DistroHopper</string>
 
+    <!-- Not translatable: the items are references; the strings they point
+         at carry the translations. -->
+    <string-array name="dash_app_sort_order_entries" translatable="false">
+        <item>@string/option_dash_app_sort_order_alphabetic</item>
+        <item>@string/option_dash_app_sort_order_recent</item>
+        <item>@string/option_dash_app_sort_order_most_used</item>
+        <item>@string/option_dash_app_sort_order_custom</item>
+    </string-array>
+
     <!-- Must mirror the AppSortOrder enum values, in the same order as
          dash_app_sort_order_entries. Not translatable: persisted preference keys. -->
     <string-array name="dash_app_sort_order_values" translatable="false">


### PR DESCRIPTION
## Summary
Moved the `dash_app_sort_order_entries` string array from the translatable strings file to the untranslatable strings file, since it contains only references to other translatable strings rather than user-facing text.

## Key Changes
- Moved `dash_app_sort_order_entries` string array from `values/strings.xml` to `values/untranslatable-strings.xml`
- Added explanatory comment clarifying that the array is not translatable because it contains references to strings that are independently translated
- The array itself remains unchanged; only its location and translatable attribute were modified

## Implementation Details
The `dash_app_sort_order_entries` array contains references (`@string/...`) to individual translatable strings for each sort order option. Since the array is just a container of references and doesn't contain any user-facing text itself, it should be marked as non-translatable. The actual translations are handled by the individual string resources it references (`option_dash_app_sort_order_alphabetic`, `option_dash_app_sort_order_recent`, etc.), which remain in the translatable strings file.

https://claude.ai/code/session_01Bc9EDRTR2BabZz7m4pEJPF