### PR TITLE
Add open source licenses screen and legal information

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ If you want to help out and translate the project into a language that isn't lis
 
 If you are a developer and want to implement a new feature or fix a bug, you may feel free to give it a go and open a pull request. Before you go there, you may just want to be aware that this is a project I started in high school back in 2012, and some of the code quality very much shows this :-)
 
+
+## Licence
+
+DistroHopper is free software, licensed under the [GNU General Public Licence v3](LICENSE). It comes with absolutely no warranty.
+
+It bundles a few works under licences of their own, whose full texts live in [`licenses/`](licenses) and are shipped inside the APK (About → Open source licences):
+
+| Bundled work | Licence |
+| --- | --- |
+| [Ubuntu font](https://design.ubuntu.com/font) | Ubuntu Font Licence 1.0 |
+| [Oxygen font](https://github.com/vernnobile/oxygenFont) | SIL Open Font Licence 1.1 |
+| [OpenDyslexic font](https://opendyslexic.org/) | SIL Open Font Licence 1.1 |
+| [ProgressWheel](https://github.com/Todd-Davies/ProgressWheel/) by Todd Davies | MIT |
+| AndroidX, Kotlin, kotlinx.coroutines, ACRA, DragSortListView | Apache Licence 2.0 |

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,7 +85,34 @@ android {
     lint {
         disable 'MissingTranslation', 'ExtraTranslation'
     }
+    sourceSets {
+        main {
+            // The licence texts are shipped inside the APK, not just kept in the
+            // repository: the SIL OFL and the Ubuntu Font Licence both require the
+            // licence to travel with the fonts, and whoever installs a build from
+            // the Play Store never sees the repository. Staged into a generated
+            // folder by copyLicenseAssets below so there is exactly one copy of
+            // each text under version control.
+            assets.srcDirs += "$buildDir/generated/licenseAssets"
+        }
+    }
 }
+
+// Stages the repository's licence texts (plus the app's own GPLv3) where the
+// asset merger can pick them up, under assets/licenses/. LicensesActivity reads
+// them back out by those paths.
+def copyLicenseAssets = tasks.register('copyLicenseAssets', Copy) {
+    into "$buildDir/generated/licenseAssets/licenses"
+
+    from(rootProject.file('licenses'))
+    from(rootProject.file('LICENSE')) {
+        rename '.*', 'gpl-3.0.txt'
+    }
+}
+
+// preBuild rather than the merge*Assets tasks: it is a stable, public task name
+// that every variant already depends on.
+tasks.named('preBuild') { dependsOn copyLicenseAssets }
 
 repositories {
     maven {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,26 @@
 				android:value="be.robinj.distrohopper.preferences.PreferencesActivity" />
 		</activity>
 		<activity
+			android:name="be.robinj.distrohopper.LicensesActivity"
+			android:label="@string/title_activity_licenses"
+			android:parentActivityName="be.robinj.distrohopper.AboutActivity"
+			android:theme="@style/AboutTheme"
+			android:exported="false">
+			<meta-data
+				android:name="android.support.PARENT_ACTIVITY"
+				android:value="be.robinj.distrohopper.AboutActivity" />
+		</activity>
+		<activity
+			android:name="be.robinj.distrohopper.LicenseTextActivity"
+			android:label="@string/title_activity_licenses"
+			android:parentActivityName="be.robinj.distrohopper.LicensesActivity"
+			android:theme="@style/AboutTheme"
+			android:exported="false">
+			<meta-data
+				android:name="android.support.PARENT_ACTIVITY"
+				android:value="be.robinj.distrohopper.LicensesActivity" />
+		</activity>
+		<activity
 			android:name="be.robinj.distrohopper.preferences.PreferencesActivity"
 			android:label="@string/title_activity_preferences"
 			android:parentActivityName="be.robinj.distrohopper.HomeActivity"

--- a/app/src/main/java/be/robinj/distrohopper/AboutActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/AboutActivity.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import java.util.Calendar
 
 class AboutActivity : AppCompatActivity() {
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -38,6 +39,13 @@ class AboutActivity : AppCompatActivity() {
 			this.findViewById<View>(R.id.linkTransifex).setOnClickListener {
 				this.openUrl(this.getString(R.string.about_transifex_url))
 			}
+			this.findViewById<View>(R.id.linkLicenses).setOnClickListener {
+				this.startActivity(Intent(this, LicensesActivity::class.java))
+			}
+
+			this.findViewById<TextView>(R.id.tvCopyright).text = this.getString(
+				R.string.about_copyright,
+				Calendar.getInstance().get(Calendar.YEAR).toString())
 
 			val context = this.baseContext
 

--- a/app/src/main/java/be/robinj/distrohopper/LicenseTextActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/LicenseTextActivity.kt
@@ -1,0 +1,60 @@
+package be.robinj.distrohopper
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import java.io.IOException
+
+/** Shows the full text of one licence, read from the APK's bundled assets. */
+class LicenseTextActivity : AppCompatActivity() {
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+		this.setContentView(R.layout.activity_license_text)
+		InsetsHelper.applySystemBarsPadding(this)
+
+		this.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+		val title = this.intent.getStringExtra(EXTRA_TITLE)
+		if (title != null) {
+			this.title = title
+		}
+
+		val asset = this.intent.getStringExtra(EXTRA_ASSET)
+
+		this.findViewById<TextView>(R.id.tvLicenseText).text = this.readLicense(asset)
+	}
+
+	/**
+	 * The bundled licences are a few tens of kilobytes at most, so this reads on
+	 * the main thread rather than dragging in a loader for a one-shot screen.
+	 */
+	private fun readLicense(asset: String?): String {
+		if (asset == null) {
+			return this.getString(R.string.licenses_read_error)
+		}
+
+		return try {
+			this.assets.open("$ASSET_DIR/$asset").use { it.readBytes().toString(Charsets.UTF_8) }
+		} catch (ex: IOException) {
+			this.getString(R.string.licenses_read_error)
+		}
+	}
+
+	override fun onOptionsItemSelected(item: MenuItem): Boolean {
+		if (item.itemId == android.R.id.home) {
+			this.finish()
+
+			return true
+		}
+
+		return super.onOptionsItemSelected(item)
+	}
+
+	companion object {
+		const val EXTRA_TITLE = "be.robinj.distrohopper.LICENSE_TITLE"
+		const val EXTRA_ASSET = "be.robinj.distrohopper.LICENSE_ASSET"
+
+		private const val ASSET_DIR = "licenses"
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/LicensesActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/LicensesActivity.kt
@@ -1,0 +1,82 @@
+package be.robinj.distrohopper
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.MenuItem
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Lists everything DistroHopper ships that carries a licence of its own, and
+ * opens the full text of each. The texts themselves are bundled as assets (see
+ * the copyLicenseAssets task in app/build.gradle) because the SIL OFL and the
+ * Ubuntu Font Licence both require the licence to be distributed along with the
+ * fonts — a copy sitting in the git repository doesn't reach someone who
+ * installed a build from the Play Store.
+ */
+class LicensesActivity : AppCompatActivity() {
+	/**
+	 * @param component Name of the bundled work. Not translated: these are proper names.
+	 * @param license Name of the licence it is under. Likewise untranslated.
+	 * @param asset Path of the full licence text within the APK's assets.
+	 */
+	private data class Entry(val component: String, val license: String, val asset: String)
+
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+		this.setContentView(R.layout.activity_licenses)
+		InsetsHelper.applySystemBarsPadding(this)
+
+		this.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+		val container = this.findViewById<LinearLayout>(R.id.llLicenses)
+		val inflater = LayoutInflater.from(this)
+
+		for (entry in ENTRIES) {
+			val row = inflater.inflate(R.layout.view_license_entry, container, false)
+
+			row.findViewById<TextView>(R.id.tvLicenseComponent).text = entry.component
+			row.findViewById<TextView>(R.id.tvLicenseName).text =
+				this.getString(R.string.licenses_entry_license, entry.license)
+			row.setOnClickListener { this.openLicenseText(entry) }
+
+			container.addView(row)
+		}
+	}
+
+	private fun openLicenseText(entry: Entry) {
+		val intent = Intent(this, LicenseTextActivity::class.java)
+		intent.putExtra(LicenseTextActivity.EXTRA_TITLE, entry.component)
+		intent.putExtra(LicenseTextActivity.EXTRA_ASSET, entry.asset)
+
+		this.startActivity(intent)
+	}
+
+	override fun onOptionsItemSelected(item: MenuItem): Boolean {
+		if (item.itemId == android.R.id.home) {
+			this.finish()
+
+			return true
+		}
+
+		return super.onOptionsItemSelected(item)
+	}
+
+	companion object {
+		private const val APACHE = "apache-2.0.txt"
+
+		private val ENTRIES = listOf(
+			Entry("DistroHopper", "the GNU General Public Licence v3", "gpl-3.0.txt"),
+			Entry("Ubuntu font", "the Ubuntu Font Licence 1.0", "fonts/Ubuntu-UFL.txt"),
+			Entry("Oxygen font", "the SIL Open Font Licence 1.1", "fonts/Oxygen-OFL.txt"),
+			Entry("OpenDyslexic font", "the SIL Open Font Licence 1.1", "fonts/OpenDyslexic-OFL.txt"),
+			Entry("ProgressWheel by Todd Davies", "the MIT Licence", "ProgressWheel-MIT.txt"),
+			Entry("Android Jetpack (AndroidX)", "the Apache Licence 2.0", APACHE),
+			Entry("Kotlin and kotlinx.coroutines", "the Apache Licence 2.0", APACHE),
+			Entry("ACRA", "the Apache Licence 2.0", APACHE),
+			Entry("DragSortListView", "the Apache Licence 2.0", APACHE),
+		)
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/thirdparty/ProgressWheel.java
+++ b/app/src/main/java/be/robinj/distrohopper/thirdparty/ProgressWheel.java
@@ -20,6 +20,28 @@ import be.robinj.distrohopper.preferences.FontPreference;
 /*
  * Source: https://github.com/Todd-Davies/ProgressWheel/
  * Thanks, Todd Davies
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Todd Davies
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 /**

--- a/app/src/main/res/drawable/ic_about_licenses.xml
+++ b/app/src/main/res/drawable/ic_about_licenses.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+	android:width="24dp"
+	android:height="24dp"
+	android:viewportWidth="24"
+	android:viewportHeight="24"
+	android:tint="@color/dialog_on_surface">
+	<path
+		android:fillColor="@android:color/white"
+		android:pathData="M13,3L6,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10l-7,-7zM6,5h6v5h6v9L6,19L6,5zM8,12h8v2L8,14v-2zM8,16h8v2L8,18v-2z" />
+</vector>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -253,6 +253,105 @@
 
             </LinearLayout>
 
+            <!-- Legal. Same styling caveat as "Get involved" above: weight via
+                 android:textStyle, never android:fontFamily. -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:layout_marginBottom="8dp"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:textSize="11sp"
+                android:textColor="@color/dialog_on_surface_dim"
+                android:textAllCaps="true"
+                android:letterSpacing="0.12"
+                android:textStyle="bold"
+                android:text="@string/about_legal" />
+
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/about_card_background"
+                android:clipToOutline="true"
+                android:divider="@drawable/about_list_divider"
+                android:showDividers="middle">
+
+                <LinearLayout
+                    android:id="@+id/linkLicenses"
+                    android:orientation="horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="14dp"
+                    android:gravity="center_vertical"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?android:attr/selectableItemBackground">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginEnd="14dp"
+                        android:src="@drawable/ic_about_licenses"
+                        android:contentDescription="@string/about_licenses_title" />
+
+                    <LinearLayout
+                        android:orientation="vertical"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1">
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textSize="15sp"
+                            android:textColor="@color/dialog_on_surface"
+                            android:text="@string/about_licenses_title" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="1dp"
+                            android:textSize="12sp"
+                            android:textColor="@color/dialog_on_surface_dim"
+                            android:text="@string/about_licenses_subtitle" />
+                    </LinearLayout>
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginStart="8dp"
+                        android:src="@drawable/ic_about_chevron"
+                        android:contentDescription="@null" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <!-- GPLv3 asks that an interactive program display a copyright and
+                 no-warranty notice; this is DistroHopper's. -->
+            <TextView
+                android:id="@+id/tvCopyright"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:textSize="12sp"
+                android:textColor="@color/dialog_on_surface_variant" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="8dp"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:textSize="12sp"
+                android:lineSpacingMultiplier="1.3"
+                android:textColor="@color/dialog_on_surface_dim"
+                android:text="@string/about_gpl_notice" />
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_license_text.xml
+++ b/app/src/main/res/layout/activity_license_text.xml
@@ -1,0 +1,35 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             android:paddingLeft="@dimen/activity_horizontal_margin"
+             android:paddingRight="@dimen/activity_horizontal_margin"
+             android:paddingTop="@dimen/activity_vertical_margin"
+             android:paddingBottom="@dimen/activity_vertical_margin"
+             tools:context="be.robinj.distrohopper.LicenseTextActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:background="@drawable/about_card_background"
+        android:clipToOutline="true">
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="14dp"
+            android:scrollbars="vertical">
+
+            <TextView
+                android:id="@+id/tvLicenseText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textIsSelectable="true"
+                android:textColor="@color/dialog_on_surface_variant" />
+
+        </ScrollView>
+
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/activity_licenses.xml
+++ b/app/src/main/res/layout/activity_licenses.xml
@@ -1,0 +1,44 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="be.robinj.distrohopper.LicensesActivity">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:paddingStart="4dp"
+                android:paddingEnd="4dp"
+                android:textSize="14sp"
+                android:lineSpacingMultiplier="1.4"
+                android:textColor="@color/dialog_on_surface_variant"
+                android:text="@string/licenses_intro" />
+
+            <!-- Rows are inflated into here by LicensesActivity, one per entry. -->
+            <LinearLayout
+                android:id="@+id/llLicenses"
+                android:orientation="vertical"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/about_card_background"
+                android:clipToOutline="true"
+                android:divider="@drawable/about_list_divider"
+                android:showDividers="middle" />
+
+        </LinearLayout>
+    </ScrollView>
+</RelativeLayout>

--- a/app/src/main/res/layout/view_license_entry.xml
+++ b/app/src/main/res/layout/view_license_entry.xml
@@ -1,0 +1,41 @@
+<!-- One row of the licences list. Mirrors the About screen's link rows. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="14dp"
+    android:gravity="center_vertical"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?android:attr/selectableItemBackground">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1">
+
+        <TextView
+            android:id="@+id/tvLicenseComponent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="15sp"
+            android:textColor="@color/dialog_on_surface" />
+
+        <TextView
+            android:id="@+id/tvLicenseName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="1dp"
+            android:textSize="12sp"
+            android:textColor="@color/dialog_on_surface_dim" />
+    </LinearLayout>
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/ic_about_chevron"
+        android:contentDescription="@null" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,17 @@
     <string name="about_transifex_subtitle">Help translate DistroHopper into your language</string>
     <string name="about_github_url" translatable="false">https://github.com/RobinJ1995/DistroHopper</string>
     <string name="about_transifex_url" translatable="false">https://explore.transifex.com/distrohopper/</string>
+    <string name="about_legal">Legal</string>
+    <string name="about_licenses_title">Open source licences</string>
+    <string name="about_licenses_subtitle">Licences of the fonts and code DistroHopper is built on</string>
+    <!-- Shown at the bottom of the About screen. %1$s is the current year. -->
+    <string name="about_copyright">Copyright © 2012–%1$s Robin Jacobs</string>
+    <string name="about_gpl_notice">DistroHopper is free software: you can redistribute it and/or modify it under the terms of the GNU General Public Licence as published by the Free Software Foundation, either version 3 of the Licence, or (at your option) any later version. It comes with ABSOLUTELY NO WARRANTY. The source code is available on GitHub.</string>
+    <string name="title_activity_licenses">Open source licences</string>
+    <string name="licenses_intro">DistroHopper itself is licensed under the GNU General Public Licence v3. It also bundles the fonts and code listed below, each under its own licence. Tap an entry to read the full licence text.</string>
+    <!-- Accompanies a licence entry: which licence the component is under -->
+    <string name="licenses_entry_license">Licensed under %1$s</string>
+    <string name="licenses_read_error">The licence text could not be loaded. You can also read it in the source repository on GitHub.</string>
     <string name="button_back">Back</string>
     <string name="button_about">About</string>
     <string name="button_apply">Apply</string>

--- a/licenses/ProgressWheel-MIT.txt
+++ b/licenses/ProgressWheel-MIT.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Todd Davies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/apache-2.0.txt
+++ b/licenses/apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary
This PR adds a comprehensive licensing system to DistroHopper, including a new "Open source licences" screen accessible from the About activity, and proper attribution for all bundled dependencies and fonts.

## Key Changes

- **New Licenses Activity**: Created `LicensesActivity` and `LicenseTextActivity` to display a list of all bundled works with their licenses and allow users to view full license texts
- **License Assets**: Added license text files to `licenses/` directory (Apache 2.0, MIT for ProgressWheel, and others) that are bundled into the APK during build
- **Build Integration**: Modified `app/build.gradle` to include a `copyLicenseAssets` task that stages license files into the APK's assets directory, ensuring licenses travel with the app even when installed from Play Store
- **UI Updates**: 
  - Added "Legal" section to About screen with clickable "Open source licences" link
  - Added copyright notice and GPL v3 disclaimer at bottom of About screen
  - Created layout files for licenses list (`activity_licenses.xml`), license entries (`view_license_entry.xml`), and license text viewer (`activity_license_text.xml`)
- **Manifest Updates**: Registered new `LicensesActivity` and `LicenseTextActivity` with proper parent activity navigation
- **String Resources**: Added localized strings for legal section, copyright notice, and GPL disclaimer
- **Icon Asset**: Added `ic_about_licenses.xml` vector drawable for the licenses link
- **Attribution**: Updated ProgressWheel source file header with full MIT license text
- **Documentation**: Updated README.md with license information and table of bundled works

## Implementation Details

- License texts are staged at build time rather than kept only in the repository, ensuring compliance with SIL OFL and Ubuntu Font License requirements for distribution
- The system supports displaying licenses for fonts (Ubuntu, Oxygen, OpenDyslexic), third-party libraries (ProgressWheel, AndroidX, Kotlin, ACRA, DragSortListView), and the app itself (GPLv3)
- Copyright year is dynamically calculated using `Calendar.getInstance().get(Calendar.YEAR)` to keep the notice current
- License text reading is done on the main thread since files are small (tens of KB at most)

https://claude.ai/code/session_012AQrNZiqiZrhEAhDxbUDS9