### PR TITLE
Add a dev-mode main-looper profiler

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -64,6 +64,7 @@ import be.robinj.distrohopper.home.StartupLoader;
 import be.robinj.distrohopper.home.ThemeApplier;
 import be.robinj.distrohopper.home.WallpaperColourApplier;
 import be.robinj.distrohopper.dev.LogToaster;
+import be.robinj.distrohopper.dev.LooperProfiler;
 import be.robinj.distrohopper.folder.FolderOverlay;
 import be.robinj.distrohopper.onboarding.OnboardingActivity;
 import be.robinj.distrohopper.onboarding.OnboardingGate;
@@ -188,6 +189,10 @@ public class HomeActivity extends AppCompatActivity
 					log.attachObserver(this.logToaster);
 				}
 			}
+
+			// Costs a string per message, so it stays off until switched on //
+			LooperProfiler.setEnabled (prefs.getBoolean (Preference.DEV.getName(), false)
+				&& prefs.getBoolean (Preference.DEV_LOOPER_PROFILE.getName(), false));
 
 			// Initialise caches //
 			this.appLabelCache = new AppLabelCache(this.getBaseContext());

--- a/app/src/main/java/be/robinj/distrohopper/dev/Log.java
+++ b/app/src/main/java/be/robinj/distrohopper/dev/Log.java
@@ -137,10 +137,31 @@ public class Log extends Observed
 
 	private void appendToDevLog (LogLevel level, String tag, String message)
 	{
+		if (this.append (level, tag, message))
+		{
+			// Outside the lock: observers touch the UI, and holding the log lock across
+			// that would let a logging background thread block on the main thread. //
+			this.nudgeObservers ();
+		}
+	}
+
+	/**
+	 * Appends without waking the observers, for sources that fire per main-looper
+	 * message ({@link LooperProfiler}): a nudge posts to that looper, and the post
+	 * would itself be logged and nudge again. //
+	 */
+	void appendQuietly (LogLevel level, String tag, String message)
+	{
+		this.append (level, tag, message);
+	}
+
+	/** Records the entry, answering whether it was kept (logging can be off). */
+	private boolean append (LogLevel level, String tag, String message)
+	{
 		synchronized (this.lock)
 		{
 			if (!this.enabled)
-				return;
+				return false;
 
 			if (this.entries.size () >= Log.CAPACITY)
 				this.entries.removeFirst ();
@@ -149,8 +170,6 @@ public class Log extends Observed
 				System.currentTimeMillis (), Thread.currentThread ().getName ()));
 		}
 
-		// Outside the lock: observers touch the UI, and holding the log lock across that
-		// would let a logging background thread block on the main thread. //
-		this.nudgeObservers ();
+		return true;
 	}
 }

--- a/app/src/main/java/be/robinj/distrohopper/dev/LooperProfiler.kt
+++ b/app/src/main/java/be/robinj/distrohopper/dev/LooperProfiler.kt
@@ -1,0 +1,38 @@
+package be.robinj.distrohopper.dev
+
+import android.os.Looper
+import android.util.Printer
+
+/**
+ * Logs every message dispatched on the main looper, to find work running when
+ * nothing should be. A spin shows up as one line repeating; the entry
+ * timestamps give its rate. The "finished" line is dropped as a duplicate.
+ */
+class LooperProfiler(private val log: Log) : Printer {
+	override fun println(x: String?) {
+		val line = x ?: return
+
+		if (! line.startsWith(DISPATCH_PREFIX)) {
+			return
+		}
+
+		// Quietly: a nudge posts to this looper, which would be logged, which
+		// would nudge again //
+		this.log.appendQuietly(LogLevel.VERBOSE, TAG,
+			line.substring(DISPATCH_PREFIX.length))
+	}
+
+	companion object {
+		private const val TAG = "MainLooper"
+
+		/** What Looper prefixes the line it prints before dispatching a message. */
+		private const val DISPATCH_PREFIX = ">>>>> Dispatching to "
+
+		/** On, the looper builds a string per message; off, it does nothing. */
+		@JvmStatic
+		fun setEnabled(enabled: Boolean) {
+			Looper.getMainLooper().setMessageLogging(
+				if (enabled) LooperProfiler(Log.getInstance()) else null)
+		}
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
+++ b/app/src/main/java/be/robinj/distrohopper/preferences/Preference.kt
@@ -86,6 +86,8 @@ enum class Preference(
 	DEV("dev"),
 	/** Dev: surface internal log messages as on-screen toasts. */
 	DEV_LOG_TOASTER("dev_log_toaster", null, DEV),
+	/** Dev: log every message dispatched on the main looper into the in-app log. */
+	DEV_LOOPER_PROFILE("dev_looper_profile", false, DEV),
 	/** Dev: allow freely resizing any widget, ignoring its declared limits. */
 	DEV_WIDGET_RESIZE_ANY("dev_widget_resize_any", false, DEV),
 	/** Dev: show a dot at every grid intersection while dragging or resizing. */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,8 @@
     <string name="hint_dashsearch_focus_on_open">Focus the search box and show the keyboard when the dash is opened.</string>
     <string name="option_dev_log_toaster">Log toasts</string>
     <string name="hint_dev_log_toaster">Show log items in toast messages.</string>
+    <string name="option_dev_looper_profile">Profile main looper</string>
+    <string name="hint_dev_looper_profile">Log every message the main thread handles. Slows the app down; takes effect after a restart.</string>
     <string name="option_customise">Customise</string>
     <string name="hint_customise">Customise the look and feel.</string>
     <string name="customise_done">Done</string>

--- a/app/src/main/res/xml/pref_dev.xml
+++ b/app/src/main/res/xml/pref_dev.xml
@@ -16,6 +16,13 @@
 		android:defaultValue="false" />
 
 	<SwitchPreferenceCompat
+		android:key="dev_looper_profile"
+		android:dependency="dev"
+		android:title="@string/option_dev_looper_profile"
+		android:summary="@string/hint_dev_looper_profile"
+		android:defaultValue="false" />
+
+	<SwitchPreferenceCompat
 		android:key="dev_widget_resize_any"
 		android:dependency="dev"
 		android:title="@string/option_widget_resize_any"


### PR DESCRIPTION
Logs every message dispatched on the main looper to the in-app log, with its Handler, callback and `what`. A spin shows up as one line repeating; the entry timestamps give its rate.

Dev preference, off by default: while it is set the looper builds a string per message. Appends without nudging the log's observers, since a nudge posts to the main looper, which would be logged, which would nudge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdAZxb4tpweHY8TqUA4L51