### PR TITLE
Reorder themes in registry to prioritize GNOME

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/theme/ThemeRegistry.kt
+++ b/app/src/main/java/be/robinj/distrohopper/theme/ThemeRegistry.kt
@@ -9,8 +9,8 @@ object ThemeRegistry {
 	const val DEFAULT = "default"
 
 	val themes: Map<String, () -> Theme> = linkedMapOf(
-		DEFAULT to ::Default,
 		"gnome" to ::Gnome,
+		DEFAULT to ::Default,
 		"elementary" to ::Elementary,
 		"cinnamon" to ::Cinnamon,
 		"plasma" to ::Plasma,

--- a/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingActivityTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/onboarding/OnboardingActivityTest.kt
@@ -12,6 +12,7 @@ import be.robinj.distrohopper.R
 import be.robinj.distrohopper.preferences.Preference
 import be.robinj.distrohopper.preferences.Preferences
 import be.robinj.distrohopper.broadcast.AppUpgradeReceiver
+import be.robinj.distrohopper.theme.Theme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -73,7 +74,10 @@ class OnboardingActivityTest {
 
                 val cards = activity.findViewById<LinearLayout>(R.id.llOnboardingThemeCards)
                 assertNotNull("theme page should be bound", cards)
-                cards.getChildAt(1).performClick() // Gnome //
+                // Locate GNOME by its card's theme tag; the picker's order can change //
+                val gnome = (0 until cards.childCount).map { cards.getChildAt(it) }
+                    .first { (it.tag as Theme).getName() == "gnome" }
+                gnome.performClick()
 
                 val prefs = application.getSharedPreferences(Preferences.PREFERENCES, 0)
                 assertEquals("gnome", prefs.getString(Preference.THEME.getName(), null))


### PR DESCRIPTION
## Summary
Reordered the theme entries in the ThemeRegistry to change the default theme selection behavior.

## Changes
- Moved the `DEFAULT` theme entry from first to second position in the themes map
- Moved the `"gnome"` theme entry to the first position
- This change affects the iteration order of the linked map, making GNOME the first theme in the registry

## Implementation Details
Since `ThemeRegistry.themes` is a `linkedMapOf`, the insertion order is preserved and may be relied upon for default selection or UI presentation. By moving GNOME to the first position, it will now be the first theme encountered when iterating through the registry, potentially making it the preferred or default theme in any logic that depends on map ordering.

https://claude.ai/code/session_01MMwGaBkmfg5wUBaAfUrSvE