### PR TITLE
Don't report an unresolvable icon pack as an error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -765,6 +765,10 @@ licenses/                                   — full licence texts of everything
   active theme, or a preset). `IconShapePreference`/`IconTintPreference` are
   the settings strips, both previewing on the penguin sample
   `res/drawable/ic_icon_sample_foreground.xml`.
+  `IconPackHelper` applies third-party **icon packs**. A pack that will not resolve
+  (mid-update, unmounted storage, uninstalled) is an expected condition, not an
+  error: the load is skipped and the icons fall back to the system ones, with the
+  `icon_pack` preference left alone so it works again once the pack resolves.
   DistroHopper's **own** launcher icon carries a monochrome layer too, so it
   tints along with everything else: `res/drawable/ic_launcher_monochrome.xml`,
   referenced from both `mipmap-anydpi-v26` adaptive icons. It is generated —

--- a/app/src/main/java/be/robinj/distrohopper/AppManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/AppManager.java
@@ -1,7 +1,6 @@
 package be.robinj.distrohopper;
 
 import android.content.pm.LauncherActivityInfo;
-import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.UserHandle;
 
@@ -270,7 +269,7 @@ public class AppManager implements Iterable<App>
 		return this.repository.getInstalledLive ().iterator ();
 	}
 
-	public void loadIconPack (String name) throws IOException, XmlPullParserException, PackageManager.NameNotFoundException
+	public void loadIconPack (String name) throws IOException, XmlPullParserException
 	{
 		this.iconPack.loadIconPack (name);
 	}

--- a/app/src/main/java/be/robinj/distrohopper/IconPackHelper.java
+++ b/app/src/main/java/be/robinj/distrohopper/IconPackHelper.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import be.robinj.distrohopper.desktop.AppIcon;
+import be.robinj.distrohopper.dev.Log;
 
 /**
  * Created by robin on 06/09/14.
@@ -68,7 +69,7 @@ public class IconPackHelper
 		return result;
 	}
 
-	public void loadIconPack (String packageName) throws PackageManager.NameNotFoundException, IOException, XmlPullParserException
+	public void loadIconPack (String packageName) throws IOException, XmlPullParserException
 	{
 		this.name = packageName;
 		this.iconPackLoaded = false;
@@ -81,7 +82,19 @@ public class IconPackHelper
 		}
 
 		final PackageManager pm = this.context.getPackageManager();
-		this.iconPackRes = pm.getResourcesForApplication(packageName);
+		try {
+			this.iconPackRes = pm.getResourcesForApplication(packageName);
+		} catch (PackageManager.NameNotFoundException ex) {
+			// The pack can be unresolvable for all sorts of passing reasons -- mid-update,
+			// on storage that isn't mounted yet -- so this says nothing about whether it is
+			// still installed. Sit this load out and fall back to the system icons; the
+			// selection stays put and takes effect again once the pack resolves //
+			Log.getInstance().w(this.getClass().getSimpleName(),
+				"Icon pack " + packageName + " could not be resolved; using system icons.");
+			this.iconPackRes = null;
+			this.name = null;
+			return;
+		}
 
 		// Try res/xml/appfilter.xml first
 		int xmlId = this.iconPackRes.getIdentifier("appfilter", "xml", packageName);

--- a/app/src/test/java/be/robinj/distrohopper/IconPackHelperTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/IconPackHelperTest.kt
@@ -1,6 +1,8 @@
 package be.robinj.distrohopper
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import androidx.test.core.app.ApplicationProvider
@@ -9,6 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 
 @RunWith(RobolectricTestRunner::class)
 class IconPackHelperTest {
@@ -29,12 +32,42 @@ class IconPackHelperTest {
 
     @Test fun unloadedPackCannotResolveNamedIcon() = assertNull(helper.getIcon("missing"))
 
-    /** An unresolvable pack is an expected condition, not an error to throw or report. */
-    @Test fun loadingUnresolvablePackLeavesTheIconPackUnloaded() {
+    /**
+     * A pack can stop resolving at any time -- uninstalled, mid-update, on storage that
+     * isn't mounted yet. That is an expected condition, not an error to throw or report.
+     */
+    @Test fun anUnresolvablePackLeavesTheIconPackUnloaded() {
         helper.loadIconPack("ddt.free.icon.packs")
 
         assertFalse(helper.isIconPackLoaded)
         assertNull(helper.getIcon("anything"))
+    }
+
+    /** Installed, but carrying nothing we can use: unloaded too, and equally not an error. */
+    @Test fun anInstalledPackWithoutAnAppfilterStaysUnloaded() {
+        helper.loadIconPack(installEmptyPack())
+
+        assertFalse(helper.isIconPackLoaded)
+        assertNull(helper.getIcon("anything"))
+    }
+
+    /** A failed load must not leave the previous pack's state resolving icons. */
+    @Test fun anUnresolvablePackClearsWhatTheLastLoadLeftBehind() {
+        helper.loadIconPack(installEmptyPack())
+        helper.loadIconPack("ddt.free.icon.packs")
+
+        assertFalse(helper.isIconPackLoaded)
+        assertNull(helper.getIcon("anything"))
+    }
+
+    /** An icon pack package that resolves but holds no icon resources of its own. */
+    private fun installEmptyPack(packageName: String = "fake.icon.pack"): String {
+        Shadows.shadowOf(context.packageManager).installPackage(PackageInfo().apply {
+            this.packageName = packageName
+            applicationInfo = ApplicationInfo().apply { this.packageName = packageName }
+        })
+
+        return packageName
     }
 
     @Test fun fallbackWrapsOriginalDrawable() {

--- a/app/src/test/java/be/robinj/distrohopper/IconPackHelperTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/IconPackHelperTest.kt
@@ -29,6 +29,14 @@ class IconPackHelperTest {
 
     @Test fun unloadedPackCannotResolveNamedIcon() = assertNull(helper.getIcon("missing"))
 
+    /** An unresolvable pack is an expected condition, not an error to throw or report. */
+    @Test fun loadingUnresolvablePackLeavesTheIconPackUnloaded() {
+        helper.loadIconPack("ddt.free.icon.packs")
+
+        assertFalse(helper.isIconPackLoaded)
+        assertNull(helper.getIcon("anything"))
+    }
+
     @Test fun fallbackWrapsOriginalDrawable() {
         val drawable = ColorDrawable(Color.RED)
         assertSame(drawable, helper.getFallbackIcon(drawable).drawable)

--- a/app/src/test/java/be/robinj/distrohopper/home/AppsLoaderTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/home/AppsLoaderTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -53,6 +54,30 @@ class AppsLoaderTest {
 			Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER),
 			resolveInfo,
 		)
+	}
+
+	/**
+	 * The selection must outlive a load that couldn't resolve the pack -- it may well
+	 * resolve on the next start -- so nothing here may "tidy away" the stale-looking
+	 * preference, and the apps still load against their own system icons.
+	 */
+	@Test fun anUnresolvableIconPackDoesNotCostTheUserTheirSelection() {
+		this.scenario.close()
+		this.scenario = ActivityTestSupport.launchHome(configurePrefs = {
+			it.putString(Preference.ICON_PACK.getName(), "ddt.free.icon.packs")
+		})
+
+		this.scenario.onActivity { activity ->
+			val appManager = activity.appManager
+
+			assertFalse(appManager.isIconPackLoaded)
+			// The apps still loaded, each falling back to its own system icon //
+			assertTrue(appManager.installedApps.isNotEmpty())
+			appManager.installedApps.forEach { assertNotNull(it.icon.drawable) }
+		}
+
+		assertEquals("ddt.free.icon.packs", Preferences.getSharedPreferences(this.application)
+			.getString(Preference.ICON_PACK.getName(), ""))
 	}
 
 	@Test fun aBrokenPackageIsSkippedInsteadOfAbortingTheLoad() {


### PR DESCRIPTION
An icon pack that won't resolve is an expected condition, not an error, so skip the load and fall back to system icons instead of throwing and filing a silent crash report on every start.