### PR TITLE
Stop the progress wheel's spin when it is detached

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/thirdparty/ProgressWheel.java
+++ b/app/src/main/java/be/robinj/distrohopper/thirdparty/ProgressWheel.java
@@ -325,6 +325,14 @@ public class ProgressWheel extends View {
 		setText("0%");
 		invalidate();
 	}
+	@Override
+	protected void onDetachedFromWindow() {
+		// Off screen invalidate() short-circuits, so nothing paces the spin and the
+		// queued frame keeps this view's activity alive //
+		this.stopSpinning();
+
+		super.onDetachedFromWindow();
+	}
 	/**
 	 * Turn off spin mode
 	 */


### PR DESCRIPTION
A spinning wheel that leaves the window keeps spinning, unthrottled — off screen `invalidate()` short-circuits, so no traversal is scheduled and no sync barrier paces the next frame. The queued frame also keeps the view's activity alive.

Caught by a bugreport from a device on v3.0.0: the main thread `Runnable` inside `ProgressWheel$1.handleMessage`, `utm=1629936` at `HZ=100` (4h32m user time), `Activities: 3` against `ViewRootImpl: 1`.

#139 covers the path that produced that; this covers the rest. The wheel does not resume on re-attach, which suits its one caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdAZxb4tpweHY8TqUA4L51