### PR TITLE
Fix crash dragging a widget bigger than the grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -696,9 +696,12 @@ licenses/                                   — full licence texts of everything
   coarse grid keeps a real resize range instead of collapsing to one span.
   Placement and restore defer until the page has been measured (cell size > 0)
   so a widget can never land at 1×1, and `WidgetHost.restoreWidgets` re-clamps
-  saved spans to the current provider limits once measured. New widgets land on
-  the desktop currently shown; drops and moves stay within it. Long-pressing a
-  widget puts its `WidgetContainer` into
+  saved spans to the current provider limits once measured. That re-clamp always
+  brings a span back inside the grid — a smaller preset can leave a saved widget
+  wider or taller than the grid it now sits on, and the snap maths work out "grid
+  minus span" — even when the desktop is too full to re-pack the widget or its
+  provider has gone away. New widgets land on the desktop currently shown; drops
+  and moves stay within it. Long-pressing a widget puts its `WidgetContainer` into
   edit mode: edge handles resize by touch (clamped to the provider's
   `min`/`maxResize*` limits and `resizeMode`, unless the developer-only
   unrestricted widget resizing preference `DEV_WIDGET_RESIZE_ANY` is enabled,

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetGrid.kt
@@ -342,6 +342,10 @@ object WidgetGrid {
 
 	/**
 	 * Snap a pixel offset to the nearest cell boundary.
+	 *
+	 * A negative [maxCell] means the caller's item is bigger than the grid it is
+	 * being snapped into ("cols minus span" underflows): cell 0 is then the only
+	 * placement there is, and clamping to it beats throwing out of a drag.
 	 */
 	@JvmStatic
 	fun snapToCell(px: Int, cellSizePx: Int, maxCell: Int): Int {
@@ -349,7 +353,7 @@ object WidgetGrid {
 			return 0
 		}
 
-		return (px.toFloat() / cellSizePx.toFloat()).roundToInt().coerceIn(0, maxCell)
+		return (px.toFloat() / cellSizePx.toFloat()).roundToInt().coerceIn(0, max(0, maxCell))
 	}
 
 	/**

--- a/app/src/main/java/be/robinj/distrohopper/widgets/WidgetHost.kt
+++ b/app/src/main/java/be/robinj/distrohopper/widgets/WidgetHost.kt
@@ -90,15 +90,21 @@ class WidgetHost(
 
 		for (i in 0 until container.childCount) {
 			val child = container.getChildAt(i) as? WidgetContainer ?: continue
-			val info = this.widgetManager.getAppWidgetInfo(child.appWidgetId) ?: continue
 			val lp = child.layoutParams as WidgetsContainer.LayoutParams
+			// The px limits of a provider that has gone away (uninstalled, or
+			// mid-update) are unknown, but its widget still gets held to the grid //
+			val limits = if (unrestricted) {
+				null
+			} else {
+				this.widgetManager.getAppWidgetInfo(child.appWidgetId)
+			}
 
 			val colSpan = WidgetGrid.clampSpan(lp.colSpan,
-				if (unrestricted) 0 else minResizeWidthPx(info),
-				if (unrestricted) 0 else info.maxResizeWidth, cellW, WidgetGrid.COLS)
+				limits?.let { minResizeWidthPx(it) } ?: 0,
+				limits?.maxResizeWidth ?: 0, cellW, WidgetGrid.COLS)
 			val rowSpan = WidgetGrid.clampSpan(lp.rowSpan,
-				if (unrestricted) 0 else minResizeHeightPx(info),
-				if (unrestricted) 0 else info.maxResizeHeight, cellH, WidgetGrid.ROWS)
+				limits?.let { minResizeHeightPx(it) } ?: 0,
+				limits?.maxResizeHeight ?: 0, cellH, WidgetGrid.ROWS)
 
 			// Always validate against the widgets already placed this pass, not
 			// just when the span changed: growing one widget can collide with a
@@ -110,14 +116,14 @@ class WidgetHost(
 			} else {
 				WidgetGrid.findFreeRect(kept, colSpan, rowSpan)
 					?.also { it.appWidgetId = child.appWidgetId }
-			}
-
-			if (placed == null) {
-				// No room for the re-clamped size; leave the widget untouched but
-				// still record it so the others avoid its cells //
-				kept.add(WidgetLayout(child.appWidgetId, lp.col, lp.row, lp.colSpan, lp.rowSpan))
-
-				continue
+					// The grid is full: keep the saved position (overlapping, as
+					// before) but never the saved SIZE — a span left larger than the
+					// grid, after the user picked a smaller grid preset, underflows
+					// the "cols minus span" bound in the drag snap and crashes //
+					?: WidgetLayout(child.appWidgetId,
+						lp.col.coerceIn(0, WidgetGrid.COLS - colSpan),
+						lp.row.coerceIn(0, WidgetGrid.ROWS - rowSpan),
+						colSpan, rowSpan)
 			}
 
 			if (placed.col != lp.col || placed.row != lp.row ||

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetGridTest.kt
@@ -242,6 +242,13 @@ class WidgetGridTest {
         assertEquals(0, WidgetGrid.snapToCell(123, 0, 7))
     }
 
+    @Test fun snapToCellHandlesAnItemBiggerThanTheGrid() {
+        // Callers pass "grid size minus span", which underflows for a widget
+        // saved bigger than the grid it is now on; cell 0 is all that is left //
+        assertEquals(0, WidgetGrid.snapToCell(5000, 100, -1))
+        assertEquals(0, WidgetGrid.snapToCell(0, 100, -3))
+    }
+
     @Test fun initialSpanPrefersTargetCells() {
         // Provider's preferred cell count is used directly when within limits //
         assertEquals(3, WidgetGrid.initialSpan(3, 0, 0, 100, 8))

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetHostTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetHostTest.kt
@@ -42,6 +42,39 @@ class WidgetHostTest {
 		}
 	}
 
+	@Test fun restoreShrinksAWidgetLeftBiggerThanTheGridEvenWithNowhereToRepackIt() {
+		scenario.onActivity { activity ->
+			val grid = WidgetTestSupport.standaloneGrid(activity)
+			WidgetTestSupport.layoutGrid(grid)
+			val host = WidgetTestSupport.host(activity, grid)
+			val widgetManager = AppWidgetManager.getInstance(activity)
+			Shadows.shadowOf(widgetManager)
+				.addBoundWidget(1, WidgetTestSupport.providerInfo())
+			Shadows.shadowOf(widgetManager)
+				.addBoundWidget(2, WidgetTestSupport.providerInfo())
+
+			// Widget 1 fills the desktop, so the oversized widget 2 — a size saved
+			// against a bigger grid, before the user picked a smaller preset — has
+			// nowhere to be re-packed. Its span must still come back inside the
+			// grid: the drag snap works out "cols minus span" and underflows //
+			DesktopLayoutTestStore.saveWidgets(activity.applicationContext, listOf(
+				WidgetLayout(1, 0, 0, WidgetGrid.COLS, WidgetGrid.ROWS, 0),
+				WidgetLayout(2, 0, 0, WidgetGrid.COLS + 2, WidgetGrid.ROWS + 2, 0),
+			))
+
+			host.restoreWidgets()
+
+			val oversized = (0 until grid.childCount)
+				.map { grid.getChildAt(it) as WidgetContainer }
+				.single { it.appWidgetId == 2 }
+			val lp = oversized.layoutParams as WidgetsContainer.LayoutParams
+			assertEquals(WidgetGrid.COLS, lp.colSpan)
+			assertEquals(WidgetGrid.ROWS, lp.rowSpan)
+			assertEquals(0, lp.col)
+			assertEquals(0, lp.row)
+		}
+	}
+
 	@Test fun configureResultWithoutPendingStateOrResultIntentDoesNothing() {
 		scenario.onActivity { activity ->
 			val grid = WidgetTestSupport.standaloneGrid(activity)

--- a/app/src/test/java/be/robinj/distrohopper/widgets/WidgetsContainerDragListenerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/widgets/WidgetsContainerDragListenerTest.kt
@@ -104,6 +104,23 @@ class WidgetsContainerDragListenerTest {
 		}
 	}
 
+	@Test fun draggingAWidgetBiggerThanTheGridSnapsToTheOriginInsteadOfCrashing() {
+		scenario.onActivity { activity ->
+			val fixture = fixture(activity)
+			// A size saved against a bigger grid, before the user picked a smaller
+			// preset: the snap bound ("cols minus span") goes negative //
+			lp(fixture.container).colSpan = WidgetGrid.COLS + 1
+			lp(fixture.container).rowSpan = WidgetGrid.ROWS + 1
+			val (x, y) = receiverPositionForCell(5, 4)
+
+			assertTrue(fixture.listener.onDrag(fixture.receiver,
+				DragEvents.obtain(DragEvent.ACTION_DRAG_LOCATION, x, y, fixture.container)))
+
+			assertEquals(0, fixture.grid.moveTargetCol)
+			assertEquals(0, fixture.grid.moveTargetRow)
+		}
+	}
+
 	@Test fun leavingTheDesktopHidesTheLandingTarget() {
 		scenario.onActivity { activity ->
 			val fixture = fixture(activity)


### PR DESCRIPTION
ACRA crash (3.0.0/111): dragging a widget whose span is bigger than the grid throws `IllegalArgumentException` from `snapToCell` — the bound is "grid size minus span", which goes negative.

A widget outgrows the grid when the user picks a smaller grid preset and `reclampPage` can't fix it on restore: no free rectangle to re-pack into, or the provider is momentarily unavailable. Both paths left the oversized span in place.

- `WidgetHost.reclampPage`: grid bound always applies in those two cases.
- `WidgetGrid.snapToCell`: negative bound clamps to cell 0 instead of throwing.

Three regression tests, all failing without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144zVvWFhKeP2XmdT265g8g