### PR TITLE
Make the icon pack in effect part of the icon config

### DIFF
--- a/app/src/main/java/be/robinj/distrohopper/AppManager.java
+++ b/app/src/main/java/be/robinj/distrohopper/AppManager.java
@@ -189,7 +189,8 @@ public class AppManager implements Iterable<App>
 	 */
 	public synchronized IconRenderer getIconRenderer ()
 	{
-		final IconConfig config = IconConfig.fromPrefs (this.parent.getApplicationContext ());
+		final IconConfig config = IconConfig.fromPrefs (
+			this.parent.getApplicationContext (), this.getAppliedIconPack ());
 
 		if (this.iconRenderer == null
 			|| ! this.iconRenderer.getConfig ().signature ().equals (config.signature ()))
@@ -272,6 +273,27 @@ public class AppManager implements Iterable<App>
 	public void loadIconPack (String name) throws IOException, XmlPullParserException
 	{
 		this.iconPack.loadIconPack (name);
+	}
+
+	/** Applies the configured icon pack. Load it before any icon is rendered or cached. */
+	public void loadConfiguredIconPack ()
+	{
+		try
+		{
+			this.iconPack.loadIconPack (Preferences.getSharedPreferences (
+				this.parent.getApplicationContext ())
+				.getString (Preference.ICON_PACK.getName (), ""));
+		}
+		catch (final Exception ex)
+		{
+			new ExceptionHandler (ex).logAndTrack ();
+		}
+	}
+
+	/** The pack the icons are actually drawn with, or "" when none is in effect. */
+	public String getAppliedIconPack ()
+	{
+		return this.iconPack.getAppliedPackageName ();
 	}
 
 	public void movePinnedApp (int oldIndex, int newIndex)

--- a/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
+++ b/app/src/main/java/be/robinj/distrohopper/HomeActivity.java
@@ -861,7 +861,8 @@ public class HomeActivity extends AppCompatActivity
 
 		final String stored = prefs.getString (Preference.ICON_CONFIG_SIGNATURE.getName (), null);
 
-		return ! IconConfig.fromPrefs (this).signature ().equals (stored);
+		return ! IconConfig.fromPrefs (this, this.apps.getAppliedIconPack ())
+			.signature ().equals (stored);
 	}
 
 
@@ -995,14 +996,7 @@ public class HomeActivity extends AppCompatActivity
 			SharedPreferences prefs = this.getSharedPreferences ();
 
 			// Load selected icon pack before caching icons
-			try {
-				final String iconPack = prefs.getString(be.robinj.distrohopper.preferences.Preference.ICON_PACK.getName(), "");
-				if (!iconPack.isEmpty()) {
-					installedApps.loadIconPack(iconPack);
-				}
-			} catch (Exception ex) {
-				new ExceptionHandler(ex).logAndTrack();
-			}
+			installedApps.loadConfiguredIconPack ();
 
 			if (prefs.getBoolean (Preference.LAUNCHER_SHOW_RUNNING_APPS.getName(), false))
 				this.apps.addRunningApps (this.dash.getChameleonicBgColour ());

--- a/app/src/main/java/be/robinj/distrohopper/IconPackHelper.java
+++ b/app/src/main/java/be/robinj/distrohopper/IconPackHelper.java
@@ -205,6 +205,12 @@ public class IconPackHelper
 		}
 	}
 
+	/** The pack whose icons are actually being drawn, or "" when none is. */
+	public String getAppliedPackageName ()
+	{
+		return this.iconPackLoaded && this.name != null ? this.name : "";
+	}
+
 	public boolean isIconPackLoaded ()
 	{
 		return this.iconPackLoaded;

--- a/app/src/main/java/be/robinj/distrohopper/home/AppsLoader.kt
+++ b/app/src/main/java/be/robinj/distrohopper/home/AppsLoader.kt
@@ -36,21 +36,10 @@ object AppsLoader {
 	): AppManager {
 		val appManager = AppManager(parent)
 
-		// Reconcile the icon cache against the current icon config *before* any app
-		// loads its icon from cache, so a changed shape/theme/wallpaper tint purges
-		// the now-stale cached icons instead of serving them.
+		// The pack is part of the icon config, so load it first; touching iconRenderer
+		// then reconciles the cache against it, purging icons the last config drew.
+		appManager.loadConfiguredIconPack()
 		appManager.iconRenderer
-
-		// Load selected icon pack before any icons are requested
-		try {
-			val iconPack = Preferences.getSharedPreferences(context)
-				.getString(Preference.ICON_PACK.getName(), "")!!
-			if (iconPack.isNotEmpty()) {
-				appManager.loadIconPack(iconPack)
-			}
-		} catch (ex: Exception) {
-			ExceptionHandler(ex).logAndTrack()
-		}
 
 		val tStart = System.currentTimeMillis()
 

--- a/app/src/main/java/be/robinj/distrohopper/icons/IconConfig.java
+++ b/app/src/main/java/be/robinj/distrohopper/icons/IconConfig.java
@@ -28,18 +28,21 @@ public final class IconConfig {
 	private final int tintColor;
 	private final int tintBackground;
 	private final int tintForeground;
+	private final String iconPack;
 
 	public IconConfig(final IconShape shape, final boolean tintedIcons, final int sizePx,
-					  final int tintColor, final int tintBackground, final int tintForeground) {
+					  final int tintColor, final int tintBackground, final int tintForeground,
+					  final String iconPack) {
 		this.shape = shape;
 		this.tintedIcons = tintedIcons;
 		this.sizePx = sizePx;
 		this.tintColor = tintColor;
 		this.tintBackground = tintBackground;
 		this.tintForeground = tintForeground;
+		this.iconPack = iconPack;
 	}
 
-	public static IconConfig fromPrefs(final Context context) {
+	public static IconConfig fromPrefs(final Context context, final String iconPack) {
 		final PreferencesRepository prefs = new PreferencesRepository(context);
 
 		final IconShape shape = IconShape.fromPreferenceValue(
@@ -54,7 +57,7 @@ public final class IconConfig {
 		final boolean night = isNightMode(context);
 
 		return new IconConfig(shape, tinted, sizePx, tint,
-			tintBackground(tint, night), tintForeground(tint, night));
+			tintBackground(tint, night), tintForeground(tint, night), iconPack);
 	}
 
 	public static boolean isNightMode(final Context context) {
@@ -120,7 +123,8 @@ public final class IconConfig {
 	public String signature() {
 		final String base = this.shape.getPreferenceValue()
 			+ "|tinted=" + this.tintedIcons
-			+ "|sz=" + this.sizePx;
+			+ "|sz=" + this.sizePx
+			+ "|pack=" + this.iconPack;
 
 		if (!this.tintedIcons) {
 			return base;

--- a/app/src/main/java/be/robinj/distrohopper/icons/IconShapePreference.java
+++ b/app/src/main/java/be/robinj/distrohopper/icons/IconShapePreference.java
@@ -55,7 +55,7 @@ public class IconShapePreference extends IconStripPreference {
 	private Drawable renderPreview(final Context context, final AdaptiveIconDrawable sample,
 								   final IconShape shape, final int size) {
 		// Shape previews are never tinted: they show the silhouette, not the colour. //
-		final IconConfig config = new IconConfig(shape, false, size, Color.WHITE, Color.WHITE, Color.WHITE);
+		final IconConfig config = new IconConfig(shape, false, size, Color.WHITE, Color.WHITE, Color.WHITE, "");
 		return new IconRenderer(context, config).render(sample);
 	}
 

--- a/app/src/main/java/be/robinj/distrohopper/icons/IconTintPreference.java
+++ b/app/src/main/java/be/robinj/distrohopper/icons/IconTintPreference.java
@@ -81,7 +81,7 @@ public class IconTintPreference extends IconStripPreference {
 	private Drawable renderTinted(final Context context, final AdaptiveIconDrawable sample,
 								  final int colour, final boolean night, final int size) {
 		final IconConfig config = new IconConfig(IconShape.CIRCLE, true, size, colour,
-			IconConfig.tintBackground(colour, night), IconConfig.tintForeground(colour, night));
+			IconConfig.tintBackground(colour, night), IconConfig.tintForeground(colour, night), "");
 		return new IconRenderer(context, config).render(sample);
 	}
 

--- a/app/src/test/java/be/robinj/distrohopper/AppManagerTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/AppManagerTest.kt
@@ -63,6 +63,58 @@ class AppManagerTest {
         assertTrue(cacheContains(key))
     }
 
+    private fun setIconPack(packageName: String) =
+        Preferences.getSharedPreferences(ApplicationProvider.getApplicationContext())
+            .edit().putString(Preference.ICON_PACK.getName(), packageName).commit()
+
+    private fun storedSignature(manager: AppManager) =
+        Preferences.getSharedPreferences(manager.context)
+            .getString(Preference.ICON_CONFIG_SIGNATURE.getName(), null)
+
+    @Test fun theIconPackInEffectIsPartOfTheIconConfig() = withManager { manager ->
+        setIconPack("ddt.free.icon.packs")
+        manager.loadConfiguredIconPack()
+
+        // The pack does not resolve, so nothing is in effect and the icons are the system's.
+        assertEquals("", manager.appliedIconPack)
+        assertTrue(manager.iconRenderer.config.signature().endsWith("|pack="))
+    }
+
+    @Test fun losingTheIconPackPurgesTheIconCache() {
+        // The signature the cache would have been written with while the pack applied.
+        val withPack = scenario.let { s ->
+            var sig = ""
+            s.onActivity { sig = it.appManager.iconRenderer.config.signature() }
+            sig
+        } + "ddt.free.icon.packs"
+        scenario.close()
+
+        val key = "pack-icon"
+        assertTrue(cacheAnIcon(key).containsKey(key))
+
+        // A fresh start with the pack no longer resolving: config differs, cache goes.
+        scenario = ActivityTestSupport.launchHome(configurePrefs = {
+            it.putString(Preference.ICON_PACK.getName(), "ddt.free.icon.packs")
+            it.putString(Preference.ICON_CONFIG_SIGNATURE.getName(), withPack)
+        })
+
+        assertFalse(cacheContains(key))
+    }
+
+    @Test fun anUnchangedIconPackStateKeepsTheIconCache() = withManager { manager ->
+        setIconPack("ddt.free.icon.packs")
+        manager.loadConfiguredIconPack()
+        manager.iconRenderer
+
+        val key = "keep-me"
+        assertTrue(cacheAnIcon(key).containsKey(key))
+        manager.loadConfiguredIconPack()
+        manager.iconRenderer
+
+        assertTrue(cacheContains(key))
+        assertEquals(manager.iconRenderer.config.signature(), storedSignature(manager))
+    }
+
     @Test fun everyAppHasNonEmptyPackageName() = withManager { manager ->
         manager.forEach { assertTrue(it.packageName.isNotEmpty()) }
     }

--- a/app/src/test/java/be/robinj/distrohopper/icons/IconConfigTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/icons/IconConfigTest.kt
@@ -18,7 +18,7 @@ class IconConfigTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 
     private fun config(shape: IconShape, tinted: Boolean) =
-        IconConfig(shape, tinted, 108, Color.BLUE, Color.DKGRAY, Color.WHITE)
+        IconConfig(shape, tinted, 108, Color.BLUE, Color.DKGRAY, Color.WHITE, "")
 
     @Test fun signatureDiffersAcrossShapes() {
         assertNotEquals(
@@ -34,20 +34,28 @@ class IconConfigTest {
 
     @Test fun signatureDiffersAcrossTheResolvedTintColour() {
         assertNotEquals(
-            IconConfig(IconShape.CIRCLE, true, 108, Color.BLUE, Color.DKGRAY, Color.WHITE).signature(),
-            IconConfig(IconShape.CIRCLE, true, 108, Color.RED, Color.DKGRAY, Color.WHITE).signature())
+            IconConfig(IconShape.CIRCLE, true, 108, Color.BLUE, Color.DKGRAY, Color.WHITE, "").signature(),
+            IconConfig(IconShape.CIRCLE, true, 108, Color.RED, Color.DKGRAY, Color.WHITE, "").signature())
     }
 
     @Test fun signatureIgnoresTintColourWhenTintingIsOff() {
         // With tinting off the resolved colour is irrelevant, so a theme/wallpaper
         // change must not invalidate the cache.
         assertEquals(
-            IconConfig(IconShape.CIRCLE, false, 108, Color.BLUE, Color.DKGRAY, Color.WHITE).signature(),
-            IconConfig(IconShape.CIRCLE, false, 108, Color.RED, Color.GREEN, Color.YELLOW).signature())
+            IconConfig(IconShape.CIRCLE, false, 108, Color.BLUE, Color.DKGRAY, Color.WHITE, "").signature(),
+            IconConfig(IconShape.CIRCLE, false, 108, Color.RED, Color.GREEN, Color.YELLOW, "").signature())
+    }
+
+    @Test fun signatureDiffersAcrossTheIconPackInEffect() {
+        assertNotEquals(
+            IconConfig(IconShape.CIRCLE, false, 108, Color.BLUE, Color.DKGRAY, Color.WHITE, "")
+                .signature(),
+            IconConfig(IconShape.CIRCLE, false, 108, Color.BLUE, Color.DKGRAY, Color.WHITE,
+                "ddt.free.icon.packs").signature())
     }
 
     @Test fun fromPrefsDefaultsToSystemShapeAndTintOff() {
-        val config = IconConfig.fromPrefs(this.context)
+        val config = IconConfig.fromPrefs(this.context, "")
         assertEquals(IconShape.SYSTEM, config.getShape())
         assertFalse(config.isTintedIcons())
         assertTrue(config.getSizePx() > 0)

--- a/app/src/test/java/be/robinj/distrohopper/icons/IconRendererTest.kt
+++ b/app/src/test/java/be/robinj/distrohopper/icons/IconRendererTest.kt
@@ -27,7 +27,7 @@ class IconRendererTest {
     private val tintBackground = Color.DKGRAY
 
     private fun config(shape: IconShape, tinted: Boolean = false) =
-        IconConfig(shape, tinted, this.size, this.tintForeground, this.tintBackground, this.tintForeground)
+        IconConfig(shape, tinted, this.size, this.tintForeground, this.tintBackground, this.tintForeground, "")
 
     private fun renderer(shape: IconShape, tinted: Boolean = false) =
         IconRenderer(this.context, this.config(shape, tinted))


### PR DESCRIPTION
Cached icons are served without consulting the pack, so icons drawn by a pack that no longer loads keep showing indefinitely; the pack belongs in `IconConfig.signature()` alongside shape, size and tint, so the existing reconcile purges them whenever it changes.