### PR TITLE
Add a developer memory readout

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/Application.java
+++ b/app/src/main/java/be/robinj/distrohopper/Application.java
@@ -17,6 +17,7 @@ import org.acra.config.ToastConfigurationBuilder;
 import org.acra.data.StringFormat;
 import org.acra.sender.HttpSender;
 
+import be.robinj.distrohopper.dev.HeapProbe;
 import be.robinj.distrohopper.preferences.FontPreference;
 import be.robinj.distrohopper.preferences.Preferences;
 
@@ -38,6 +39,11 @@ public class Application extends android.app.Application
 	@Override
 	public void onCreate() {
 		super.onCreate();
+
+		// Unconditional: the activity counters only mean anything from process
+		// start, and gating them on a preference read here would miss whatever was
+		// created before it. The readout that uses them is dev-only. //
+		HeapProbe.INSTANCE.register(this);
 
 		// Apply the chosen font to every activity. onActivityPreCreated runs
 		// before the activity inflates its layout (and before AppCompat installs

--- a/app/src/main/java/be/robinj/distrohopper/dev/DevLogsActivity.kt
+++ b/app/src/main/java/be/robinj/distrohopper/dev/DevLogsActivity.kt
@@ -3,6 +3,8 @@ package be.robinj.distrohopper.dev
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.Menu
+import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -20,6 +22,7 @@ class DevLogsActivity : AppCompatActivity(), IObserver {
 
 	private lateinit var rvLogs: RecyclerView
 	private lateinit var tvLogsEmpty: TextView
+	private var memoryDialog: DevMemoryDialog? = null
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
@@ -40,6 +43,22 @@ class DevLogsActivity : AppCompatActivity(), IObserver {
 		this.refresh()
 	}
 
+	override fun onCreateOptionsMenu(menu: Menu): Boolean {
+		this.menuInflater.inflate(R.menu.dev_logs, menu)
+
+		return true
+	}
+
+	override fun onOptionsItemSelected(item: MenuItem): Boolean {
+		if (item.itemId != R.id.miDevLogsMemory) {
+			return super.onOptionsItemSelected(item)
+		}
+
+		this.memoryDialog = DevMemoryDialog(this).also { it.show() }
+
+		return true
+	}
+
 	override fun onStart() {
 		super.onStart()
 
@@ -50,6 +69,11 @@ class DevLogsActivity : AppCompatActivity(), IObserver {
 	}
 
 	override fun onStop() {
+		// A dialog left showing retains this activity, which would corrupt the very
+		// count it exists to report. //
+		this.memoryDialog?.dismiss()
+		this.memoryDialog = null
+
 		this.log.detachObserver(this)
 		this.handler.removeCallbacks(this.refreshRunnable)
 

--- a/app/src/main/java/be/robinj/distrohopper/dev/DevMemoryDialog.kt
+++ b/app/src/main/java/be/robinj/distrohopper/dev/DevMemoryDialog.kt
@@ -1,0 +1,139 @@
+package be.robinj.distrohopper.dev
+
+import android.text.format.Formatter
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
+import be.robinj.distrohopper.DependencyContainer
+import be.robinj.distrohopper.R
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** Read on open and on demand; never polled. */
+class DevMemoryDialog(
+	private val activity: DevLogsActivity,
+	private val stats: MemoryStats = MemoryStats(),
+) {
+	private var dialog: AlertDialog? = null
+	private var rows: LinearLayout? = null
+	private var previous: MemorySnapshot? = null
+
+	fun show() {
+		val body = LayoutInflater.from(this.activity)
+			.inflate(R.layout.widget_dev_memory, null) as LinearLayout
+		this.rows = body
+
+		val dialog = AlertDialog.Builder(this.activity)
+			.setTitle(R.string.option_dev_memory)
+			.setView(body)
+			.setNeutralButton(R.string.option_dev_memory_refresh, null)
+			.setNegativeButton(R.string.option_dev_memory_close, null)
+			.setPositiveButton(R.string.option_dev_memory_gc, null)
+			.create()
+
+		// After show(), or the buttons would dismiss the dialog they refresh //
+		dialog.setOnShowListener {
+			dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
+				.setOnClickListener { this.render(this.stats.read()) }
+			dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+				.setOnClickListener { this.collect(it) }
+		}
+
+		this.dialog = dialog
+		dialog.show()
+		this.render(this.stats.read())
+	}
+
+	fun dismiss() {
+		this.dialog?.dismiss()
+		this.dialog = null
+		this.rows = null
+	}
+
+	/** Twice, since the first pass only finalises what the second can free. */
+	private fun collect(button: View) {
+		button.isEnabled = false
+
+		val dispatchers = DependencyContainer.of(this.activity).dispatchers
+		this.activity.lifecycleScope.launch {
+			withContext(dispatchers.io) {
+				Runtime.getRuntime().gc()
+				System.runFinalization()
+				Runtime.getRuntime().gc()
+			}
+
+			delay(SETTLE_MS)
+
+			val before = this@DevMemoryDialog.previous
+			val after = this@DevMemoryDialog.stats.read()
+			this@DevMemoryDialog.render(after)
+			this@DevMemoryDialog.log(before, after)
+			button.isEnabled = true
+		}
+	}
+
+	private fun render(snapshot: MemorySnapshot) {
+		val rows = this.rows ?: return
+		val deltas = snapshot.minus(this.previous)
+		rows.removeAllViews()
+
+		this.addRow(rows, R.string.dev_memory_activities,
+			this.activity.getString(R.string.dev_memory_activities_value,
+				snapshot.liveActivities, snapshot.uncollectedActivities),
+			count(deltas.uncollectedActivities))
+
+		this.addRow(rows, R.string.dev_memory_native_heap,
+			Formatter.formatShortFileSize(this.activity, snapshot.nativeHeapBytes),
+			deltas.nativeHeapBytes?.let { this.size(it) })
+
+		this.previous = snapshot
+	}
+
+	private fun addRow(rows: LinearLayout, label: Int, value: String, delta: String?) {
+		val row = LayoutInflater.from(this.activity)
+			.inflate(R.layout.widget_dev_memory_row, rows, false)
+
+		row.findViewById<TextView>(R.id.tvMemoryLabel).setText(label)
+		row.findViewById<TextView>(R.id.tvMemoryValue).text = value
+
+		val deltaView = row.findViewById<TextView>(R.id.tvMemoryDelta)
+		deltaView.text = delta ?: ""
+		deltaView.visibility = if (delta == null) View.GONE else View.VISIBLE
+
+		rows.addView(row)
+	}
+
+	/** A signed size, so a delta does not read as another figure. */
+	private fun size(bytes: Long): String {
+		val sign = if (bytes > 0) "+" else "−"
+
+		return "(" + sign +
+			Formatter.formatShortFileSize(this.activity, Math.abs(bytes)) + ")"
+	}
+
+	/** Into the log too, so a reading can be exported rather than only seen. */
+	private fun log(before: MemorySnapshot?, after: MemorySnapshot) {
+		if (before == null) {
+			return
+		}
+
+		Log.getInstance().i(TAG, "GC: uncollected " + before.uncollectedActivities +
+			" → " + after.uncollectedActivities + ", native heap " +
+			Formatter.formatShortFileSize(this.activity, before.nativeHeapBytes) +
+			" → " + Formatter.formatShortFileSize(this.activity, after.nativeHeapBytes))
+	}
+
+	private companion object {
+		const val TAG = "Memory"
+
+		/** Reference clearing runs alongside us; counting at once would race it. */
+		const val SETTLE_MS = 250L
+
+		fun count(delta: Int?): String? =
+			delta?.let { "(" + (if (it > 0) "+" else "−") + Math.abs(it) + ")" }
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/dev/HeapProbe.kt
+++ b/app/src/main/java/be/robinj/distrohopper/dev/HeapProbe.kt
@@ -1,0 +1,66 @@
+package be.robinj.distrohopper.dev
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+
+/** Counts the activities the process is still holding, for the memory readout. */
+object HeapProbe {
+	/** Bounded: the launcher's process lives for days. */
+	private const val CAPACITY = 64
+
+	private val lock = Any()
+	private val queue = ReferenceQueue<Activity>()
+	private val destroyed = ArrayList<WeakReference<Activity>>()
+	private var created = 0
+	private var buried = 0
+
+	/** Unconditional: gated on a preference, it would miss what preceded the read. */
+	fun register(application: Application) {
+		application.registerActivityLifecycleCallbacks(Callbacks)
+	}
+
+	fun liveActivities(): Int = synchronized(this.lock) { this.created - this.buried }
+
+	/** An upper bound, not a leak count: these may be pending collection. */
+	fun uncollectedActivities(): Int = synchronized(this.lock) {
+		this.prune()
+		this.destroyed.size
+	}
+
+	/** Draining the queue first is what makes the count fall on the next read. */
+	private fun prune() {
+		while (this.queue.poll() != null) {
+			// get() below is what removes the entry //
+		}
+
+		this.destroyed.removeAll { it.get() == null }
+	}
+
+	private object Callbacks : Application.ActivityLifecycleCallbacks {
+		override fun onActivityCreated(activity: Activity, state: Bundle?) {
+			synchronized(HeapProbe.lock) { HeapProbe.created++ }
+		}
+
+		override fun onActivityDestroyed(activity: Activity) {
+			synchronized(HeapProbe.lock) {
+				HeapProbe.buried++
+				HeapProbe.prune()
+
+				while (HeapProbe.destroyed.size >= CAPACITY) {
+					HeapProbe.destroyed.removeAt(0)
+				}
+
+				HeapProbe.destroyed.add(WeakReference(activity, HeapProbe.queue))
+			}
+		}
+
+		override fun onActivityStarted(activity: Activity) {}
+		override fun onActivityResumed(activity: Activity) {}
+		override fun onActivityPaused(activity: Activity) {}
+		override fun onActivityStopped(activity: Activity) {}
+		override fun onActivitySaveInstanceState(activity: Activity, out: Bundle) {}
+	}
+}

--- a/app/src/main/java/be/robinj/distrohopper/dev/MemorySnapshot.kt
+++ b/app/src/main/java/be/robinj/distrohopper/dev/MemorySnapshot.kt
@@ -1,0 +1,24 @@
+package be.robinj.distrohopper.dev
+
+/** One reading of what the process is holding. */
+data class MemorySnapshot(
+	val liveActivities: Int,
+	val uncollectedActivities: Int,
+	val nativeHeapBytes: Long,
+) {
+	/** Movement against [previous]; null where a figure did not move. */
+	fun minus(previous: MemorySnapshot?): Deltas {
+		if (previous == null) {
+			return Deltas(null, null)
+		}
+
+		return Deltas(
+			uncollectedActivities =
+				(this.uncollectedActivities - previous.uncollectedActivities)
+					.takeIf { it != 0 },
+			nativeHeapBytes =
+				(this.nativeHeapBytes - previous.nativeHeapBytes).takeIf { it != 0L })
+	}
+
+	data class Deltas(val uncollectedActivities: Int?, val nativeHeapBytes: Long?)
+}

--- a/app/src/main/java/be/robinj/distrohopper/dev/MemoryStats.kt
+++ b/app/src/main/java/be/robinj/distrohopper/dev/MemoryStats.kt
@@ -1,0 +1,13 @@
+package be.robinj.distrohopper.dev
+
+import android.os.Debug
+
+/** Bitmaps are native since API 26, so Runtime's figures would say nothing. */
+class MemoryStats(
+	private val nativeHeap: () -> Long = { Debug.getNativeHeapAllocatedSize() },
+) {
+	fun read(): MemorySnapshot = MemorySnapshot(
+		liveActivities = HeapProbe.liveActivities(),
+		uncollectedActivities = HeapProbe.uncollectedActivities(),
+		nativeHeapBytes = this.nativeHeap())
+}

--- a/app/src/main/res/drawable/ic_dev_memory.xml
+++ b/app/src/main/res/drawable/ic_dev_memory.xml
@@ -1,0 +1,17 @@
+<!-- A memory chip: the pins are what make it read as memory rather than a card. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24"
+        android:viewportHeight="24"
+        android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M8,6h8a2,2 0 0,1 2,2v8a2,2 0 0,1 -2,2h-8a2,2 0 0,1 -2,-2v-8a2,2 0 0,1 2,-2zM8,8v8h8v-8z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M10,10h4v4h-4z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,3h1.5v3h-1.5zM13.5,3h1.5v3h-1.5zM9,18h1.5v3h-1.5zM13.5,18h1.5v3h-1.5zM3,9h3v1.5h-3zM3,13.5h3v1.5h-3zM18,9h3v1.5h-3zM18,13.5h3v1.5h-3z" />
+</vector>

--- a/app/src/main/res/layout/widget_dev_memory.xml
+++ b/app/src/main/res/layout/widget_dev_memory.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Body of the developer memory dialog: a label/value row per figure, with a
+     dim delta beside the ones that moved since the last reading. Weight is set
+     with textStyle rather than fontFamily — FontInflaterFactory swaps the family
+     on every TextView, so a fontFamily here would silently vanish. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:id="@+id/llDevMemory"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              android:paddingStart="24dp"
+              android:paddingEnd="24dp"
+              android:paddingTop="8dp"
+              android:paddingBottom="8dp" />

--- a/app/src/main/res/layout/widget_dev_memory_row.xml
+++ b/app/src/main/res/layout/widget_dev_memory_row.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- One figure: label, then the value and its delta pushed to the end. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="horizontal"
+              android:baselineAligned="true"
+              android:paddingTop="9dp"
+              android:paddingBottom="9dp">
+
+    <TextView
+        android:id="@+id/tvMemoryLabel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textSize="14sp"
+        android:textColor="@color/dialog_on_surface_variant" />
+
+    <TextView
+        android:id="@+id/tvMemoryValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:textSize="14sp"
+        android:textColor="@color/dialog_on_surface" />
+
+    <TextView
+        android:id="@+id/tvMemoryDelta"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:textSize="12sp"
+        android:textColor="@color/dialog_on_surface_dim"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/dev_logs.xml
+++ b/app/src/main/res/menu/dev_logs.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/miDevLogsMemory"
+        android:icon="@drawable/ic_dev_memory"
+        android:title="@string/option_dev_memory"
+        app:showAsAction="ifRoom|withText" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,13 @@
     <string name="hint_dashsearch_focus_on_open">Focus the search box and show the keyboard when the dash is opened.</string>
     <string name="option_dev_log_toaster">Log toasts</string>
     <string name="hint_dev_log_toaster">Show log items in toast messages.</string>
+    <string name="option_dev_memory">Memory</string>
+    <string name="option_dev_memory_close">Close</string>
+    <string name="option_dev_memory_refresh">Refresh</string>
+    <string name="option_dev_memory_gc">Run GC</string>
+    <string name="dev_memory_activities">Activities</string>
+    <string name="dev_memory_activities_value">%1$d live · %2$d uncollected</string>
+    <string name="dev_memory_native_heap">Native heap</string>
     <string name="option_customise">Customise</string>
     <string name="hint_customise">Customise the look and feel.</string>
     <string name="customise_done">Done</string>

--- a/app/src/test/java/be/robinj/distrohopper/dev/MemorySnapshotTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/dev/MemorySnapshotTest.kt
@@ -1,0 +1,42 @@
+package be.robinj.distrohopper.dev
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** The deltas the dialog renders: only what moved, signed. */
+class MemorySnapshotTest {
+	private fun snapshot(uncollected: Int = 0, nativeHeap: Long = 1_000L) =
+		MemorySnapshot(1, uncollected, nativeHeap)
+
+	@Test fun `the first reading has nothing to compare against`() {
+		val deltas = this.snapshot().minus(null)
+
+		assertNull(deltas.uncollectedActivities)
+		assertNull(deltas.nativeHeapBytes)
+	}
+
+	@Test fun `a figure that did not move has no delta`() {
+		val before = this.snapshot(uncollected = 2, nativeHeap = 5_000L)
+		val deltas = this.snapshot(uncollected = 2, nativeHeap = 5_000L).minus(before)
+
+		assertNull(deltas.uncollectedActivities)
+		assertNull(deltas.nativeHeapBytes)
+	}
+
+	@Test fun `what a collection freed reads as a negative delta`() {
+		val before = this.snapshot(uncollected = 2, nativeHeap = 9_000L)
+		val deltas = this.snapshot(uncollected = 1, nativeHeap = 4_000L).minus(before)
+
+		assertEquals(-1, deltas.uncollectedActivities)
+		assertEquals(-5_000L, deltas.nativeHeapBytes)
+	}
+
+	@Test fun `growth reads as a positive delta`() {
+		val before = this.snapshot(uncollected = 0, nativeHeap = 1_000L)
+		val deltas = this.snapshot(uncollected = 2, nativeHeap = 3_000L).minus(before)
+
+		assertEquals(2, deltas.uncollectedActivities)
+		assertEquals(2_000L, deltas.nativeHeapBytes)
+	}
+}


### PR DESCRIPTION
A Memory action on the logs screen shows activities live and uncollected, and the native heap. Run GC collects and shows what moved.

Uncollected is an upper bound, not a leak count — a count that survives a second GC is the leak.

Production footprint is one line in `Application`: `HeapProbe.register(this)`. Everything else is in `dev/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdAZxb4tpweHY8TqUA4L51