### PR TITLE
Require a failing test with every bug fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ codebase — older Java alongside newer Kotlin.
   activities/views without a device).
 - Instrumented tests live under `app/src/androidTest/` (require a
   device/emulator; rarely the right place for new tests — prefer Robolectric).
+- A bug fix lands with a test that fails without it. #140 shipped without one
+  and blanked the startup spinner in v3.0.1.
 - Release workflow: pushing a `v*` tag builds signed release artifacts and
   attaches them to a GitHub Release. Tags whose version ends in a letter (for
   example `v3.0.0d`) are marked as GitHub pre-releases and are not promoted to


### PR DESCRIPTION
Two lines in AGENTS.md, under Build & test.

#140 shipped without a test and blanked the startup spinner in v3.0.1; #146 fixes it and adds the test that would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdAZxb4tpweHY8TqUA4L51

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdAZxb4tpweHY8TqUA4L51)_