### PR TITLE
Release cached app icons on onTrimMemory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,13 @@ licenses/                                   — full licence texts of everything
     `ThemeApplier` keeps it visible while the spinner is, and
     `StartupLoader` collapses it (instead of revealing the BFB) once loading
     finishes.
+  - `IconMemoryTrimmer` — drops cached app icons on
+    `HomeActivity.onTrimMemory`; nothing released them before.
+    `TRIM_MEMORY_UI_HIDDEN` spares the pinned apps, `TRIM_MEMORY_BACKGROUND`
+    and deeper drop those too; the legacy `TRIM_MEMORY_RUNNING_*` levels are
+    ignored because Android 14 stopped delivering them. `App.releaseIcon` only
+    drops the reference — `App.getIcon` restores it from `AppManager.iconCache`
+    (set by `AppsLoader`), re-rendering on a miss.
   - `LauncherEdgeController` — repositions/reorients the launcher bar per
     edge, panel edge handling, and widget-area insets; owns the current
     `launcherEdge` and navigation insets.

--- a/app/src/main/java/be/robinj/distrohopper/App.java
+++ b/app/src/main/java/be/robinj/distrohopper/App.java
@@ -331,29 +331,81 @@ public class App implements Parcelable
 
 	public AppIcon getIcon (boolean useCached)
 	{
-		if (this.icon == null || (!this.iconLoaded && !useCached)) {
-			AppIcon icon = null;
-			if (this.appManager.isIconPackLoaded ()) {
-				icon = this.appManager.getIconPack().getIconForApp(this);
-			}
-			if (icon == null) {
-				// Shape the system icon to the chosen mask (no-op for legacy icons); //
-				// icon-pack icons above are deliberately left as the pack designed them. //
-				final Drawable rendered =
-					this.appManager.getIconRenderer().render(this.loadFallbackIcon());
-				icon = this.appManager.getIconPack().getFallbackIcon(rendered);
-			}
+		// Read once and return that, not the field: releaseIcon() can null it
+		// mid-call from the main thread. Losing the race re-derives the icon. //
+		AppIcon icon = this.icon;
 
-			if (this.user != null && icon != null) {
-				// Work-profile badge on whichever icon won (icon pack or fallback) //
-				icon = new AppIcon (Profiles.badgedIcon (this.context, icon.getDrawable (), this.user));
+		if (icon == null || (!this.iconLoaded && !useCached)) {
+			// A cached icon is already icon-packed, shaped and badged. Misses fall
+			// through to the render path below. //
+			icon = useCached ? this.iconFromCache () : null;
+
+			if (icon == null) {
+				if (this.appManager.isIconPackLoaded ()) {
+					icon = this.appManager.getIconPack().getIconForApp(this);
+				}
+				if (icon == null) {
+					// Shape the system icon to the chosen mask (no-op for legacy icons); //
+					// icon-pack icons above are deliberately left as the pack designed them. //
+					final Drawable rendered =
+						this.appManager.getIconRenderer().render(this.loadFallbackIcon());
+					icon = this.appManager.getIconPack().getFallbackIcon(rendered);
+				}
+
+				if (this.user != null && icon != null) {
+					// Work-profile badge on whichever icon won. Not reached for a
+					// cached icon, which was badged before it was cached. //
+					icon = new AppIcon (Profiles.badgedIcon (this.context, icon.getDrawable (), this.user));
+				}
 			}
 
 			this.icon = icon;
 			this.iconLoaded = true;
 		}
 
-		return this.icon;
+		return icon;
+	}
+
+	/** This app's icon from the on-disk cache; null when absent or unreadable. */
+	private AppIcon iconFromCache ()
+	{
+		final ICache<Drawable> iconCache = this.appManager == null
+			? null
+			: this.appManager.getIconCache ();
+
+		if (iconCache == null) {
+			return null;
+		}
+
+		try {
+			final Drawable cached = iconCache.get (this.getProfileScopedKey ());
+
+			return cached == null ? null : new AppIcon (cached);
+		} catch (final Exception ex) {
+			// A failed cache read must never keep an icon off the screen. //
+			new ExceptionHandler (ex).logAndTrack ();
+
+			return null;
+		}
+	}
+
+	/**
+	 * Drops the in-memory icon; the next {@link #getIcon()} restores it. A view
+	 * showing the icon holds its own reference, so it keeps working and the
+	 * bitmap is not reclaimed until that view lets go.
+	 *
+	 * @return whether an icon was held, and has now been dropped.
+	 */
+	public boolean releaseIcon ()
+	{
+		if (this.icon == null) {
+			return false;
+		}
+
+		this.icon = null;
+		this.iconLoaded = false;
+
+		return true;
 	}
 
 	private Drawable loadFallbackIcon ()

--- a/app/src/main/java/be/robinj/distrohopper/AppManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/AppManager.java
@@ -3,6 +3,7 @@ package be.robinj.distrohopper;
 import android.content.pm.LauncherActivityInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.graphics.drawable.Drawable;
 import android.os.UserHandle;
 
 import org.xmlpull.v1.XmlPullParserException;
@@ -11,8 +12,10 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import be.robinj.distrohopper.cache.AppIconCache;
+import be.robinj.distrohopper.cache.ICache;
 import be.robinj.distrohopper.icons.IconConfig;
 import be.robinj.distrohopper.icons.IconRenderer;
 import be.robinj.distrohopper.preferences.Preference;
@@ -37,6 +40,8 @@ public class AppManager implements Iterable<App>
 	private final IconPackHelper iconPack;
 
 	private IconRenderer iconRenderer;
+
+	private ICache<Drawable> iconCache;
 
 	private final HomeActivity parent;
 
@@ -182,6 +187,17 @@ public class AppManager implements Iterable<App>
 		return this.iconPack;
 	}
 
+	/** The loader's on-disk icon cache; null until the loader has run. */
+	public ICache<Drawable> getIconCache ()
+	{
+		return this.iconCache;
+	}
+
+	public void setIconCache (final ICache<Drawable> iconCache)
+	{
+		this.iconCache = iconCache;
+	}
+
 	/**
 	 * The renderer that shapes adaptive icons to the current {@link IconConfig}.
 	 * Rebuilt whenever the icon-shape/themed preferences change (in-process or
@@ -243,6 +259,12 @@ public class AppManager implements Iterable<App>
 	public List<App> getPinned ()
 	{
 		return this.repository.getPinnedLive ();
+	}
+
+	/** Every pinned app, across all desktops - not just the one on screen. */
+	public Set<App> getAllPinned ()
+	{
+		return this.repository.allPinned ();
 	}
 
 	public List<App> getRunningApps ()

--- a/app/src/main/java/be/robinj/distrohopper/AppRepository.kt
+++ b/app/src/main/java/be/robinj/distrohopper/AppRepository.kt
@@ -272,6 +272,9 @@ class AppRepository(private val context: Context) {
 		this.pinnedChanged()
 	}
 
+	/** Every pinned app across all desktops, including ones not on screen. */
+	fun allPinned(): Set<App> = this.pinnedByPage.flatMapTo(mutableSetOf()) { it }
+
 	/** Removes [app] from every desktop (e.g. when it is uninstalled). */
 	fun unpinFromAllDesktops(app: App): Boolean {
 		var modified = false

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -57,6 +57,7 @@ import be.robinj.distrohopper.home.GestureAction;
 import be.robinj.distrohopper.home.HomeGestureController;
 import be.robinj.distrohopper.home.HomeStateBinder;
 import be.robinj.distrohopper.home.HomeViewModel;
+import be.robinj.distrohopper.home.IconMemoryTrimmer;
 import be.robinj.distrohopper.home.LauncherEdgeController;
 import be.robinj.distrohopper.home.LayoutTransitionConfigurer;
 import be.robinj.distrohopper.home.SearchLoader;
@@ -100,6 +101,7 @@ public class HomeActivity extends AppCompatActivity
 {
 	private LensManager lenses;
 	private AppManager apps;
+	private IconMemoryTrimmer iconMemoryTrimmer;
 	private AppWidgetManager widgetManager;
 	private WidgetHost widgetHost;
 	private DesktopAppHost desktopAppHost;
@@ -816,6 +818,23 @@ public class HomeActivity extends AppCompatActivity
 	}
 
 	@Override
+	public void onTrimMemory (final int level)
+	{
+		super.onTrimMemory (level);
+
+		try
+		{
+			if (this.iconMemoryTrimmer != null)
+				this.iconMemoryTrimmer.onTrimMemory (level);
+		}
+		catch (final Exception ex)
+		{
+			// Reclaiming memory must never crash the launcher //
+			new ExceptionHandler (ex).logAndTrack ();
+		}
+	}
+
+	@Override
 	public void onDestroy ()
 	{
 		FolderOverlay.clearFor (this);
@@ -941,6 +960,7 @@ public class HomeActivity extends AppCompatActivity
 			ProgressWheel pwDashSearchProgress = this.viewFinder.get(R.id.pwDashSearchProgress);
 
 			this.apps = installedApps;
+			this.iconMemoryTrimmer = new IconMemoryTrimmer (installedApps);
 			this.lenses = new LensManager (this.getApplicationContext (), llDashHomeAppsContainer, llDashHomeLensesContainer, pwDashSearchProgress, installedApps);
 			// Runs searches on the activity's lifecycleScope + dispatchers, like StartupLoader //
 			this.lenses.setSearchLoader (new SearchLoader (this, DependencyContainer.of (this).getDispatchers ()));

--- a/app/src/main/java/be/robinj/distrohopper/home/AppsLoader.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/AppsLoader.kt
@@ -36,6 +36,9 @@ object AppsLoader {
 	): AppManager {
 		val appManager = AppManager(parent)
 
+		// Set before any app loads an icon; App.getIcon reads it back.
+		appManager.iconCache = appIconCache
+
 		// Reconcile the icon cache against the current icon config *before* any app
 		// loads its icon from cache, so a changed shape/theme/wallpaper tint purges
 		// the now-stale cached icons instead of serving them.

--- a/app/src/main/java/be/robinj/distrohopper/home/IconMemoryTrimmer.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/IconMemoryTrimmer.kt
@@ -1,0 +1,57 @@
+package be.robinj.distrohopper.home
+
+import android.content.ComponentCallbacks2
+import be.robinj.distrohopper.App
+import be.robinj.distrohopper.AppManager
+import be.robinj.distrohopper.dev.Log
+
+/**
+ * Drops cached app-icon bitmaps on [ComponentCallbacks2.onTrimMemory]. Each
+ * [App] holds one rendered icon (108dp ARGB_8888) for the life of the process;
+ * nothing released them before.
+ *
+ * UI_HIDDEN spares the pinned apps; BACKGROUND and deeper drop those too. The
+ * legacy TRIM_MEMORY_RUNNING_* levels are ignored because Android 14 stopped
+ * delivering them.
+ *
+ * [App.releaseIcon] only drops the reference, so an icon a view still holds is
+ * not reclaimed until that view lets go of it.
+ */
+class IconMemoryTrimmer(private val apps: AppManager) {
+	/** @return how many icons were dropped. */
+	fun onTrimMemory(level: Int): Int = when {
+		level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> this.release(sparePinned = false)
+		level >= ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> this.release(sparePinned = true)
+		else -> 0
+	}
+
+	private fun release(sparePinned: Boolean): Int {
+		val spared: Set<App> = if (sparePinned) this.apps.allPinned else emptySet()
+
+		var released = 0
+		// Snapshot: the installed list is live and the loader may still be filling it.
+		for (app in this.apps.installedApps.toList()) {
+			if (app in spared) {
+				continue
+			}
+
+			if (app.releaseIcon()) {
+				released++
+			}
+		}
+
+		if (released > 0) {
+			LOG.v(
+				"IconMemoryTrimmer",
+				"Released $released app icon(s)" +
+					if (sparePinned) ", sparing ${spared.size} pinned" else " (including pinned)",
+			)
+		}
+
+		return released
+	}
+
+	private companion object {
+		private val LOG: Log = Log.getInstance()
+	}
+}

--- a/app/src/test/java/be/robinj/distrohopper/home/IconMemoryTrimmerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/IconMemoryTrimmerTest.kt
@@ -1,0 +1,208 @@
+package be.robinj.distrohopper.home
+
+import android.content.ComponentCallbacks2
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import androidx.test.core.app.ActivityScenario
+import be.robinj.distrohopper.ActivityTestSupport
+import be.robinj.distrohopper.App
+import be.robinj.distrohopper.AppManager
+import be.robinj.distrohopper.HomeActivity
+import be.robinj.distrohopper.cache.ICache
+import be.robinj.distrohopper.cache.TestDrawableCache
+import be.robinj.distrohopper.desktop.AppIcon
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.LEGACY)
+class IconMemoryTrimmerTest {
+	private lateinit var scenario: ActivityScenario<HomeActivity>
+
+	@Before fun setUp() {
+		this.scenario = ActivityTestSupport.launchHome()
+	}
+
+	@After fun tearDown() {
+		this.scenario.close()
+	}
+
+	private class HashLabelCache : ICache<String>, MutableMap<String, String> by HashMap() {
+		override fun getName() = "labels"
+	}
+
+	/** Counts reads, so a test can tell a cache re-hydration from a re-render. */
+	private class CountingIconCache(private val inner: ICache<Drawable>) :
+		ICache<Drawable>, MutableMap<String, Drawable> by inner {
+		var reads = 0
+
+		override fun getName() = this.inner.getName()
+
+		override fun get(key: String): Drawable? {
+			this.reads++
+
+			return this.inner[key]
+		}
+	}
+
+	/** A BitmapDrawable, so it survives a round trip through DrawableCache. */
+	private fun icon(context: Context, colour: Int = Color.RED): AppIcon = AppIcon(
+		BitmapDrawable(
+			context.resources,
+			Bitmap.createBitmap(4, 4, Bitmap.Config.ARGB_8888).apply { eraseColor(colour) },
+		),
+	)
+
+	/**
+	 * A loaded launcher whose apps all hold an icon, with that icon also written
+	 * through to the cache — the state the launcher is in once startup finishes.
+	 */
+	private fun loadedApps(
+		activity: HomeActivity,
+		name: String,
+	): Triple<AppManager, CountingIconCache, IconMemoryTrimmer> {
+		val cache = CountingIconCache(TestDrawableCache(activity, name))
+		cache.clear()
+
+		val appManager = runBlocking {
+			AppsLoader.loadApps(
+				activity, activity.applicationContext, HashLabelCache(), cache,
+			) { _, _ -> }
+		}
+
+		for (app in appManager.installedApps) {
+			app.setIcon(this.icon(activity), cache)
+		}
+
+		return Triple(appManager, cache, IconMemoryTrimmer(appManager))
+	}
+
+	private fun loadedIconCount(apps: AppManager): Int =
+		apps.installedApps.count { it.isIconLoaded }
+
+	@Test fun uiHiddenReleasesTheDashTailButSparesPinnedApps() {
+		this.scenario.onActivity { activity ->
+			val (apps, _, trimmer) = this.loadedApps(activity, "trim_ui_hidden")
+			val pinned = apps.installedApps.first()
+			apps.pin(pinned, false, false)
+
+			val total = apps.installedApps.size
+			assertEquals(total, this.loadedIconCount(apps))
+
+			val released = trimmer.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
+
+			assertEquals(total - 1, released)
+			assertTrue("the pinned app keeps its icon", pinned.isIconLoaded)
+			assertEquals(1, this.loadedIconCount(apps))
+		}
+	}
+
+	@Test fun backgroundReleasesEverythingIncludingPinnedApps() {
+		this.scenario.onActivity { activity ->
+			val (apps, _, trimmer) = this.loadedApps(activity, "trim_background")
+			val pinned = apps.installedApps.first()
+			apps.pin(pinned, false, false)
+
+			val total = apps.installedApps.size
+			val released = trimmer.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+
+			assertEquals(total, released)
+			assertFalse("even a pinned app gives its icon up", pinned.isIconLoaded)
+			assertEquals(0, this.loadedIconCount(apps))
+		}
+	}
+
+	@Test fun levelsDeeperThanBackgroundAlsoReleaseEverything() {
+		this.scenario.onActivity { activity ->
+			val (apps, _, trimmer) = this.loadedApps(activity, "trim_complete")
+			apps.pin(apps.installedApps.first(), false, false)
+
+			val total = apps.installedApps.size
+
+			assertEquals(total, trimmer.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE))
+		}
+	}
+
+	/**
+	 * The legacy foreground levels. Android 14 stopped delivering them; where they
+	 * still arrive the launcher is on screen, so there is nothing to gain.
+	 */
+	@Test fun foregroundRunningLevelsReleaseNothing() {
+		this.scenario.onActivity { activity ->
+			val (apps, _, trimmer) = this.loadedApps(activity, "trim_running")
+			val total = apps.installedApps.size
+
+			for (level in intArrayOf(
+				ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE,
+				ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW,
+				ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+			)) {
+				assertEquals("level $level must not release", 0, trimmer.onTrimMemory(level))
+			}
+
+			assertEquals(total, this.loadedIconCount(apps))
+		}
+	}
+
+	@Test fun trimmingTwiceReleasesNothingTheSecondTime() {
+		this.scenario.onActivity { activity ->
+			val (_, _, trimmer) = this.loadedApps(activity, "trim_twice")
+
+			assertTrue(trimmer.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) > 0)
+			assertEquals(0, trimmer.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND))
+		}
+	}
+
+	@Test fun aReleasedIconComesBackFromTheCacheRatherThanBeingRerendered() {
+		this.scenario.onActivity { activity ->
+			val (apps, cache, trimmer) = this.loadedApps(activity, "trim_reload")
+			val app: App = apps.installedApps.first()
+
+			trimmer.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+			assertFalse(app.isIconLoaded)
+
+			val before = cache.reads
+			val restored = app.icon
+
+			assertNotNull(restored)
+			assertTrue("the icon was read back out of the cache", cache.reads > before)
+			assertTrue(app.isIconLoaded)
+		}
+	}
+
+	/** A cache miss must still produce an icon, by falling through to a render. */
+	@Test fun aReleasedIconIsRerenderedWhenTheCacheHasLostIt() {
+		this.scenario.onActivity { activity ->
+			val (apps, cache, trimmer) = this.loadedApps(activity, "trim_cache_miss")
+			val app: App = apps.installedApps.first()
+
+			trimmer.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+			cache.clear()
+
+			assertNotNull(app.icon)
+			assertTrue(app.isIconLoaded)
+		}
+	}
+
+	@Test fun releasingAnAppThatHoldsNoIconReportsNothingReleased() {
+		this.scenario.onActivity { activity ->
+			val (apps, _, _) = this.loadedApps(activity, "trim_no_icon")
+			val app = apps.installedApps.first()
+
+			assertTrue(app.releaseIcon())
+			assertFalse("already released", app.releaseIcon())
+		}
+	}
+}


### PR DESCRIPTION
Each `App` held its rendered icon (108dp `ARGB_8888`) for the life of the process, and nothing ever released them.

`IconMemoryTrimmer`, driven from `HomeActivity.onTrimMemory`, drops them. `TRIM_MEMORY_UI_HIDDEN` spares the pinned apps, `TRIM_MEMORY_BACKGROUND` and deeper drop those too; the legacy `TRIM_MEMORY_RUNNING_*` levels are ignored because `ComponentCallbacks2` marks them `@deprecated "Apps are not notified of this level since API level 34"`.

The split is freeable vs. not: the bar's `AppLauncher` views hold their own `AppIcon`, so releasing a pinned icon frees nothing while costing a re-derive on return, whereas the dash's long tail has no view holding it.

`App.releaseIcon` only drops the reference; `App.getIcon` restores it from the on-disk icon cache, now held by `AppManager` and set by `AppsLoader` — that cache was previously read once, at construction, and is already cleared on any shape/pack/tint change. `getIcon` also reads the `icon` field once and returns that value instead of re-reading it on the way out, since `releaseIcon` runs on the main thread while lens searches and the icon-caching pass call `getIcon` on IO.

Not exercised on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KngjcKYmfRXNcdWnU44uS4