### PR TITLE
Add minimum SDK version check to prevent crashes on older Android

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -11,6 +11,7 @@ import android.content.pm.LauncherApps;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -36,6 +37,7 @@ import android.widget.GridView;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -140,6 +142,16 @@ public class HomeActivity extends AppCompatActivity
 	protected void onCreate (Bundle savedInstanceState)
 	{
 		super.onCreate (savedInstanceState);
+
+		// An install can be forced past minSdk. Nothing here runs on a framework
+		// that old, so say so and get out rather than crash on a missing API //
+		if (Build.VERSION.SDK_INT < this.getApplicationInfo ().minSdkVersion)
+		{
+			Toast.makeText (this, R.string.unsupported_android_version, Toast.LENGTH_LONG).show ();
+			this.finish ();
+
+			return;
+		}
 
 		// First run: hand over to the setup wizard before initialising anything //
 		if (OnboardingGate.shouldShow (DependencyContainer.of (this).getPrefs ()))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <string name="unsupported_android_version">DistroHopper does not support this version of Android.</string>
     <string name="action_settings">Settings</string>
     <string name="dash_search_hint">Search</string>
     <string name="dash_lens_apps_title">Applications</string>


### PR DESCRIPTION
## Summary
Added a runtime check in HomeActivity to detect when the app is running on an Android version below the declared minimum SDK version and gracefully exit with a user-friendly message instead of crashing.

## Key Changes
- Added `Build.VERSION` import to check the current Android API level
- Added `Toast` import for user notifications
- Implemented SDK version validation in `HomeActivity.onCreate()` that:
  - Compares the current device's API level against the app's declared minimum SDK version
  - Displays a user-friendly toast message if the device is unsupported
  - Finishes the activity gracefully to prevent further execution
- Added localized string resource `unsupported_platform` to inform users their Android version is not supported

## Implementation Details
The check is performed early in `onCreate()` before any other initialization, ensuring that no framework APIs newer than the minimum SDK are called. This prevents crashes that could occur if the app is sideloaded or installed on a device with an older Android version than declared in the manifest.

https://claude.ai/code/session_01WFmSvF2ZyfioNn5M4Vzqmv