### PR TITLE
Don't crash when a profile has no system badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,14 @@ licenses/                                   — full licence texts of everything
     which load via `AppRepository.queryOtherProfileApps()`
     (LauncherApps), launch via `LauncherApps.startMainActivity`, get the
     profile badge on their icon, and participate in `App.equals` (the same
-    package can exist in both profiles). Persistence/cache keys use
+    package can exist in both profiles). Not every profile a launcher sees
+    has a system badge, and the platform is inconsistent about saying so:
+    AOSP hands `getUserBadgedDrawableForDensity` the drawable back
+    unbadged, while some vendor builds look up badge resource 0 and throw
+    (a Funtouch OS crash on the icon-loading path). `Profiles.profileGlyph`
+    turns both into a null glyph, and its callers — `Profiles.badgedIcon`
+    and the glyph indicators — fall back to the un-badged icon / our own
+    `ic_profile` glyph. Persistence/cache keys use
     `App.getProfileScopedKey()` — identical to the old
     package+activity key for personal apps, with the profile serial
     appended otherwise (so old pinned-app prefs keep matching). The
@@ -214,9 +221,10 @@ licenses/                                   — full licence texts of everything
     `GNOME_PANEL` (Gnome) draws a profile pill at the panel's top-left,
     shown only while the dash is open (`GnomeProfilePillIndicator` +
     the custom-drawn `ProfilePillView`); other themes are `NONE` for now.
-    Glyph indicators badge the generic `ic_profile` glyph with the system
-    profile badge via `getUserBadgedIcon` (correct for work/private/clone
-    profiles); the personal profile uses the theme's
+    Glyph indicators use the system profile badge *as* the whole glyph
+    (`Profiles.profileGlyph` badges a transparent square, so it is correct
+    for work/private/clone profiles by itself), desaturated to sit beside
+    the monochrome glyph set; the personal profile uses the theme's
     `profile_indicator_personal_glyph` (the house glyph for Unity).
     Indicators implement `desktop/dash/profile/ProfileIndicator` and are
     driven by the pager's page-scroll callback so the highlight/pill animates

--- a/app/src/main/java/be/robinj/distrohopper/Profiles.kt
+++ b/app/src/main/java/be/robinj/distrohopper/Profiles.kt
@@ -2,6 +2,7 @@ package be.robinj.distrohopper
 
 import android.content.Context
 import android.content.pm.LauncherApps
+import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.ColorMatrix
@@ -13,6 +14,7 @@ import android.os.Build
 import android.os.Process
 import android.os.UserHandle
 import android.os.UserManager
+import be.robinj.distrohopper.dev.Log
 
 /**
  * Helpers around Android user profiles, surfaced in the UI as "profiles":
@@ -79,7 +81,8 @@ object Profiles {
 	 * private-space lock, …) in the bottom-right corner. The badge is composited
 	 * ourselves rather than via [getUserBadgedDrawableForDensity], whose badge
 	 * rect the platform ignores for some drawables (leaving a tiny default badge
-	 * that is barely visible on the big dash icons).
+	 * that is barely visible on the big dash icons). Returns [drawable] itself
+	 * when the system has no badge for the profile (see [profileGlyph]).
 	 */
 	@JvmStatic
 	fun badgedIcon(context: Context, drawable: Drawable, user: UserHandle): Drawable {
@@ -87,13 +90,14 @@ object Profiles {
 		val size = if (intrinsic > 0) intrinsic
 			else (96 * context.resources.displayMetrics.density).toInt()
 
+		val badgeSize = Math.max((size * BADGE_FRACTION).toInt(), 1)
+		val badge = this.profileGlyph(context, user, badgeSize) ?: return drawable
+
 		val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
 		val canvas = Canvas(bitmap)
 		drawable.setBounds(0, 0, size, size)
 		drawable.draw(canvas)
 
-		val badgeSize = (size * BADGE_FRACTION).toInt()
-		val badge = this.profileGlyph(context, user, badgeSize)
 		badge.setBounds(size - badgeSize, size - badgeSize, size, size)
 		badge.draw(canvas)
 
@@ -107,16 +111,33 @@ object Profiles {
 	 * keep in sync. Used as the profile's tab glyph in indicators. [desaturate]
 	 * greyscales it (keeping its shape, unlike a flat tint) to sit better beside a
 	 * monochrome glyph set.
+	 *
+	 * Null when the system has no badge for the profile: not every profile a
+	 * launcher can see is badged, and while AOSP then hands back the drawable it
+	 * was given, some vendor builds instead look up badge resource 0 and throw
+	 * ([Resources.NotFoundException], seen crashing icon loading on Funtouch OS).
+	 * Callers own the un-badged fallback.
 	 */
 	@JvmStatic
 	@JvmOverloads
 	fun profileGlyph(
-		context: Context, user: UserHandle, sizePx: Int, desaturate: Boolean = false): Drawable {
+		context: Context, user: UserHandle, sizePx: Int, desaturate: Boolean = false): Drawable? {
 		// A transparent square base, with the badge filling its whole bounds.
 		val blank = BitmapDrawable(context.resources,
-			Bitmap.createBitmap(sizePx, sizePx, Bitmap.Config.ARGB_8888))
-		val badge = context.packageManager
-			.getUserBadgedDrawableForDensity(blank, user, Rect(0, 0, sizePx, sizePx), 0)
+			Bitmap.createBitmap(Math.max(sizePx, 1), Math.max(sizePx, 1), Bitmap.Config.ARGB_8888))
+		val badge = try {
+			context.packageManager
+				.getUserBadgedDrawableForDensity(blank, user, Rect(0, 0, sizePx, sizePx), 0)
+		} catch (ex: Resources.NotFoundException) {
+			Log.getInstance().w("Profiles", "No profile badge for user $user: $ex")
+
+			null
+		} ?: return null
+
+		// AOSP returns the drawable unchanged when the profile has no badge. //
+		if (badge === blank) {
+			return null
+		}
 
 		if (desaturate) {
 			badge.mutate()

--- a/app/src/main/java/be/robinj/distrohopper/desktop/dash/profile/UnityRibbonIndicator.kt
+++ b/app/src/main/java/be/robinj/distrohopper/desktop/dash/profile/UnityRibbonIndicator.kt
@@ -74,9 +74,11 @@ class UnityRibbonIndicator(
 		} else {
 			// The system badge is the whole glyph, so it stays correct for the
 			// profile type (work briefcase, private-space lock, …) by itself;
-			// desaturated so it sits beside the monochrome personal glyph.
+			// desaturated so it sits beside the monochrome personal glyph. Not
+			// every profile has a system badge, so fall back to our own glyph.
 			val px = (36 * this.context.resources.displayMetrics.density).toInt()
 			Profiles.profileGlyph(this.context, profile, px, desaturate = true)
+				?: ContextCompat.getDrawable(this.context, R.drawable.ic_profile)
 		}
 
 	override fun onPageScrolled(position: Int, positionOffset: Float) {

--- a/app/src/test/java/be/robinj/distrohopper/ProfilesBadgeTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/ProfilesBadgeTest.kt
@@ -1,0 +1,95 @@
+package be.robinj.distrohopper
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.os.UserHandle
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.ShadowApplicationPackageManager
+
+/**
+ * Not every profile a launcher can see has a system badge, and the platform is
+ * inconsistent about saying so: AOSP hands the drawable back unbadged, while
+ * some vendor builds look up badge resource 0 and throw. Either way the badge
+ * is simply absent — never a crash on the icon-loading path.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ProfilesBadgeTest {
+	private val context = ApplicationProvider.getApplicationContext<Context>()
+	private val user = ActivityTestSupport.workProfileHandle()
+	private val icon: Drawable get() = ColorDrawable(Color.RED).apply { setBounds(0, 0, 64, 64) }
+
+	@Test @Config(shadows = [ThrowingBadgeShadow::class])
+	fun glyphIsAbsentWhenTheSystemBadgeLookupThrows() {
+		// Funtouch OS on a vivo V2111 (Android 12) crashed here: the badge //
+		// resource for the profile is 0, and looking it up throws. //
+		assertNull(Profiles.profileGlyph(this.context, this.user, 32))
+	}
+
+	@Test @Config(shadows = [ThrowingBadgeShadow::class])
+	fun iconIsLeftUnbadgedWhenTheSystemBadgeLookupThrows() {
+		val unbadged = this.icon
+
+		assertSame(unbadged, Profiles.badgedIcon(this.context, unbadged, this.user))
+	}
+
+	@Test @Config(shadows = [UnbadgedShadow::class])
+	fun glyphIsAbsentWhenTheSystemLeavesTheDrawableUnbadged() {
+		assertNull(Profiles.profileGlyph(this.context, this.user, 32))
+	}
+
+	@Test @Config(shadows = [UnbadgedShadow::class])
+	fun iconIsLeftUnbadgedWhenTheSystemLeavesTheDrawableUnbadged() {
+		val unbadged = this.icon
+
+		assertSame(unbadged, Profiles.badgedIcon(this.context, unbadged, this.user))
+	}
+
+	@Test @Config(shadows = [BadgingShadow::class])
+	fun badgedProfileStillGetsItsGlyphAndBadgedIcon() {
+		assertNotNull(Profiles.profileGlyph(this.context, this.user, 32))
+
+		val unbadged = this.icon
+		assertNotSame(unbadged, Profiles.badgedIcon(this.context, unbadged, this.user))
+	}
+
+	/** A vendor package manager that throws on a profile with no badge resource. */
+	@Implements(className = "android.app.ApplicationPackageManager", isInAndroidSdk = false)
+	class ThrowingBadgeShadow : ShadowApplicationPackageManager() {
+		@Implementation
+		protected fun getUserBadgedDrawableForDensity(
+			drawable: Drawable, user: UserHandle, badgeLocation: Rect?, badgeDensity: Int): Drawable =
+			throw Resources.NotFoundException("Resource ID #0x0")
+	}
+
+	/** AOSP's answer for an unbadged profile: the drawable it was handed. */
+	@Implements(className = "android.app.ApplicationPackageManager", isInAndroidSdk = false)
+	class UnbadgedShadow : ShadowApplicationPackageManager() {
+		@Implementation
+		protected fun getUserBadgedDrawableForDensity(
+			drawable: Drawable, user: UserHandle, badgeLocation: Rect?, badgeDensity: Int): Drawable =
+			drawable
+	}
+
+	/** A profile that does have a badge (the usual work-profile case). */
+	@Implements(className = "android.app.ApplicationPackageManager", isInAndroidSdk = false)
+	class BadgingShadow : ShadowApplicationPackageManager() {
+		@Implementation
+		protected fun getUserBadgedDrawableForDensity(
+			drawable: Drawable, user: UserHandle, badgeLocation: Rect?, badgeDensity: Int): Drawable =
+			ColorDrawable(Color.BLUE)
+	}
+}


### PR DESCRIPTION
Fixes a startup crash on a device with a second profile: `Resources$NotFoundException: Resource ID #0x0`, thrown from `Profiles.profileGlyph` via `App.getIcon` → `AppsLoader.loadIcons`.

Not every profile a launcher sees through `LauncherApps` has a system badge. AOSP's `getUserBadgedDrawableForDensity` then hands the drawable back unbadged, but some vendor ROMs look up badge resource 0 anyway and throw. That happens off the main thread during icon loading, so the app dies before home is drawn — on every launch, as long as the profile exists.

`profileGlyph` now returns null for both shapes of "no badge" (the throw, and the drawable handed straight back). `badgedIcon` falls back to the un-badged icon, `UnityRibbonIndicator` to our own `ic_profile` glyph; badged profiles are unaffected. Also guards the badge size against a 0px bitmap.

`ProfilesBadgeTest` covers all three platform answers with Robolectric shadows of `ApplicationPackageManager`; its regression tests fail on the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)