### PR TITLE
CI: Remove claude/** branch filter and add concurrency control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ master, 'claude/**' ]
+    # Deliberately master and tags only. Every other branch here exists to
+    # become a pull request, and pull_request already covers those — listing
+    # them again would run the whole workflow twice for every push to an open
+    # PR's head branch.
+    branches: [ master ]
     tags: [ 'v*' ]
   pull_request:
     branches: [ master ]
@@ -12,6 +16,13 @@ on:
         description: 'Version to release, e.g. v3.0.1 — a single trailing letter (v3.0.1a) publishes a pre-release'
         required: true
         type: string
+
+# A new push to a PR makes the in-flight run for its previous head pointless.
+# master and tag runs are grouped too, but never cancelled: they cut releases,
+# and a half-finished release job is worse than a redundant one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Single source of truth for "is this a release, and which version is it".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: CI
 
 on:
   push:
-    # Deliberately master and tags only. Every other branch here exists to
-    # become a pull request, and pull_request already covers those — listing
-    # them again would run the whole workflow twice for every push to an open
-    # PR's head branch.
     branches: [ master ]
     tags: [ 'v*' ]
   pull_request:


### PR DESCRIPTION
## Summary
Updated the CI workflow to remove the `claude/**` branch filter and add concurrency control for pull requests to prevent redundant workflow runs.

## Key Changes
- **Removed `claude/**` branch filter**: The CI workflow now only triggers on `master` branch pushes (in addition to all tags and pull requests)
- **Added concurrency configuration**: Implemented concurrency grouping to cancel in-flight runs when a new push is made to a pull request, while preserving master and tag runs to ensure release jobs complete

## Implementation Details
The concurrency configuration uses:
- `github.head_ref` for pull requests (the head branch name) and `github.ref` for other events to group runs
- Selective cancellation: only pull request runs are cancelled when a new push occurs (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`), while master and tag runs are never cancelled to prevent incomplete releases

https://claude.ai/code/session_01B2YYKq8RKuNHP1b4KFZsow