### PR TITLE
Always stop the loading wheel's spin

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/home/StartupLoader.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/StartupLoader.kt
@@ -105,6 +105,10 @@ class StartupLoader(
 				throw ex
 			} catch (ex: Exception) {
 				ExceptionHandler(ex).show(this@StartupLoader.activity)
+			} finally {
+				// HomeActivity started the spin and only our progress callbacks
+				// stop it, so a load that throws or is cancelled must not skip this //
+				lalSpinner.progressWheel.stopSpinning()
 			}
 		}
 	}


### PR DESCRIPTION
`stopSpinning()` is called from nowhere in the app — the spin has only ever ended as a side effect of `StartupLoader`'s first `setProgress()` callback, which clears `isSpinning`. That was safe while loading was an `AsyncTask`, which ran to completion regardless of the activity. On `lifecycleScope` the job is cancelled when the activity is destroyed, so a load cancelled or thrown before its first progress callback leaves the wheel spinning.

That matters because the spin loop is only self-pacing while the wheel is on screen: `invalidate()` schedules a traversal, whose sync barrier holds the loop until the next vsync. Hidden or detached, `invalidate()` short-circuits, no barrier is posted, and the loop — which re-posts itself with `delayMillis`, 0 by default — runs flat out on the main looper for the life of the process.

`ProgressWheel` itself is untouched. Unit tests and `assembleDebug` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdAZxb4tpweHY8TqUA4L51