### PR TITLE
Minimise crash-report data collection and add a privacy policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,8 +529,13 @@ etc/                                        — design assets (SVG/XCF sources, 
     cursor rather than collected first, so a cancelled keystroke stops
     mid-directory; cancellation is checked per directory and per row (the runner
     cancels on every keystroke). `localfiles/SearchFolderStore` holds the granted trees as
-    persisted URI permissions under `Preference.LENS_LOCALFILES_V2_FOLDERS`,
-    pruning any whose grant the system took back;
+    persisted URI permissions in the lens's **own** preferences file — under
+    `folders` in `Preferences.forLens(LocalFiles.KEY)`, i.e.
+    `lens_LocalFiles_v2_prefs` — pruning any whose grant the system took back.
+    A tree URI spells out the folder's name and path, and the main `"prefs"`
+    file is in the crash-report allowlist (see `Application`), so this is
+    deliberately not a `Preference` enum entry; give any future lens that
+    persists user-specific state its own `forLens` file for the same reason.
     `preferences/LocalFilesFoldersActivity` is its settings screen. It
     deliberately holds **no storage permission** — a granted tree is the
     permission — which is why it finds nothing until a folder is added, and why

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,130 @@
+# Privacy Policy — DistroHopper
+
+_Last updated: 2026-08-02_
+
+DistroHopper (`be.robinj.distrohopper`) is a free, open-source Android home
+screen. It contains **no advertising, no analytics, and no tracking SDKs**, and
+does **no third-party data collection**. It is built on open-source libraries
+(ACRA among them), but none of them collect or transmit your data.
+
+## Who is responsible
+
+The data controller is:
+
+- **Name:** Robin Jacobs
+- **Contact:** robin@robinj.be
+
+I run the crash-report server (`acra.robinj.be`) myself, on infrastructure I
+operate in Ireland. No analytics provider, advertising network or other company
+receives your data, and it never leaves the EEA.
+
+## Crash reports
+
+If the app crashes or hits a handled error, it sends a crash report to that
+server. This is **on by default**; you can turn it off at any time under
+**Settings → Advanced → "Send crash reports"**. The separate `-paranoia` build
+has crash reporting compiled out entirely.
+
+A crash report contains:
+
+- The app and version that crashed
+- Your Android version, and your device's model, brand and variant code
+- Screen specifications and approximate total/free memory
+- The technical error details (stack trace) and the name of the failing thread
+- DistroHopper's own recent log output (the last 100 lines its process wrote),
+  which records what the app was doing before it failed
+- Whether it was a full crash or a handled, non-fatal error
+- Screen orientation and language at the moment of the crash
+- Your DistroHopper settings, including which icon pack and which search sources
+  you have enabled
+- When the app started and when the error happened
+- A random per-report identifier and a random installation identifier
+
+The log is DistroHopper's own output only — not your device's system log, and not
+any other app's. It records what the app was doing: loading and sorting your
+apps, drawing the home screen, and errors it recovered from. It is written not to
+name the apps you have installed.
+
+Because a crash report is a technical snapshot, the error details can
+occasionally mention a specific app, icon pack or file that was involved in the
+failure. This is incidental to diagnosing the fault, not an attempt to record
+what you use.
+
+A crash report does **not** contain your files, messages, contacts, location,
+your device's system log, accounts, advertising ID, any hardware or SIM
+identifier, your searches, **the apps on your home screen, your home-screen
+layout, or your app-usage history**.
+
+**Installation identifier:** a random value created when you install the app. It
+is used only to tell whether several reports came from the same installation
+(one device crashing repeatedly vs. many people hitting one bug). It is not
+linked to your identity and is reset if you reinstall.
+
+**Legal basis:** legitimate interest (Art. 6(1)(f) GDPR) — diagnosing and fixing
+crashes so the app works. No profiling, no sale, no sharing.
+
+**Retention:** a crash report is deleted 180 days after it arrives. While a fault
+is still being reported, a summary of it is kept — which error it is, in which
+app version, and how many installations hit it — but that summary holds counts
+and technical detail, never the installation identifier. Once the last report of
+a fault has aged out, the summary is deleted with it.
+
+## Search
+
+The search sources enabled by default — your installed apps and files on your
+device — run entirely on your device and send nothing anywhere.
+
+You can additionally enable DuckDuckGo, F-Droid, GitHub or Google Play as search
+sources. If you do, **what you type in the search box is sent to that provider**
+so it can return results, and their own privacy policy applies
+([DuckDuckGo](https://duckduckgo.com/privacy),
+[F-Droid](https://f-droid.org/docs/Privacy_Policy/),
+[GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement),
+[Google](https://policies.google.com/privacy)). DistroHopper never stores your
+searches and never receives them itself.
+
+## Accessibility Service
+
+An optional gesture can open your notification tray. Because that is the only way
+a home screen can do it, this uses an Accessibility Service that you must switch
+on yourself in Android's settings. It is off unless you enable it, and it does
+one thing: open the notification tray. It observes no events and reads no screen
+content.
+
+## What stays on your device
+
+Your installed-app list, home-screen layout, folders, widgets and app launch
+counts are stored only on your device.
+
+DistroHopper asks for **no storage or media permissions at all**. If you use the
+file search, you pick each folder yourself through Android's own folder picker,
+and the app can read only the folders you chose — nothing else on your device.
+You can withdraw a folder at any time in the Local files settings. Searching
+those folders happens entirely on your device; nothing about your files is sent
+anywhere.
+
+## Children
+
+DistroHopper is not directed at children and does not knowingly collect data
+from them.
+
+## Your rights
+
+You can ask me to give you a copy of any data relating to you, correct it, delete
+it, or restrict how it is used. Because crash reporting relies on legitimate
+interest, you also have the **right to object** to it — and you can exercise that
+yourself at any time, immediately, by turning off "Send crash reports" in
+Settings → Advanced.
+
+Email the contact address above for any of these. In practice the only identifier
+that could link reports to you is the random installation identifier, so please
+include it if you can — otherwise I may not be able to find your reports.
+
+If you are unhappy with how I handle your data, you can complain to the Irish
+Data Protection Commission ([dataprotection.ie](https://www.dataprotection.ie)),
+or to the supervisory authority where you live.
+
+## Changes
+
+If this policy changes, the updated version will be published here with a new
+date. Significant changes will be noted in the app's release notes.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -71,12 +71,15 @@ a fault has aged out, the summary is deleted with it.
 
 ## Search
 
-The search sources enabled by default — your installed apps and files on your
-device — run entirely on your device and send nothing anywhere.
+Out of the box, search only looks at your installed apps, entirely on your
+device. Searching the files on your device is optional: you turn it on yourself
+and choose which folders it may look in, and it too runs entirely on your
+device. Neither sends anything anywhere.
 
-You can additionally enable DuckDuckGo, F-Droid, GitHub or Google Play as search
-sources. If you do, **what you type in the search box is sent to that provider**
-so it can return results, and their own privacy policy applies
+You can also enable remote search sources — currently DuckDuckGo, F-Droid,
+GitHub and Google Play; the full list is in the app's search settings. If you
+do, **what you type in the search box is sent to that provider** so it can
+return results, and their own privacy policy applies
 ([DuckDuckGo](https://duckduckgo.com/privacy),
 [F-Droid](https://f-droid.org/docs/Privacy_Policy/),
 [GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement),
@@ -127,4 +130,4 @@ or to the supervisory authority where you live.
 ## Changes
 
 If this policy changes, the updated version will be published here with a new
-date. Significant changes will be noted in the app's release notes.
+date.

--- a/app/src/main/java/be/robinj/distrohopper/Application.java
+++ b/app/src/main/java/be/robinj/distrohopper/Application.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.acra.ACRA;
+import org.acra.ReportField;
 import org.acra.config.CoreConfigurationBuilder;
 import org.acra.config.HttpSenderConfigurationBuilder;
 import org.acra.config.ToastConfigurationBuilder;
@@ -86,6 +87,53 @@ public class Application extends android.app.Application
 
 		ACRA.init(this, new CoreConfigurationBuilder()
 				.withReportFormat(StringFormat.JSON)
+				// Diagnostic-only report content (GDPR data minimisation). Anything
+				// not listed is NOT collected — notably DEVICE_FEATURES, ENVIRONMENT,
+				// DUMPSYS_MEMINFO and BUILD_CONFIG, all of which ACRA collects by
+				// DEFAULT. BUILD_CONFIG especially: it reflects over every
+				// BuildConfig constant, which here includes ACRA_USERNAME and
+				// ACRA_PASSWORD. Never add it back.
+				//
+				// LOGCAT is kept deliberately: a stack trace says where the app died,
+				// not what led there, and the lifecycle/widget-host/binder failures
+				// worth debugging show up only in the log. ACRA reads it with
+				// logcatFilterByPid=true, so it is this process's last 100 lines, not
+				// the device log.
+				//
+				// Caveat: logcat is sent verbatim and cannot be filtered here, so
+				// whatever the app logs ends up in the report. PRIVACY.md describes
+				// what a report contains. //
+				.withReportContent(
+						ReportField.REPORT_ID,
+						ReportField.PACKAGE_NAME,
+						ReportField.APP_VERSION_CODE,
+						ReportField.APP_VERSION_NAME,
+						ReportField.ANDROID_VERSION,
+						ReportField.PHONE_MODEL,
+						ReportField.BRAND,
+						ReportField.PRODUCT,
+						ReportField.STACK_TRACE,
+						ReportField.LOGCAT,
+						ReportField.IS_SILENT,
+						ReportField.CRASH_CONFIGURATION,
+						ReportField.DISPLAY,
+						ReportField.THREAD_DETAILS,
+						ReportField.TOTAL_MEM_SIZE,
+						ReportField.AVAILABLE_MEM_SIZE,
+						ReportField.SHARED_PREFERENCES,
+						ReportField.USER_APP_START_DATE,
+						ReportField.USER_CRASH_DATE,
+						ReportField.INSTALLATION_ID)
+				// SHARED_PREFERENCES is scoped to an ALLOWLIST: the launcher's own
+				// settings ("prefs") and the enabled-search-sources list ("lenses").
+				// Every other prefs file is excluded by omission — including those
+				// describing the user's app inventory / home-screen layout / usage
+				// history ("pinned", "app_usage", "dash_layout", "launcher_layout",
+				// "desktop_layout"), the "cache_app_*" caches, and each lens's own
+				// file (Preferences.forLens, e.g. the folders the Local files lens
+				// may search). An allowlist keeps any future prefs file private by
+				// default. //
+				.withAdditionalSharedPreferences("prefs", "lenses")
 				.withPluginConfigurations(
 						new HttpSenderConfigurationBuilder()
 								.withUri("https://acra.robinj.be/report")

--- a/app/src/main/java/be/robinj/distrohopper/broadcast/PackageManagerBroadcastReceiver.java
+++ b/app/src/main/java/be/robinj/distrohopper/broadcast/PackageManagerBroadcastReceiver.java
@@ -75,7 +75,7 @@ public class PackageManagerBroadcastReceiver extends BroadcastReceiver
 					friendlyAction = "being replaced";
 				}
 
-				Log.getInstance ().v (this.getClass ().getSimpleName (), "Package " + friendlyAction + ": " + packageName);
+				Log.getInstance ().v (this.getClass ().getSimpleName (), "Package " + friendlyAction);
 			}
 		}
 		catch (Exception ex)

--- a/app/src/main/java/be/robinj/distrohopper/broadcast/WorkProfileAppsCallback.kt
+++ b/app/src/main/java/be/robinj/distrohopper/broadcast/WorkProfileAppsCallback.kt
@@ -33,7 +33,7 @@ class WorkProfileAppsCallback(private val parent: HomeActivity) : LauncherApps.C
 			}
 
 			Log.getInstance().v(this.javaClass.simpleName,
-				"Package added in other profile: $packageName")
+				"Package added in other profile")
 		}
 	}
 
@@ -44,7 +44,7 @@ class WorkProfileAppsCallback(private val parent: HomeActivity) : LauncherApps.C
 				.forEach { appManager.remove(it) }
 
 			Log.getInstance().v(this.javaClass.simpleName,
-				"Package removed in other profile: $packageName")
+				"Package removed in other profile")
 		}
 	}
 

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LocalFiles.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/LocalFiles.kt
@@ -34,7 +34,7 @@ class LocalFiles(context: Context) : Lens(context) {
 	// Bumped from "LocalFiles" when this lens moved from a MediaStore query to
 	// user-granted SAF folders: a different feature, so the old one retires
 	// rather than silently becoming an empty version of the new one. //
-	override val key = "LocalFiles_v2"
+	override val key = KEY
 
 	override fun getName() = "Local files"
 
@@ -207,6 +207,9 @@ class LocalFiles(context: Context) : Lens(context) {
 	}
 
 	companion object {
+		/** This lens's stable identifier; also names its preferences file. */
+		const val KEY = "LocalFiles_v2"
+
 		private const val TAG = "LocalFiles"
 		private val LOG: Log = Log.getInstance()
 

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/localfiles/SearchFolderStore.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/lens/localfiles/SearchFolderStore.kt
@@ -1,12 +1,13 @@
 package be.robinj.distrohopper.desktop.dash.lens.localfiles
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
+import be.robinj.distrohopper.desktop.dash.lens.LocalFiles
 import be.robinj.distrohopper.dev.Log
-import be.robinj.distrohopper.preferences.Preference
-import be.robinj.distrohopper.preferences.PreferencesRepository
+import be.robinj.distrohopper.preferences.Preferences
 
 /**
  * The folders the Local files lens is allowed to search: SAF document trees the
@@ -14,9 +15,21 @@ import be.robinj.distrohopper.preferences.PreferencesRepository
  * permission grants so they survive reboots.
  *
  * Nothing here needs a manifest permission — a granted tree *is* the permission.
+ *
+ * These live in the lens's own preferences file rather than the main "prefs"
+ * one: a tree URI spells out the folder's name and path, so keeping it out of
+ * "prefs" keeps it out of everything scoped to that file, crash reports
+ * included.
  */
 class SearchFolderStore(private val context: Context) {
-	private val prefs = PreferencesRepository(this.context)
+	private val prefs = preferences(this.context)
+
+	private fun stored(): Set<String> =
+		this.prefs.getStringSet(KEY_FOLDERS, emptySet())?.toSet() ?: emptySet()
+
+	private fun store(values: Set<String>) {
+		this.prefs.edit().putStringSet(KEY_FOLDERS, values).apply()
+	}
 
 	/**
 	 * The granted folders, minus any whose grant the system has since dropped
@@ -24,13 +37,13 @@ class SearchFolderStore(private val context: Context) {
 	 * from the stored set as they're noticed, so nothing lists a dead grant.
 	 */
 	fun folders(): List<Uri> {
-		val stored = this.prefs.getStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS)
+		val stored = this.stored()
 		val live = this.readableUris()
 		val kept = stored.filter { live.contains(it) }
 
 		if (kept.size != stored.size) {
 			LOG.i(TAG, "Dropping ${stored.size - kept.size} folder(s) whose grant is gone.")
-			this.prefs.putStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS, kept.toSet())
+			this.store(kept.toSet())
 		}
 
 		return kept.sorted().map(Uri::parse)
@@ -41,16 +54,12 @@ class SearchFolderStore(private val context: Context) {
 		this.context.contentResolver
 			.takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
-		val stored = this.prefs.getStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS)
-		this.prefs.putStringSet(
-			Preference.LENS_LOCALFILES_V2_FOLDERS, stored + treeUri.toString())
+		this.store(this.stored() + treeUri.toString())
 	}
 
 	/** Forgets [treeUri] and gives its grant back to the system. */
 	fun remove(treeUri: Uri) {
-		val stored = this.prefs.getStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS)
-		this.prefs.putStringSet(
-			Preference.LENS_LOCALFILES_V2_FOLDERS, stored - treeUri.toString())
+		this.store(this.stored() - treeUri.toString())
 
 		try {
 			this.context.contentResolver
@@ -58,7 +67,9 @@ class SearchFolderStore(private val context: Context) {
 		} catch (ex: SecurityException) {
 			// Already gone (revoked, or released twice); the stored entry is what
 			// mattered and it is already removed. //
-			LOG.v(TAG, "Nothing to release for $treeUri: ${ex.message}")
+			// Neither the URI nor the exception message: a SecurityException about a
+			// grant quotes the URI back, and that spells out the user's folder. //
+			LOG.v(TAG, "Nothing to release: ${ex.javaClass.simpleName}")
 		}
 	}
 
@@ -83,7 +94,7 @@ class SearchFolderStore(private val context: Context) {
 				if (cursor.moveToFirst()) cursor.getString(0) else null
 			}
 		} catch (ex: Exception) {
-			LOG.v(TAG, "Couldn't read the name of $treeUri: ${ex.message}")
+			LOG.v(TAG, "Couldn't read a folder's name: ${ex.javaClass.simpleName}")
 			null
 		} ?: (treeUri.lastPathSegment ?: treeUri.toString())
 	}
@@ -95,6 +106,14 @@ class SearchFolderStore(private val context: Context) {
 			.toSet()
 
 	companion object {
+		/** The key the granted tree URIs live under, within the lens's own file. */
+		const val KEY_FOLDERS = "folders"
+
+		/** The Local files lens's preferences file. */
+		@JvmStatic
+		fun preferences(context: Context): SharedPreferences =
+			Preferences.getSharedPreferences(context, Preferences.forLens(LocalFiles.KEY))
+
 		private const val TAG = "SearchFolderStore"
 		private val LOG: Log = Log.getInstance()
 	}

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
@@ -78,9 +78,7 @@ enum class Preference(
 	/** What the home-screen swipe-up gesture does (a GestureAction value). */
 	GESTURE_SWIPE_UP("gesture_swipe_up", "open_dash"),
 	/** What the home-screen swipe-down gesture does (a GestureAction value). */
-	GESTURE_SWIPE_DOWN("gesture_swipe_down", "none"),
-	/** SAF tree URIs the Local files lens is allowed to search, as strings. */
-	LENS_LOCALFILES_V2_FOLDERS("lens_localfiles_v2_folders");
+	GESTURE_SWIPE_DOWN("gesture_swipe_down", "none");
 
 	fun getName(): String = this.key
 

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preferences.java
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preferences.java
@@ -13,6 +13,17 @@ public class Preferences {
 	// The desktop's widgets, pinned apps and folders share one file (see DesktopLayoutStorage).
 	public static final String DESKTOP_LAYOUT = "desktop_layout";
 
+	/**
+	 * The preferences file belonging to one lens, named after its
+	 * {@code Lens.getKey()}. Each lens owns its own file rather than sharing the
+	 * main "prefs" one, so a lens can persist user-specific state (the folders
+	 * the Local files lens may search, for instance) without it landing in
+	 * anything scoped to "prefs" — crash reports included.
+	 */
+	public static String forLens(final String lensKey) {
+		return "lens_" + lensKey + "_prefs";
+	}
+
 	public static SharedPreferences getSharedPreferences(final Context context) {
 		return Preferences.getSharedPreferences(context, Preferences.PREFERENCES);
 	}

--- a/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppHost.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/DesktopAppHost.kt
@@ -45,7 +45,8 @@ class DesktopAppHost(
 			if (app == null) {
 				changed = true // Pruned: the app is no longer installed //
 
-				Log.getInstance().w(this.javaClass.simpleName, "Pruned stale desktop app: ${layout.key}")
+				Log.getInstance().w(this.javaClass.simpleName,
+					"Pruned stale desktop app at ${layout.page}:${layout.col},${layout.row}")
 
 				continue
 			}
@@ -71,7 +72,7 @@ class DesktopAppHost(
 
 				if (free == null) {
 					Log.getInstance().w(this.javaClass.simpleName,
-						"No room for desktop app on page $page: ${layout.key}")
+						"No room for desktop app on page $page (from ${layout.col},${layout.row})")
 
 					continue
 				}

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LocalFilesTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/LocalFilesTest.kt
@@ -11,8 +11,6 @@ import android.provider.DocumentsContract
 import androidx.test.core.app.ApplicationProvider
 import be.robinj.distrohopper.R
 import be.robinj.distrohopper.desktop.dash.lens.localfiles.SearchFolderStore
-import be.robinj.distrohopper.preferences.Preference
-import be.robinj.distrohopper.preferences.PreferencesRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
@@ -34,8 +32,8 @@ class LocalFilesTest {
 
     @Before fun setUp() {
         application = ApplicationProvider.getApplicationContext()
-        PreferencesRepository(application)
-            .putStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS, emptySet())
+        SearchFolderStore.preferences(application).edit()
+            .putStringSet(SearchFolderStore.KEY_FOLDERS, emptySet()).commit()
 
         provider = FakeDocumentsProvider()
         ShadowContentResolver.registerProviderInternal(AUTHORITY, provider)
@@ -303,10 +301,10 @@ class LocalFilesTest {
         grantFolder("papers")
 
         // Recorded but never granted, so the store never returns it //
-        PreferencesRepository(application).putStringSet(
-            Preference.LENS_LOCALFILES_V2_FOLDERS,
+        SearchFolderStore.preferences(application).edit().putStringSet(
+            SearchFolderStore.KEY_FOLDERS,
             setOf(treeUriFor("papers").toString(), treeUriFor("gone").toString()),
-        )
+        ).commit()
 
         assertEquals(listOf("notes.txt"), lens.collect("notes", 10).results.map { it.name })
     }
@@ -328,8 +326,8 @@ class LocalFilesTest {
     }
 
     @Test fun survivesAFolderThatIsNotADocumentTree() {
-        PreferencesRepository(application).putStringSet(
-            Preference.LENS_LOCALFILES_V2_FOLDERS, setOf("content://$AUTHORITY/nonsense"))
+        SearchFolderStore.preferences(application).edit().putStringSet(
+            SearchFolderStore.KEY_FOLDERS, setOf("content://$AUTHORITY/nonsense")).commit()
         application.contentResolver.takePersistableUriPermission(
             Uri.parse("content://$AUTHORITY/nonsense"), Intent.FLAG_GRANT_READ_URI_PERMISSION)
 

--- a/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/localfiles/SearchFolderStoreTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/desktop/dash/lens/localfiles/SearchFolderStoreTest.kt
@@ -8,8 +8,6 @@ import android.database.MatrixCursor
 import android.net.Uri
 import android.provider.DocumentsContract
 import androidx.test.core.app.ApplicationProvider
-import be.robinj.distrohopper.preferences.Preference
-import be.robinj.distrohopper.preferences.PreferencesRepository
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -21,13 +19,13 @@ import org.robolectric.shadows.ShadowContentResolver
 @RunWith(RobolectricTestRunner::class)
 class SearchFolderStoreTest {
     private lateinit var application: Application
-    private lateinit var prefs: PreferencesRepository
+    private lateinit var prefs: android.content.SharedPreferences
     private lateinit var store: SearchFolderStore
 
     @Before fun setUp() {
         application = ApplicationProvider.getApplicationContext()
-        prefs = PreferencesRepository(application)
-        prefs.putStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS, emptySet())
+        prefs = SearchFolderStore.preferences(application)
+        put(emptySet())
 
         ShadowContentResolver.registerProviderInternal(AUTHORITY, NamingProvider())
 
@@ -38,7 +36,11 @@ class SearchFolderStoreTest {
         DocumentsContract.buildTreeDocumentUri(AUTHORITY, documentId)
 
     private fun stored(): Set<String> =
-        prefs.getStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS)
+        prefs.getStringSet(SearchFolderStore.KEY_FOLDERS, emptySet())!!.toSet()
+
+    private fun put(values: Set<String>) {
+        prefs.edit().putStringSet(SearchFolderStore.KEY_FOLDERS, values).commit()
+    }
 
     @Test fun startsEmpty() {
         assertTrue(store.folders().isEmpty())
@@ -106,17 +108,13 @@ class SearchFolderStoreTest {
     /** A grant can vanish while the app is away: the folder must not linger. */
     @Test fun aFolderWhoseGrantIsGoneIsDropped() {
         store.add(treeUri("documents"))
-        prefs.putStringSet(
-            Preference.LENS_LOCALFILES_V2_FOLDERS,
-            stored() + treeUri("unmounted-sd-card").toString(),
-        )
+        put(stored() + treeUri("unmounted-sd-card").toString())
 
         assertEquals(listOf(treeUri("documents")), store.folders())
     }
 
     @Test fun droppedFoldersArePrunedFromStorageNotJustHidden() {
-        prefs.putStringSet(
-            Preference.LENS_LOCALFILES_V2_FOLDERS, setOf(treeUri("gone").toString()))
+        put(setOf(treeUri("gone").toString()))
 
         store.folders()
 

--- a/app/src/test/java/be/robinj/distrohopper/preferences/LocalFilesFoldersActivityTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/preferences/LocalFilesFoldersActivityTest.kt
@@ -38,8 +38,8 @@ class LocalFilesFoldersActivityTest {
 
     @Before fun setUp() {
         application = ApplicationProvider.getApplicationContext()
-        PreferencesRepository(application)
-            .putStringSet(Preference.LENS_LOCALFILES_V2_FOLDERS, emptySet())
+        SearchFolderStore.preferences(application).edit()
+            .putStringSet(SearchFolderStore.KEY_FOLDERS, emptySet()).commit()
         ShadowContentResolver.registerProviderInternal(AUTHORITY, NamingProvider())
         // Names resolve off the main thread in production; run that inline here //
         LocalFilesFoldersActivity.ioDispatcher = Dispatchers.Unconfined


### PR DESCRIPTION
ACRA never set `reportContent`, so its 29-field default set applied. That included `BUILD_CONFIG`, which reflects over every `BuildConfig` constant — here the ACRA basic-auth credentials — putting them in every crash report.

- Explicit `withReportContent(...)` allowlist; `SHARED_PREFERENCES` scoped to `prefs` + `lenses`
- Keep package names and SAF folder paths out of the log, since `LOGCAT` is collected
- Move the Local files lens's granted folders to a per-lens preferences file, outside that scope
- Add `PRIVACY.md`

`LOGCAT` is deliberately kept — a stack trace says where the app died, not what led there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYyazm5njACW1LrBiMbUPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYyazm5njACW1LrBiMbUPG)_